### PR TITLE
Add local alias for mark-one

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "paths": {
       "testData": ["common/__tests__/data/index.ts"],
       "client/*": ["client/*"],
-      "server/*": ["server/*"]
+      "server/*": ["server/*"],
+      "mark-one": ["../../mark-one/src/index.ts"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
Adds local alias to `tsconfig.json` for mark one UI library allowing usage of mark-one in the course planner UI before mark-one is published to a public registry

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #77

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
 