### PR TITLE
Apply Cell Highlighting - Faculty Absences

### DIFF
--- a/src/client/components/pages/Faculty/FacultyScheduleTable.tsx
+++ b/src/client/components/pages/Faculty/FacultyScheduleTable.tsx
@@ -39,6 +39,7 @@ import {
   facultyTypeEnumToTitleCase,
 } from 'common/utils/facultyHelperFunctions';
 import { CellLayout } from 'client/components/general';
+import { absenceToVariant } from '../utils/absenceToVariant';
 
 interface FacultyScheduleTableProps {
   /**
@@ -142,6 +143,7 @@ const FacultyScheduleTable: FunctionComponent<FacultyScheduleTableProps> = ({
               </TableCell>
               <TableCell>{faculty.jointWith}</TableCell>
               <TableCell
+                variant={absenceToVariant(faculty.fall.absence)}
                 verticalAlignment={VALIGN.TOP}
               >
                 <CellLayout>
@@ -178,7 +180,7 @@ const FacultyScheduleTable: FunctionComponent<FacultyScheduleTableProps> = ({
                   </BorderlessButton>
                 </CellLayout>
               </TableCell>
-              <TableCell>
+              <TableCell variant={absenceToVariant(faculty.fall.absence)}>
                 {faculty.fall.courses.map((course): ReactElement => (
                   <div key={course.id}>
                     {course.catalogNumber}
@@ -186,6 +188,7 @@ const FacultyScheduleTable: FunctionComponent<FacultyScheduleTableProps> = ({
                 ))}
               </TableCell>
               <TableCell
+                variant={absenceToVariant(faculty.spring.absence)}
                 verticalAlignment={VALIGN.TOP}
               >
                 <CellLayout>
@@ -222,7 +225,7 @@ const FacultyScheduleTable: FunctionComponent<FacultyScheduleTableProps> = ({
                   </BorderlessButton>
                 </CellLayout>
               </TableCell>
-              <TableCell>
+              <TableCell variant={absenceToVariant(faculty.spring.absence)}>
                 {faculty.spring.courses.map((course): ReactElement => (
                   <div key={course.id}>
                     {course.catalogNumber}

--- a/src/client/components/pages/utils/__tests__/absenceToVariant.test.tsx
+++ b/src/client/components/pages/utils/__tests__/absenceToVariant.test.tsx
@@ -1,0 +1,80 @@
+import { strictEqual } from 'assert';
+import {
+  noLongerActiveAbsence,
+  parentalLeaveAbsence,
+  presentAbsence,
+  researchLeaveAbsence,
+  sabbaticalAbsence,
+  sabbaticalEligibleAbsence,
+  sabbaticalIneligibleAbsence,
+  teachingReliefAbsence,
+} from 'common/__tests__/data/absence';
+import { TEXT_VARIANT } from 'mark-one';
+import { absenceToVariant } from '../absenceToVariant';
+
+describe('Instructor Filter Function', function () {
+  context('when absence type is ABSENCE_TYPE.PARENTAL_LEAVE', function () {
+    it('should return the negative text variant', function () {
+      strictEqual(
+        absenceToVariant(parentalLeaveAbsence),
+        TEXT_VARIANT.NEGATIVE
+      );
+    });
+  });
+  context('when absence type is ABSENCE_TYPE.RESEARCH_LEAVE', function () {
+    it('should return the negative text variant', function () {
+      strictEqual(
+        absenceToVariant(researchLeaveAbsence),
+        TEXT_VARIANT.NEGATIVE
+      );
+    });
+  });
+  context('when absence type is ABSENCE_TYPE.NO_LONGER_ACTIVE', function () {
+    it('should return the medium text variant', function () {
+      strictEqual(
+        absenceToVariant(noLongerActiveAbsence),
+        TEXT_VARIANT.MEDIUM
+      );
+    });
+  });
+  context('when absence type is ABSENCE_TYPE.SABBATICAL', function () {
+    it('should return the base text variant', function () {
+      strictEqual(
+        absenceToVariant(sabbaticalAbsence),
+        TEXT_VARIANT.BASE
+      );
+    });
+  });
+  context('when absence type is ABSENCE_TYPE.SABBATICAL_ELIGIBLE', function () {
+    it('should return the base text variant', function () {
+      strictEqual(
+        absenceToVariant(sabbaticalEligibleAbsence),
+        TEXT_VARIANT.BASE
+      );
+    });
+  });
+  context('when absence type is ABSENCE_TYPE.SABBATICAL_INELIGIBLE', function () {
+    it('should return the base text variant', function () {
+      strictEqual(
+        absenceToVariant(sabbaticalIneligibleAbsence),
+        TEXT_VARIANT.BASE
+      );
+    });
+  });
+  context('when absence type is ABSENCE_TYPE.TEACHING_RELIEF', function () {
+    it('should return the base text variant', function () {
+      strictEqual(
+        absenceToVariant(teachingReliefAbsence),
+        TEXT_VARIANT.BASE
+      );
+    });
+  });
+  context('when absence type is ABSENCE_TYPE.PRESENT', function () {
+    it('should return the base text variant', function () {
+      strictEqual(
+        absenceToVariant(presentAbsence),
+        TEXT_VARIANT.BASE
+      );
+    });
+  });
+});

--- a/src/client/components/pages/utils/absenceToVariant.ts
+++ b/src/client/components/pages/utils/absenceToVariant.ts
@@ -7,13 +7,15 @@ import { TEXT_VARIANT } from 'mark-one';
  * the given absence
  */
 export const absenceToVariant = (absence: FacultyAbsence): TEXT_VARIANT => {
-  if ([ABSENCE_TYPE.PARENTAL_LEAVE, ABSENCE_TYPE.RESEARCH_LEAVE]
-    .includes(absence.type)) {
-    return TEXT_VARIANT.NEGATIVE;
-  } if ([ABSENCE_TYPE.NO_LONGER_ACTIVE].includes(absence.type)) {
-    return TEXT_VARIANT.MEDIUM;
+  switch (absence.type) {
+    case ABSENCE_TYPE.PARENTAL_LEAVE:
+    case ABSENCE_TYPE.RESEARCH_LEAVE:
+      return TEXT_VARIANT.NEGATIVE;
+    case ABSENCE_TYPE.NO_LONGER_ACTIVE:
+      return TEXT_VARIANT.MEDIUM;
+    default:
+      return TEXT_VARIANT.BASE;
   }
-  return TEXT_VARIANT.BASE;
 };
 
 export default absenceToVariant;

--- a/src/client/components/pages/utils/absenceToVariant.ts
+++ b/src/client/components/pages/utils/absenceToVariant.ts
@@ -1,0 +1,19 @@
+import { ABSENCE_TYPE } from 'common/constants';
+import { FacultyAbsence } from 'common/dto/faculty/FacultyResponse.dto';
+import { TEXT_VARIANT } from 'mark-one';
+
+/**
+ * Finds the corresponding variant of type TEXT_VARIANT corresponding to
+ * the given absence
+ */
+export const absenceToVariant = (absence: FacultyAbsence): TEXT_VARIANT => {
+  if ([ABSENCE_TYPE.PARENTAL_LEAVE, ABSENCE_TYPE.RESEARCH_LEAVE]
+    .includes(absence.type)) {
+    return TEXT_VARIANT.NEGATIVE;
+  } if ([ABSENCE_TYPE.NO_LONGER_ACTIVE].includes(absence.type)) {
+    return TEXT_VARIANT.MEDIUM;
+  }
+  return TEXT_VARIANT.BASE;
+};
+
+export default absenceToVariant;

--- a/src/common/__tests__/data/absence.ts
+++ b/src/common/__tests__/data/absence.ts
@@ -1,0 +1,66 @@
+import { ABSENCE_TYPE } from 'common/constants';
+import { FacultyAbsence } from 'common/dto/faculty/FacultyResponse.dto';
+
+/**
+ * An example Parental Leave FacultyAbsence with an id and type
+ */
+export const parentalLeaveAbsence: FacultyAbsence = {
+  id: '2bb45c1d-ea20-4ad1-80fc-e502e70613d1',
+  type: ABSENCE_TYPE.PARENTAL_LEAVE,
+};
+
+/**
+ * An example Research Leave FacultyAbsence with an id and type
+ */
+export const researchLeaveAbsence: FacultyAbsence = {
+  id: '47a0cf09-9d4b-4cea-b2de-7afe39133770',
+  type: ABSENCE_TYPE.RESEARCH_LEAVE,
+};
+
+/**
+ * An example No Longer Active FacultyAbsence with an id and type
+ */
+export const noLongerActiveAbsence: FacultyAbsence = {
+  id: '8339ef34-18af-4901-9085-7d9b741261bf',
+  type: ABSENCE_TYPE.NO_LONGER_ACTIVE,
+};
+
+/**
+ * An example Sabbatical FacultyAbsence with an id and type
+ */
+export const sabbaticalAbsence: FacultyAbsence = {
+  id: '30f57dc3-5c40-4ab4-a796-dc0516014ab2',
+  type: ABSENCE_TYPE.SABBATICAL,
+};
+
+/**
+ * An example Sabbatical Eligible FacultyAbsence with an id and type
+ */
+export const sabbaticalEligibleAbsence: FacultyAbsence = {
+  id: '044d3e45-6645-45c0-b518-16e7111ca850',
+  type: ABSENCE_TYPE.SABBATICAL_ELIGIBLE,
+};
+
+/**
+ * An example Sabbatical Ineligible FacultyAbsence with an id and type
+ */
+export const sabbaticalIneligibleAbsence: FacultyAbsence = {
+  id: 'c2945883-b6da-4b3b-8de3-4a8030569a6c',
+  type: ABSENCE_TYPE.SABBATICAL_INELIGIBLE,
+};
+
+/**
+ * An example Teaching Relief FacultyAbsence with an id and type
+ */
+export const teachingReliefAbsence: FacultyAbsence = {
+  id: 'eab7c74e-881d-469a-9f0d-7bd369889993',
+  type: ABSENCE_TYPE.TEACHING_RELIEF,
+};
+
+/**
+ * An example Present FacultyAbsence with an id and type
+ */
+export const presentAbsence: FacultyAbsence = {
+  id: 'c4582348-08b4-4997-b3ff-61e8befe76b3',
+  type: ABSENCE_TYPE.PRESENT,
+};


### PR DESCRIPTION
This PR applies the cell highlighting capability that was added in `mark-one` through [this TableCell Text Styling PR.](https://github.com/seas-computing/mark-one/pull/94). We decided on the styling through [ticket 300](https://github.com/seas-computing/course-planner/issues/300) taking color contrast into consideration. "Parental Leave" and "Research Leave" absences have the `negative text` color, and "No Longer Active" absences will have the `medium text` color - these three absence types will also have a bold font weight.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #300 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
