### PR TITLE
Set server global prefix to /course-planner

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -35,6 +35,7 @@ async function bootstrap(): Promise<void> {
     SwaggerModule.setup('docs/api', app, document);
   }
   app.useGlobalPipes(new BadRequestExceptionPipe());
+  app.setGlobalPrefix('/course-planner');
   await app.listen(SERVER_PORT);
 
   if (module.hot) {


### PR DESCRIPTION
Because we're using path-based routing with our load balancer configuration, all of our routes need to begin with `/course-planner/`

I considered setting the prefix to `/course-planner/api`, but decided against it as our `login`/`logout` routes wouldn't really make sense under an `/api/` prefix, and there may be other endpoints we want to have outside the `/api/` space as well (e.g. `/healthcheck`)

Interestingly, this change does not affect the Swagger docs.

**Note: You will need to update the SERVER_URL environment variable to include `/course-planner`**

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #___

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
