### PR TITLE
Replace html form element with Mark-One Form component for CourseModal and FacultyModal forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7346,9 +7346,9 @@
       }
     },
     "mark-one": {
-      "version": "0.0.2-develop.49",
-      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.0.2-develop.49.tgz",
-      "integrity": "sha512-0u+NthVoYc7la8ANoWoLh12gCCD5AGquA5R9KO5hQqSC+0XJlr2rfOfLoRvu16nyymKTlP0o1q0GAGKmt53pfA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.2.3.tgz",
+      "integrity": "sha512-CYH3UeYzBxmq1foUOJef6Ibgijrl60wACZKDgScsRiKGy+wg6tAHUU0bI4sh5T4qc3CAHic0yIowGWiYxew1XA==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",
         "@openfonts/open-sans_all": "^1.43.0",
@@ -9155,11 +9155,21 @@
       "dev": true
     },
     "polished": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.7.tgz",
-      "integrity": "sha512-b4OViUOihwV0icb9PHmWbR+vPqaSzSAEbgLskvb7ANPATVXGiYv/TQFHQo65S53WU9i5EQ1I03YDOJW7K0bmYg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.1.tgz",
+      "integrity": "sha512-/QgHrNGYwIA4mwxJ/7FSvalUJsm7KNfnXiScVSEG2Xa5qxDeBn4nmdjN2pW00mkM2Tts64ktc47U8F7Ed1BRAA==",
       "requires": {
-        "@babel/runtime": "^7.9.2"
+        "@babel/runtime": "^7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.18",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+          "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "portfinder": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lodash.get": "^4.4.2",
     "lodash.groupby": "^4.6.0",
     "loglevel": "^1.6.8",
-    "mark-one": "0.0.2-develop.49",
+    "mark-one": "0.2.3",
     "morgan": "^1.10.0",
     "nestjs-redis": "^1.2.8",
     "nestjs-session": "^1.0.0",

--- a/src/client/components/pages/Courses/CourseModal.tsx
+++ b/src/client/components/pages/Courses/CourseModal.tsx
@@ -23,6 +23,7 @@ import {
   Dropdown,
   ValidationErrorMessage,
   POSITION,
+  Form,
 } from 'mark-one';
 import { MetadataContext } from 'client/context/MetadataContext';
 import { ManageCourseResponseDTO } from 'common/dto/courses/ManageCourseResponse.dto';
@@ -250,7 +251,10 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
       </ModalHeader>
       <ModalBody>
         <NoteText>Note: * denotes a required field</NoteText>
-        <form id="editCourseForm">
+        <Form
+          id="editCourseForm"
+          label="Edit Course Form"
+        >
           <Fieldset
             legend="Course Area"
             isBorderVisible
@@ -356,6 +360,7 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
             label={displayNames.isUndergraduate}
             onChange={updateFormFields}
             labelPosition={POSITION.RIGHT}
+            hideError
           />
           <Dropdown
             id="isSEAS"
@@ -404,7 +409,7 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
               {courseModalError}
             </ValidationErrorMessage>
           )}
-        </form>
+        </Form>
       </ModalBody>
       <ModalFooter>
         <Button

--- a/src/client/components/pages/FacultyModal.tsx
+++ b/src/client/components/pages/FacultyModal.tsx
@@ -20,6 +20,7 @@ import {
   ValidationErrorMessage,
   NoteText,
   POSITION,
+  Form,
 } from 'mark-one';
 import { ManageFacultyResponseDTO } from 'common/dto/faculty/ManageFacultyResponse.dto';
 import {
@@ -227,7 +228,10 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
       </ModalHeader>
       <ModalBody>
         <NoteText>Note: * denotes a required field</NoteText>
-        <form id="editFacultyForm">
+        <Form
+          id="editFacultyForm"
+          label="Edit Faculty Form"
+        >
           <Dropdown
             id="courseArea"
             name="courseArea"
@@ -325,7 +329,7 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
               {facultyErrorMessage}
             </ValidationErrorMessage>
           )}
-        </form>
+        </Form>
       </ModalBody>
       <ModalFooter>
         <Button


### PR DESCRIPTION
This also adds a label to each of the forms. The prop hideError was added to the Undergraduate checkbox in the Course Modal form, because this checkbox may be left unchecked and the undergraduate field would never produce an error message.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #274 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
