### PR TITLE
Remove name field from course instance

### DIFF
--- a/src/server/entities/courseinstance.entity.ts
+++ b/src/server/entities/courseinstance.entity.ts
@@ -46,23 +46,6 @@ export enum OFFERED {
 @Entity()
 export class CourseInstance extends BaseEntity {
   /**
-   * The name of this course instance. This is usually the same as
-   * [[Course.name]], but it can change from year to year and this field is
-   * used to record those changes and provide historical data on course name
-   * changes and offered status.
-   *
-   * **Note:**
-   * Other details such as course catalog prefix, coure code or course number
-   * however will never change as changing these signifies the creation of a new
-   * course. That is to say that a course is defined by it's course code/catalog
-   * prefix. If those change, it is no longer the same course.
-   */
-  @Column({
-    type: 'varchar',
-  })
-  public readonly name: string;
-
-  /**
    * Indicates whether the course is currently being offered this [[Semester]],
    * and whether the course would normally be offered in other semesters
    */

--- a/src/server/migrations/1568725862144-DropCourseInstanceName.ts
+++ b/src/server/migrations/1568725862144-DropCourseInstanceName.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DropCourseInstanceName1568725862144 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "course_instance" DROP COLUMN "name"');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "course_instance" ADD "name" character varying NOT NULL');
+  }
+}


### PR DESCRIPTION
The name field was originally added to the `CourseInstance` model to track changes to course name from semester to semester. After some discussion, it was decided that this is no longer needed and so can be removed.

Fix #37

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #37 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
