### PR TITLE
Fix Course Admin Area Filter Dropdown Values

### DIFF
--- a/src/client/components/layout/__tests__/AppRouter.test.tsx
+++ b/src/client/components/layout/__tests__/AppRouter.test.tsx
@@ -45,9 +45,9 @@ describe('App Router', function () {
       });
     });
     context('/course-admin', function () {
-      it('renders the CourseAdmin component', async function () {
-        const { findByText } = renderWithUser('/course-admin');
-        return findByText(/Area/);
+      it('renders the CourseAdmin component', function () {
+        const { getByTestId } = renderWithUser('/course-admin');
+        return getByTestId(/courseAdminPage/);
       });
     });
     context('/faculty-admin', function () {

--- a/src/client/components/layout/__tests__/AppRouter.test.tsx
+++ b/src/client/components/layout/__tests__/AppRouter.test.tsx
@@ -47,7 +47,7 @@ describe('App Router', function () {
     context('/course-admin', function () {
       it('renders the CourseAdmin component', async function () {
         const { findByText } = renderWithUser('/course-admin');
-        return findByText(/Course Prefix/);
+        return findByText(/Area/);
       });
     });
     context('/faculty-admin', function () {

--- a/src/client/components/pages/CourseAdmin.tsx
+++ b/src/client/components/pages/CourseAdmin.tsx
@@ -130,7 +130,7 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
   }, [loadCourses]);
 
   return (
-    <>
+    <div data-testid="courseAdminPage">
       <VerticalSpace>
         <div className="create-course-button">
           <Button
@@ -258,7 +258,7 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
           }}
         />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/client/components/pages/CourseAdmin.tsx
+++ b/src/client/components/pages/CourseAdmin.tsx
@@ -25,7 +25,7 @@ import { MessageContext, MetadataContext } from 'client/context';
 import { TableRowProps } from 'mark-one/lib/Tables/TableRow';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEdit } from '@fortawesome/free-solid-svg-icons';
-import { getCatPrefixColor } from '../../../common/constants';
+import { getAreaColor } from '../../../common/constants';
 import { CourseAPI } from '../../api/courses';
 import { VerticalSpace } from '../layout';
 import CourseModal from './Courses/CourseModal';
@@ -57,10 +57,10 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
 
   const [courseValue, setCourseValue] = useState<string>('');
   const [titleValue, setTitleValue] = useState<string>('');
-  const [catalogPrefixValue, setCatalogPrefixValue] = useState<string>('All');
+  const [areaValue, setAreaValue] = useState<string>('All');
 
   /**
-   * Return filtered course based on the "Course Prefix",
+   * Return filtered course based on the "Course Area",
    * "Course" and "Title" fileds filter.
    * Note: .trim() might be used to remove whitespaces.
    * Need to ask Vittorio about the .trim()
@@ -75,10 +75,10 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
       courses,
       { field: 'title', value: titleValue, exact: false }
     );
-    if (catalogPrefixValue !== 'All') {
+    if (areaValue !== 'All') {
       courses = listFilter(
         courses,
-        { field: 'prefix', value: catalogPrefixValue, exact: true }
+        { field: 'area.name', value: areaValue, exact: true }
       );
     }
     return (courses);
@@ -150,7 +150,7 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
         <Table>
           <TableHead>
             <TableRow isStriped>
-              <TableHeadingCell scope="col">Course Prefix</TableHeadingCell>
+              <TableHeadingCell scope="col">Area</TableHeadingCell>
               <TableHeadingCell scope="col">Course</TableHeadingCell>
               <TableHeadingCell scope="col">Title</TableHeadingCell>
               <TableHeadingCell scope="col">Edit</TableHeadingCell>
@@ -160,19 +160,19 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
                 <Dropdown
                   options={
                     [{ value: 'All', label: 'All' }]
-                      .concat(metadata.catalogPrefixes.map((prefix) => ({
-                        value: prefix,
-                        label: prefix,
+                      .concat(metadata.areas.map((area) => ({
+                        value: area,
+                        label: area,
                       })))
                   }
-                  value={catalogPrefixValue}
-                  name="catalogPrefixValue"
-                  id="catalogPrefixValue"
-                  label="The table will be filtered as selected in this catalog prefix dropdown filter"
+                  value={areaValue}
+                  name="areaValue"
+                  id="areaValue"
+                  label="The table will be filtered as selected in this area dropdown filter"
                   isLabelVisible={false}
                   hideError
                   onChange={(event:React.ChangeEvent<HTMLInputElement>) => {
-                    setCatalogPrefixValue(event.currentTarget.value);
+                    setAreaValue(event.currentTarget.value);
                   }}
                 />
               </TableHeadingCell>
@@ -211,9 +211,9 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
             {filteredCourses().map((course, i): ReactElement<TableRowProps> => (
               <TableRow isStriped={i % 2 === 1} key={course.id}>
                 <TableCell
-                  backgroundColor={getCatPrefixColor(course.prefix)}
+                  backgroundColor={getAreaColor(course.area.name)}
                 >
-                  {course.prefix}
+                  {course.area.name}
                 </TableCell>
                 <TableCell>{course.catalogNumber}</TableCell>
                 <TableCell>{course.title}</TableCell>

--- a/src/client/components/pages/__tests__/CourseAdmin.test.tsx
+++ b/src/client/components/pages/__tests__/CourseAdmin.test.tsx
@@ -34,6 +34,7 @@ describe('Course Admin', function () {
     physicsCourseResponse,
     newAreaCourseResponse,
   ];
+  const catalogPrefixLabelText = 'The table will be filtered as selected in this catalog prefix dropdown filter';
   beforeEach(function () {
     getStub = stub(CourseAPI, 'getAllCourses');
     getStub.resolves(testData);
@@ -73,10 +74,10 @@ describe('Course Admin', function () {
         await wait(() => getAllByRole('row').length > 1);
         const rows = getAllByRole('row');
         const utils = within(rows[1]);
-        const cPrefix = utils.getAllByRole('option');
+        const cPrefix = utils.getAllByLabelText(catalogPrefixLabelText);
         const course = utils.getAllByPlaceholderText('Filter by Course');
         const title = utils.getAllByPlaceholderText('Filter by Title');
-        strictEqual(cPrefix.length, testData.length + 1);
+        strictEqual(cPrefix.length, 1);
         strictEqual(course.length, 1);
         strictEqual(title.length, 1);
       });
@@ -137,9 +138,7 @@ describe('Course Admin', function () {
           await wait(() => getAllByRole('row').length > 1);
           const rows = getAllByRole('row');
           const utils = within(rows[1]);
-          const cPrefix = utils.queryByLabelText(
-            'The table will be filtered as selected in this course prefix dropdown filter'
-          );
+          const cPrefix = utils.queryByLabelText(catalogPrefixLabelText);
           filterSpy.resetHistory();
           fireEvent.change(cPrefix, { target: { value: 'AnyValue' } });
           strictEqual(filterSpy.callCount, 3);
@@ -152,9 +151,7 @@ describe('Course Admin', function () {
           await wait(() => getAllByRole('row').length > 1);
           const rows = getAllByRole('row');
           const utils = within(rows[1]);
-          const cPrefix = utils.queryByLabelText(
-            'The table will be filtered as selected in this course prefix dropdown filter'
-          );
+          const cPrefix = utils.queryByLabelText(catalogPrefixLabelText);
           filterSpy.resetHistory();
           fireEvent.change(cPrefix, { target: { value: 'All' } });
           strictEqual(filterSpy.callCount, 2);

--- a/src/client/components/pages/__tests__/CourseAdmin.test.tsx
+++ b/src/client/components/pages/__tests__/CourseAdmin.test.tsx
@@ -34,7 +34,7 @@ describe('Course Admin', function () {
     physicsCourseResponse,
     newAreaCourseResponse,
   ];
-  const catalogPrefixLabelText = 'The table will be filtered as selected in this catalog prefix dropdown filter';
+  const areaLabelText = 'The table will be filtered as selected in this area dropdown filter';
   beforeEach(function () {
     getStub = stub(CourseAPI, 'getAllCourses');
     getStub.resolves(testData);
@@ -74,10 +74,10 @@ describe('Course Admin', function () {
         await wait(() => getAllByRole('row').length > 1);
         const rows = getAllByRole('row');
         const utils = within(rows[1]);
-        const cPrefix = utils.getAllByLabelText(catalogPrefixLabelText);
+        const area = utils.getAllByLabelText(areaLabelText);
         const course = utils.getAllByPlaceholderText('Filter by Course');
         const title = utils.getAllByPlaceholderText('Filter by Title');
-        strictEqual(cPrefix.length, 1);
+        strictEqual(area.length, 1);
         strictEqual(course.length, 1);
         strictEqual(title.length, 1);
       });
@@ -138,9 +138,9 @@ describe('Course Admin', function () {
           await wait(() => getAllByRole('row').length > 1);
           const rows = getAllByRole('row');
           const utils = within(rows[1]);
-          const cPrefix = utils.queryByLabelText(catalogPrefixLabelText);
+          const area = utils.queryByLabelText(areaLabelText);
           filterSpy.resetHistory();
-          fireEvent.change(cPrefix, { target: { value: 'AnyValue' } });
+          fireEvent.change(area, { target: { value: 'AnyValue' } });
           strictEqual(filterSpy.callCount, 3);
         });
         it('Calls the listFilter function once for each filter except the dropdown', async function () {
@@ -151,9 +151,9 @@ describe('Course Admin', function () {
           await wait(() => getAllByRole('row').length > 1);
           const rows = getAllByRole('row');
           const utils = within(rows[1]);
-          const cPrefix = utils.queryByLabelText(catalogPrefixLabelText);
+          const area = utils.queryByLabelText(areaLabelText);
           filterSpy.resetHistory();
-          fireEvent.change(cPrefix, { target: { value: 'All' } });
+          fireEvent.change(area, { target: { value: 'All' } });
           strictEqual(filterSpy.callCount, 2);
         });
         it('Calls the listFilter function once for each filter except the dropdown', async function () {

--- a/src/client/context/MetadataContext.ts
+++ b/src/client/context/MetadataContext.ts
@@ -35,6 +35,10 @@ export class MetadataContextValue {
   get semesters(): string[] {
     return this.value.semesters;
   }
+
+  get catalogPrefixes(): string[] {
+    return this.value.catalogPrefixes;
+  }
 }
 
 /**

--- a/src/client/context/MetadataContext.ts
+++ b/src/client/context/MetadataContext.ts
@@ -35,10 +35,6 @@ export class MetadataContextValue {
   get semesters(): string[] {
     return this.value.semesters;
   }
-
-  get catalogPrefixes(): string[] {
-    return this.value.catalogPrefixes;
-  }
 }
 
 /**


### PR DESCRIPTION
This PR updates the area filter dropdown in the Course Admin tab to use `areas` from the `metadata`. The column header was originally "Course Prefix," but Jonathan Seitz agreed that we could change the column header name to "Area."

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #269 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
