### PR TITLE
Create typeorm_metadata table in migration

### DIFF
--- a/src/server/migrations/1583524438353-CourseListingViews.ts
+++ b/src/server/migrations/1583524438353-CourseListingViews.ts
@@ -4,6 +4,7 @@ export class CourseListingViews1583524438353 implements MigrationInterface {
   public name = 'CourseListingViews1583524438353'
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('CREATE TABLE "typeorm_metadata" ("type" varchar NOT NULL, "database" varchar, "schema" varchar, "table" varchar, "name" varchar, "value" text)', undefined);
     await queryRunner.query('CREATE VIEW "CourseListingView" AS SELECT "c"."id" AS "id", "c"."notes" AS "notes", "a"."name" AS "area", c."isUndergraduate" AS "isUndergraduate", CONCAT_WS(\' \', "c"."prefix", "c"."number") AS "catalogNumber", c."sameAs" AS "sameAs", c."isSEAS" AS "isSEAS", c."termPattern" AS "termPattern" FROM "course" "c" LEFT JOIN "area" "a" ON c."areaId" = "a"."id"', undefined);
     await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'CourseListingView', "SELECT \"c\".\"id\" AS \"id\", \"c\".\"notes\" AS \"notes\", \"a\".\"name\" AS \"area\", c.\"isUndergraduate\" AS \"isUndergraduate\", CONCAT_WS(' ', \"c\".\"prefix\", \"c\".\"number\") AS \"catalogNumber\", c.\"sameAs\" AS \"sameAs\", c.\"isSEAS\" AS \"isSEAS\", c.\"termPattern\" AS \"termPattern\" FROM \"course\" \"c\" LEFT JOIN \"area\" \"a\" ON c.\"areaId\" = \"a\".\"id\""]);
     await queryRunner.query('CREATE VIEW "CourseInstanceListingView" AS SELECT "ci"."id" AS "id", "ci"."offered" AS "offered", "s"."term" AS "term", ci."courseId" AS "courseId", ci."preEnrollment" AS "preEnrollment", ci."studyCardEnrollment" AS "studyCardEnrollment", ci."actualEnrollment" AS "actualEnrollment", s."academicYear" AS "calendarYear" FROM "course_instance" "ci" LEFT JOIN "semester" "s" ON "s"."id" = ci."semesterId"', undefined);
@@ -27,5 +28,6 @@ export class CourseListingViews1583524438353 implements MigrationInterface {
     await queryRunner.query('DROP VIEW "CourseInstanceListingView"', undefined);
     await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = \'VIEW\' AND "schema" = $1 AND "name" = $2', ['public', 'CourseListingView']);
     await queryRunner.query('DROP VIEW "CourseListingView"', undefined);
+    await queryRunner.query('DROP TABLE "typeorm_metadata"', undefined);
   }
 }


### PR DESCRIPTION
TypeORM automatically creates the `typeorm_metadata` table in your database when you generate migrations or sync your schemas, but it doesn't add code to create the table to the generated migrations. There's an [open PR in the typeorm project](https://github.com/typeorm/typeorm/pull/4956/files) that would create the table when you run the migrations, but imo this should still be done as part of the migration itself, rather than through a "magic" process.

Suggested process for testing:
1. Clone a fresh copy of the project to a new directory
2. Checkout this branch: `bugfix/181-typeorm_metadata`
3. run `docker-compose up` (you may need to stop and restart since the node container sometimes quits if it tries to startup before the database is ready)
4. run the migrations: `docker-compose exec node npm run orm -- migration:run`
5. The migrations should run successfully

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #181 
<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
