### PR TITLE
Skip cleanup on build deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,13 @@ jobs:
         on:
           branch: main
     - stage: build
-      cleanup: false
       before_script: echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
       script: docker build -t $TRAVIS_REPO_SLUG:$TRAVIS_BRANCH .
       before_deploy: bash .travis_version_bump.sh
       after_deploy: docker logout
       deploy:
         provider: script
+        cleanup: false
         script: bash .travis_docker_deploy.sh
         on: 
           all_branches: true


### PR DESCRIPTION
Includes some other small tweaks:

- replace old-style `skip_cleanup: true` with `cleanup: false`, as this
will be changing in a future version
- Calling the docker deploy script explicitly with `bash`

The second point is attempting to address an issue where our builds on
develop are still failing on initial run (though they seem to be working
in debug mode on Travis). It still can't find the remote repo, even with
the updated GH token, so it may be an environment-related issue.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [ ] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [ ] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #___

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
