### PR TITLE
Meeting Modal - Add Faculty Notes

### DIFF
--- a/src/client/components/pages/Courses/MeetingModal.tsx
+++ b/src/client/components/pages/Courses/MeetingModal.tsx
@@ -18,6 +18,14 @@ import React, {
 import styled from 'styled-components';
 import { instructorDisplayNameToFirstLast } from '../utils/instructorDisplayNameToFirstLast';
 
+/**
+ * A component that applies styling for text that indicates the faculty has
+ * no associated notes
+ */
+const StyledFacultyNote = styled.span`
+  font-style: italic;
+`;
+
 interface MeetingModalProps {
   /**
    * Whether or not the modal should be visible on the page.
@@ -141,14 +149,22 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
               <h3>
                 Faculty Notes
               </h3>
-              {instance.instructors.map((instructor) => (
-                <div key={instructor.displayName}>
-                  <h4>
-                    {instructorDisplayNameToFirstLast(instructor.displayName)}
-                  </h4>
-                  <p>{instructor.notes === '' ? 'No Notes' : instructor.notes}</p>
-                </div>
-              ))}
+              <div>
+                {instance.instructors.map((instructor) => (
+                  <div key={instructor.displayName}>
+                    <h4>
+                      {instructorDisplayNameToFirstLast(instructor.displayName)}
+                    </h4>
+                    <p>
+                      {
+                        instructor.notes === ''
+                          ? <StyledFacultyNote>No Notes</StyledFacultyNote>
+                          : instructor.notes
+                      }
+                    </p>
+                  </div>
+                ))}
+              </div>
             </MeetingSchedulerBody>
           </MeetingScheduler>
           <RoomAvailability>

--- a/src/client/components/pages/Courses/MeetingModal.tsx
+++ b/src/client/components/pages/Courses/MeetingModal.tsx
@@ -16,6 +16,7 @@ import React, {
   useRef,
 } from 'react';
 import styled from 'styled-components';
+import { instructorDisplayNameToFirstLast } from '../utils/instructorDisplayNameToFirstLast';
 
 interface MeetingModalProps {
   /**
@@ -136,7 +137,19 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
         <MeetingModalBodyGrid>
           <MeetingScheduler>
             <MeetingSchedulerHeader>{`Meeting times for ${course.catalogNumber}`}</MeetingSchedulerHeader>
-            <MeetingSchedulerBody />
+            <MeetingSchedulerBody>
+              <h3>
+                Faculty Notes
+              </h3>
+              {instance.instructors.map((instructor) => (
+                <div key={instructor.displayName}>
+                  <h4>
+                    {instructorDisplayNameToFirstLast(instructor.displayName)}
+                  </h4>
+                  <p>{instructor.notes === '' ? 'No Notes' : instructor.notes}</p>
+                </div>
+              ))}
+            </MeetingSchedulerBody>
           </MeetingScheduler>
           <RoomAvailability>
             <RoomAvailabilityHeader>Room Availability</RoomAvailabilityHeader>

--- a/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
@@ -23,13 +23,14 @@ describe('Meeting Modal', function () {
     const dispatchMessage: SinonStub = stub();
     const meetingTerm = TERM.FALL;
     const semKey = meetingTerm.toLowerCase() as TermKey;
+    const testCourseInstance = cs50CourseInstance;
     beforeEach(function () {
       onCloseStub = stub();
       ({ getByText, queryByText } = render(
         <MeetingModal
           isVisible
           currentCourseInstance={{
-            course: cs50CourseInstance,
+            course: testCourseInstance,
             term: meetingTerm,
           }}
           onClose={onCloseStub}
@@ -42,6 +43,28 @@ describe('Meeting Modal', function () {
         return waitForElement(
           () => getByText(`Meetings for ${cs50CourseInstance.catalogNumber} - ${meetingTerm} ${cs50CourseInstance[semKey].calendarYear}`)
         );
+      });
+      describe('Faculty Notes', function () {
+        context('when the faculty member has associated notes', function () {
+          it('displays the faculty notes associated with the course instance', async function () {
+            const facultyWithNotes = (testCourseInstance.fall.instructors
+              .filter((instructor) => (instructor.notes !== '')));
+            const expectedNotes = facultyWithNotes
+              .map((faculty) => faculty.notes);
+            return Promise.all(expectedNotes.map((note) => waitForElement(
+              () => getByText(note)
+            )));
+          });
+        });
+        context('when the faculty member does not have associated notes', function () {
+          it('displays the text "No Notes"', function () {
+            const facultyWithoutNotes = (testCourseInstance.fall.instructors
+              .filter((instructor) => (instructor.notes === '')));
+            const modalNotes = getByText('Faculty Notes', { exact: false }).nextElementSibling;
+            const noNotesLength = (modalNotes as HTMLElement).textContent.match(/s*No Notes\s*$/g).length;
+            strictEqual(facultyWithoutNotes.length, noNotesLength);
+          });
+        });
       });
     });
     describe('On Close Behavior', function () {

--- a/src/client/components/pages/utils/__tests__/instructorDisplayNameToFirstLast.test.tsx
+++ b/src/client/components/pages/utils/__tests__/instructorDisplayNameToFirstLast.test.tsx
@@ -1,0 +1,29 @@
+import { strictEqual } from 'assert';
+import { instructorDisplayNameToFirstLast } from '../instructorDisplayNameToFirstLast';
+
+describe('Instructor Display Name to First Last Function', function () {
+  context('when the display name is an empty string', function () {
+    it('should return an empty string', function () {
+      strictEqual(
+        instructorDisplayNameToFirstLast(''),
+        ''
+      );
+    });
+  });
+  context('when the display name is one word', function () {
+    it('should return the word itself', function () {
+      strictEqual(
+        instructorDisplayNameToFirstLast('TBD'),
+        'TBD'
+      );
+    });
+  });
+  context('when the display name contains a comma', function () {
+    it('should return the name in the first last name format', function () {
+      strictEqual(
+        instructorDisplayNameToFirstLast('Protopapas, Pavlos'),
+        'Pavlos Protopapas'
+      );
+    });
+  });
+});

--- a/src/client/components/pages/utils/instructorDisplayNameToFirstLast.ts
+++ b/src/client/components/pages/utils/instructorDisplayNameToFirstLast.ts
@@ -1,0 +1,9 @@
+/**
+ * Converts the display name of an instructor to be in the
+ * first-last name format (e.g. converts "Levine, Margo" to "Margo Levine").
+ * Empty strings as inputs and one word strings as inputs themselves will be
+ * returned as the output.
+ */
+export const instructorDisplayNameToFirstLast = (displayName: string):
+string => displayName.split(/\s*,\s*/).reverse().join(' ');
+export default instructorDisplayNameToFirstLast;

--- a/src/common/__tests__/data/courseInstances.ts
+++ b/src/common/__tests__/data/courseInstances.ts
@@ -53,6 +53,7 @@ export const cs50CourseInstance: CourseInstanceResponseDTO = {
       {
         id: '8d2c8320-dfe5-4d6b-9722-525f94401c7d',
         displayName: 'Malan, David',
+        notes: 'Prefers Sanders Theater',
       },
     ],
     meetings: [
@@ -160,6 +161,7 @@ export const es095CourseInstance: CourseInstanceResponseDTO = {
       {
         id: 'ae3948c7-b254-4cfb-aa9f-5c54c13a1a86',
         displayName: 'Bottino, Paul',
+        notes: '',
       },
     ],
     meetings: [
@@ -187,6 +189,7 @@ export const es095CourseInstance: CourseInstanceResponseDTO = {
       {
         id: 'ae3948c7-b254-4cfb-aa9f-5c54c13a1a86',
         displayName: 'Bottino, Paul',
+        notes: '',
       },
     ],
     meetings: [
@@ -250,10 +253,12 @@ export const ac209aCourseInstance: CourseInstanceResponseDTO = {
       {
         id: 'dcf88d99-1b7f-4863-93d3-d0b0bb43c8e7',
         displayName: 'Rader, Kevin',
+        notes: 'Prefers Cambridge campus',
       },
       {
         id: '78f75a40-b0bd-43af-84d8-0ec68f313dba',
         displayName: 'Protopapas, Pavlos',
+        notes: 'No preference on campus',
       },
     ],
     meetings: [
@@ -329,10 +334,12 @@ export const ac209aCourseInstanceWithoutRooms
       {
         id: 'dcf88d99-1b7f-4863-93d3-d0b0bb43c8e7',
         displayName: 'Rader, Kevin',
+        notes: 'Prefers Cambridge campus',
       },
       {
         id: '78f75a40-b0bd-43af-84d8-0ec68f313dba',
         displayName: 'Protopapas, Pavlos',
+        notes: 'No preference on campus',
       },
     ],
     meetings: [

--- a/src/common/__tests__/data/courseInstances.ts
+++ b/src/common/__tests__/data/courseInstances.ts
@@ -55,6 +55,11 @@ export const cs50CourseInstance: CourseInstanceResponseDTO = {
         displayName: 'Malan, David',
         notes: 'Prefers Sanders Theater',
       },
+      {
+        id: '4d952d8a-21a1-425b-876e-321ce708dea8',
+        displayName: 'Waldo, James',
+        notes: '',
+      },
     ],
     meetings: [
       {

--- a/src/common/dto/courses/CourseInstanceResponse.ts
+++ b/src/common/dto/courses/CourseInstanceResponse.ts
@@ -33,10 +33,12 @@ abstract class Instance {
       {
         id: '5c8e015f-eae6-4586-9eb0-fc7d243403bf',
         displayName: 'Rogers, Chris',
+        notes: 'Prefers Cambridge campus',
       },
       {
         id: 'effb8b1f-0525-42d0-bcbe-29206121d8ac',
         displayName: 'Waldo, James',
+        notes: 'Prefers Allston campus',
       },
     ],
     default: [],
@@ -44,6 +46,7 @@ abstract class Instance {
   public instructors: {
     id: string;
     displayName: string;
+    notes?: string;
   }[] = [];
 
   @ApiModelProperty({

--- a/src/server/faculty/FacultyListingView.entity.ts
+++ b/src/server/faculty/FacultyListingView.entity.ts
@@ -18,6 +18,7 @@ import { FacultyCourseInstance } from 'server/courseInstance/facultycourseinstan
   SelectQueryBuilder<Faculty> => connection.createQueryBuilder()
     .select('f.id', 'id')
     .addSelect('CONCAT_WS(\', \', f."lastName", f."firstName")', 'displayName')
+    .addSelect('f.notes', 'notes')
     .addSelect('fci.order', 'instructorOrder')
     .addSelect('fci."courseInstanceId"', 'courseInstanceId')
     .leftJoin(FacultyCourseInstance, 'fci', 'fci."facultyId" = f.id')
@@ -36,6 +37,12 @@ export class FacultyListingView {
    */
   @ViewColumn()
   public displayName: string;
+
+  /**
+   * Notes specific to the faculty member outlining preferences and additional information
+   */
+  @ViewColumn()
+  public notes: string;
 
   /**
    * From [[FacultyCourseInstance]]

--- a/src/server/migrations/1614877212117-AddFacultyNotes.ts
+++ b/src/server/migrations/1614877212117-AddFacultyNotes.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Updates the FacultyListingView to include faculty notes field.
+ */
+export class AddFacultyNotes1614877212117 implements MigrationInterface {
+  name = 'AddFacultyNotes1614877212117';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = \'VIEW\' AND "schema" = $1 AND "name" = $2', ['public', 'FacultyListingView']);
+    await queryRunner.query('DROP VIEW "FacultyListingView"');
+    await queryRunner.query('CREATE VIEW "FacultyListingView" AS SELECT "f"."id" AS "id", "f"."notes" AS "notes", "fci"."order" AS "instructorOrder", CONCAT_WS(\', \', f."lastName", f."firstName") AS "displayName", fci."courseInstanceId" AS "courseInstanceId" FROM "faculty" "f" LEFT JOIN "faculty_course_instances_course_instance" "fci" ON fci."facultyId" = "f"."id"');
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'FacultyListingView', "SELECT \"f\".\"id\" AS \"id\", \"f\".\"notes\" AS \"notes\", \"fci\".\"order\" AS \"instructorOrder\", CONCAT_WS(', ', f.\"lastName\", f.\"firstName\") AS \"displayName\", fci.\"courseInstanceId\" AS \"courseInstanceId\" FROM \"faculty\" \"f\" LEFT JOIN \"faculty_course_instances_course_instance\" \"fci\" ON fci.\"facultyId\" = \"f\".\"id\""]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = \'VIEW\' AND "schema" = $1 AND "name" = $2', ['public', 'FacultyListingView']);
+    await queryRunner.query('DROP VIEW "FacultyListingView"');
+    await queryRunner.query('CREATE VIEW "FacultyListingView" AS SELECT "f"."id" AS "id", "fci"."order" AS "instructorOrder", CONCAT_WS(\', \', f."lastName", f."firstName") AS "displayName", fci."courseInstanceId" AS "courseInstanceId" FROM "faculty" "f" LEFT JOIN "faculty_course_instances_course_instance" "fci" ON fci."facultyId" = "f"."id"');
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'FacultyListingView', "SELECT \"f\".\"id\" AS \"id\", \"fci\".\"order\" AS \"instructorOrder\", CONCAT_WS(', ', f.\"lastName\", f.\"firstName\") AS \"displayName\", fci.\"courseInstanceId\" AS \"courseInstanceId\" FROM \"faculty\" \"f\" LEFT JOIN \"faculty_course_instances_course_instance\" \"fci\" ON fci.\"facultyId\" = \"f\".\"id\""]);
+  }
+}

--- a/tests/integration/server/courseInstance/courseInstance.service.test.ts
+++ b/tests/integration/server/courseInstance/courseInstance.service.test.ts
@@ -131,6 +131,31 @@ describe('Course Instance Service', function () {
         });
       });
     });
+    it('Should list the faculty notes if any for each instance', async function () {
+      const dbInstances = await instanceRepository.find({
+        relations: ['facultyCourseInstances', 'facultyCourseInstances.faculty'],
+      });
+      notStrictEqual(result.length, 0);
+      result.forEach(({ spring, fall }) => {
+        [spring, fall].forEach(({ id, instructors, offered }) => {
+          strictEqual(Array.isArray(instructors), true);
+          if (offered === OFFERED.Y) {
+            const { facultyCourseInstances } = dbInstances.find(
+              ({ id: dbID }) => dbID === id
+            );
+            facultyCourseInstances.forEach(({ faculty }) => {
+              const resultIndex = instructors.findIndex(
+                ({ id: facultyID }) => facultyID === faculty.id
+              );
+              strictEqual(
+                instructors[resultIndex].notes,
+                faculty.notes
+              );
+            });
+          }
+        });
+      });
+    });
     describe('Meetings', function () {
       let dbMeetings: Meeting[];
       beforeEach(async function () {

--- a/tests/integration/server/courseInstance/courseInstance.service.test.ts
+++ b/tests/integration/server/courseInstance/courseInstance.service.test.ts
@@ -135,10 +135,9 @@ describe('Course Instance Service', function () {
       const dbInstances = await instanceRepository.find({
         relations: ['facultyCourseInstances', 'facultyCourseInstances.faculty'],
       });
-      notStrictEqual(result.length, 0);
+      notStrictEqual(result.length, 0, 'There are no course instances.');
       result.forEach(({ spring, fall }) => {
         [spring, fall].forEach(({ id, instructors, offered }) => {
-          strictEqual(Array.isArray(instructors), true);
           if (offered === OFFERED.Y) {
             const { facultyCourseInstances } = dbInstances.find(
               ({ id: dbID }) => dbID === id

--- a/tests/integration/server/courseInstance/courseInstance.service.test.ts
+++ b/tests/integration/server/courseInstance/courseInstance.service.test.ts
@@ -138,7 +138,6 @@ describe('Course Instance Service', function () {
       notStrictEqual(result.length, 0, 'There are no course instances.');
       result.forEach(({ spring, fall }) => {
         [spring, fall].forEach(({ id, instructors, offered }) => {
-          strictEqual(Array.isArray(instructors), true, 'Semesters.instructors is not an array.');
           if (offered === OFFERED.Y) {
             const { facultyCourseInstances } = dbInstances.find(
               ({ id: dbID }) => dbID === id

--- a/tests/integration/server/courseInstance/courseInstance.service.test.ts
+++ b/tests/integration/server/courseInstance/courseInstance.service.test.ts
@@ -138,6 +138,7 @@ describe('Course Instance Service', function () {
       notStrictEqual(result.length, 0, 'There are no course instances.');
       result.forEach(({ spring, fall }) => {
         [spring, fall].forEach(({ id, instructors, offered }) => {
+          strictEqual(Array.isArray(instructors), true, 'Semesters.instructors is not an array.');
           if (offered === OFFERED.Y) {
             const { facultyCourseInstances } = dbInstances.find(
               ({ id: dbID }) => dbID === id

--- a/tests/mocks/database/population/data/faculty.ts
+++ b/tests/mocks/database/population/data/faculty.ts
@@ -13,6 +13,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.NON_LADDER,
     area: 'CS',
+    notes: 'Prefers Cambridge campus',
   },
   {
     firstName: 'Christopher',
@@ -22,6 +23,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.LADDER,
     area: 'AM',
+    notes: 'Prefers Allston campus',
   },
   {
     firstName: 'James',
@@ -31,6 +33,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.NON_LADDER,
     area: 'CS',
+    notes: '',
   },
   {
     firstName: 'Michael',
@@ -40,6 +43,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.LADDER,
     area: 'CS',
+    notes: 'Prefers Cambridge campus',
   },
   {
     firstName: 'Pavlos',
@@ -49,6 +53,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.NON_LADDER,
     area: 'ACS',
+    notes: 'Requesting room in MD',
   },
   {
     firstName: 'Kevin',
@@ -58,6 +63,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.NON_LADDER,
     area: 'ACS',
+    notes: '',
   },
   {
     firstName: 'Christopher',
@@ -67,6 +73,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.NON_LADDER,
     area: 'ACS',
+    notes: 'Requesting room in SEC',
   },
   {
     firstName: 'Prineha',
@@ -76,6 +83,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.LADDER,
     area: 'Mat & ME',
+    notes: 'Prefers Cambridge campus',
   },
   {
     firstName: 'Linsey',
@@ -85,6 +93,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.NON_LADDER,
     area: 'BE',
+    notes: 'Requesting room in SEC',
   },
   {
     firstName: 'Julia',
@@ -94,6 +103,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.NON_SEAS_LADDER,
     area: 'AP',
+    notes: 'Requesting room in SEC',
   },
   {
     firstName: 'Michelle',
@@ -103,6 +113,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.NON_LADDER,
     area: 'Mat & ME',
+    notes: '',
   },
   {
     firstName: 'Robert',
@@ -112,6 +123,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.LADDER,
     area: 'Mat & ME',
+    notes: '',
   },
   {
     firstName: 'Mark',
@@ -121,6 +133,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.NON_LADDER,
     area: 'ACS',
+    notes: 'Prefers Allston campus',
   },
   {
     firstName: 'Mark',
@@ -130,6 +143,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.NON_LADDER,
     area: 'ACS',
+    notes: '',
   },
   {
     firstName: 'Boris',
@@ -139,6 +153,7 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.LADDER,
     area: 'EE',
+    notes: 'Prefers Allston campus',
   },
   {
     firstName: 'Jennifer',
@@ -148,5 +163,6 @@ export const faculty = [
     jointWith: null,
     category: FACULTY_TYPE.LADDER,
     area: 'AP',
+    notes: 'Prefers Cambridge campus',
   },
 ];

--- a/tests/mocks/database/population/data/index.ts
+++ b/tests/mocks/database/population/data/index.ts
@@ -52,6 +52,7 @@ export interface FacultyData {
   email: string;
   HUID: string;
   jointWith: string | null;
+  notes: string | null;
   category: FACULTY_TYPE;
   area: string;
 }

--- a/tests/mocks/database/population/faculty.population.ts
+++ b/tests/mocks/database/population/faculty.population.ts
@@ -33,6 +33,7 @@ export class FacultyPopulationService extends BasePopulationService<Faculty> {
       instructor.lastName = facultyData.lastName;
       instructor.HUID = facultyData.HUID;
       instructor.jointWith = facultyData.jointWith;
+      instructor.notes = facultyData.notes;
       instructor.category = facultyData.category;
       instructor.area = allAreas.find(
         ({ name }): boolean => name === facultyData.area


### PR DESCRIPTION
This PR includes a migration that added the faculty notes to the FacultyListingView, so that these notes could be referenced within the meeting modal. When a faculty member does not have associated notes, we decided to put the italicized text, "No Notes", in place of notes. Otherwise, the faculty's associated notes are displayed.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #306

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
