### PR TITLE
Enable lcov report

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -11,5 +11,5 @@
   "clean": true,
   "instrument": true,
   "sourceMap": true,
-  "reporter": "text"
+  "reporter": ["text", "lcov"]
 }


### PR DESCRIPTION
This PR reconfigures `nyc` to also generate an `lcov` report under `coverage/lcov`. This can be helpful when pinning down uncovered branches as it highlights missing test cases `else` clauses etc. as it provides far more detail than the default text reporter

![image](https://user-images.githubusercontent.com/50675045/75572995-ed52b180-5a29-11ea-8e5a-ebbabc6dd490.png)


## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [ ] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
