### PR TITLE
Update course number type to allow alphanumeric characters

### DIFF
--- a/src/server/entities/course.entity.ts
+++ b/src/server/entities/course.entity.ts
@@ -74,7 +74,7 @@ export class Course extends BaseEntity {
     type: 'varchar',
     comment: 'The numerical part of the course code (i.e - the CS in CS 50). May also include an alphabetical component (i.e - CS 109b)',
   })
-  public number: number;
+  public number: string;
 
   /**
    * Indicates whether or not this course is an undergraduate course.


### PR DESCRIPTION
Course number was previously a `number` meaning that it was not possible to have alphabetical characters in a course code (i.e: CS 109b). This PR changes that type to a `string` to allow this.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [X] I have run `eslint` on the code
- [X] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [X] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #34 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
