### PR TITLE
Clean up database after each test runs

### DIFF
--- a/tests/mocks/database/population/__tests__/population.service.test.ts
+++ b/tests/mocks/database/population/__tests__/population.service.test.ts
@@ -1,6 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule, getRepositoryToken, TypeOrmModuleOptions } from '@nestjs/typeorm';
-import { createConnection, getRepository, Repository } from 'typeorm';
+import {
+  createConnection,
+  getRepository,
+  Repository,
+  Connection,
+} from 'typeorm';
 import { Area } from 'server/area/area.entity';
 import { strictEqual, notStrictEqual } from 'assert';
 import { Semester } from 'server/semester/semester.entity';
@@ -48,7 +53,7 @@ describe('Population Service', function () {
   });
 
   describe('Automatic population', function () {
-    before(async function () {
+    beforeEach(async function () {
       testModule = await Test.createTestingModule({
         imports: [
           ConfigModule,
@@ -73,6 +78,9 @@ describe('Population Service', function () {
         .compile();
       // calling init triggers the onApplicationBootstrap hook
       await testModule.createNestApplication().init();
+    });
+    afterEach(async function () {
+      await testModule.close();
     });
     it('Should populate the area table', async function () {
       areaRepository = testModule.get(getRepositoryToken(Area));
@@ -247,15 +255,44 @@ describe('Population Service', function () {
     });
   });
   describe('Automatic depopulation', function () {
-    before(async function () {
+    let typeormConnection: Connection;
+    beforeEach(async function () {
+      testModule = await Test.createTestingModule({
+        imports: [
+          ConfigModule,
+          TypeOrmModule.forRootAsync({
+            imports: [ConfigModule],
+            useFactory: (
+              config: ConfigService
+            ): TypeOrmModuleOptions => ({
+              ...config.dbOptions,
+              synchronize: true,
+              autoLoadEntities: true,
+              retryAttempts: 10,
+              retryDelay: 10000,
+            }),
+            inject: [ConfigService],
+          }),
+          PopulationModule,
+        ],
+      })
+        .overrideProvider(ConfigService)
+        .useValue(new ConfigService(db.connectionEnv))
+        .compile();
+      // calling init triggers the onApplicationBootstrap hook
+      await testModule.createNestApplication().init();
       // close the module, triggering beforeApplicationShutdown hook
       await testModule.close();
       // Open a direct connection to the db with TypeORM
       const config = new ConfigService(db.connectionEnv);
-      return createConnection({
+      typeormConnection = await createConnection({
         ...config.dbOptions,
         synchronize: true,
       });
+    });
+    afterEach(async function () {
+      // close our direct typeorm connection after each test
+      await typeormConnection.close();
     });
     it('Should truncate the area table', async function () {
       areaRepository = getRepository(Area);


### PR DESCRIPTION
The original Population Service tests were not properly closing their connections to the MockDB, which is:

- Not practicing good isolation, as all of the depopulation tests depend on the population tests to run first 
- Breaking the MockDB for any tests that run after the PopulationService

We've been dodging that second bullet for a while, but the integration tests for the Course Admin Modal in feature/229-course-admin-modals are running into it and need it to be fixed.

In addition to closing the direct connection from TypeORM after each depopulation test runs, I'm changing the `before`s and `after`s that create/stop the nest module to `beforeEach`s and `afterEach`s so that each inidividual test runs against a clean database, which addresses the concern from  bullet 1 above.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [ ] Normal <!-- New piece of functionality -->
- [x] High <!-- Critical bug requiring urgent review -->
