### PR TITLE
Update NonClassParent and NonClassEvent Entities

### DIFF
--- a/src/server/course/course.entity.ts
+++ b/src/server/course/course.entity.ts
@@ -10,7 +10,6 @@ import { TERM_PATTERN, IS_SEAS } from 'common/constants';
 import { BaseEntity } from '../base/base.entity';
 import { CourseInstance } from '../courseInstance/courseinstance.entity';
 import { Area } from '../area/area.entity';
-import { NonClassParent } from '../nonClassParent/nonclassparent.entity';
 
 /**
  * The parent of many [[CourseInstance]] entities. The course entity is responsibile
@@ -139,20 +138,6 @@ export class Course extends BaseEntity {
     { cascade: ['insert'] }
   )
   public instances: CourseInstance[];
-
-  /**
-   * [[NonClassParent]]s are parent entities to [[NonClassevent]] and are
-   * designed to be analogous to Courses, except that [[NonClassParent]]s can be
-   * scheduled outside of and independently from a [[Course]].
-   *
-   * ---
-   * Many [[NonClassParent]]s have one [[Course]]
-   */
-  @OneToMany(
-    (): ObjectType<NonClassParent> => NonClassParent,
-    ({ course }): Course => course
-  )
-  public nonClassParents: NonClassParent[];
 
   /**
   * The subject [[Area]] this course belongs to

--- a/src/server/location/RoomBookingInfoView.entity.ts
+++ b/src/server/location/RoomBookingInfoView.entity.ts
@@ -29,7 +29,7 @@ import { Semester } from '../semester/semester.entity';
                WHEN m."courseInstanceId" IS NOT NULL
                THEN CONCAT_WS(' ', c.prefix, c.number)
                WHEN m."nonClassEventId" IS NOT NULL
-               THEN nce.title
+               THEN ncp.title
                END`, 'meetingTitle')
     .from(Meeting, 'm')
     .leftJoin(Room, 'r', 'r.id = m."roomId"')

--- a/src/server/migrations/1617223382839-EditNonClassProperties.ts
+++ b/src/server/migrations/1617223382839-EditNonClassProperties.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Removes the title field from the NonClassEvent entity and the course id from
+ * the NonClassParent, as a NonClassParent does not need to be tied to a course.
+ * The RoomBookingInfoView was also updated so that the title displayed is from
+ * the NonClassParent rather than the NonClassEvent.
+ */
+export class EditNonClassProperties1617223382839 implements MigrationInterface {
+  name = 'EditNonClassProperties1617223382839';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = \'VIEW\' AND "schema" = $1 AND "name" = $2', ['public', 'RoomBookingInfoView']);
+    await queryRunner.query('DROP VIEW "RoomBookingInfoView"');
+    await queryRunner.query('ALTER TABLE "non_class_parent" DROP CONSTRAINT "FK_6b821019772b6920f70f81dcdca"');
+    await queryRunner.query('ALTER TABLE "non_class_parent" DROP COLUMN "courseId"');
+    await queryRunner.query('ALTER TABLE "non_class_event" DROP COLUMN "title"');
+    await queryRunner.query(`CREATE VIEW "RoomBookingInfoView" AS SELECT "m"."day" AS "day", "r"."id" AS "roomId", "s"."term" AS "term", s."academicYear" AS "calendarYear", m."startTime" AS "startTime", m."endTime" AS "endTime", CASE
+               WHEN m."courseInstanceId" IS NOT NULL
+               THEN CONCAT_WS(' ', "c"."prefix", "c"."number")
+               WHEN m."nonClassEventId" IS NOT NULL
+               THEN "ncp"."title"
+               END AS "meetingTitle" FROM "meeting" "m" LEFT JOIN "room" "r" ON "r"."id" = m."roomId"  LEFT JOIN "course_instance" "ci" ON m."courseInstanceId" = "ci"."id"  LEFT JOIN "course" "c" ON ci."courseId" = "c"."id"  LEFT JOIN "non_class_event" "nce" ON m."nonClassEventId" = "nce"."id"  LEFT JOIN "non_class_parent" "ncp" ON nce."nonClassParentId" = "ncp"."id"  LEFT JOIN "semester" "s" ON COALESCE(ci."semesterId", nce."semesterId") = "s"."id"`);
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'RoomBookingInfoView', "SELECT \"m\".\"day\" AS \"day\", \"r\".\"id\" AS \"roomId\", \"s\".\"term\" AS \"term\", s.\"academicYear\" AS \"calendarYear\", m.\"startTime\" AS \"startTime\", m.\"endTime\" AS \"endTime\", CASE\n               WHEN m.\"courseInstanceId\" IS NOT NULL\n               THEN CONCAT_WS(' ', \"c\".\"prefix\", \"c\".\"number\")\n               WHEN m.\"nonClassEventId\" IS NOT NULL\n               THEN \"ncp\".\"title\"\n               END AS \"meetingTitle\" FROM \"meeting\" \"m\" LEFT JOIN \"room\" \"r\" ON \"r\".\"id\" = m.\"roomId\"  LEFT JOIN \"course_instance\" \"ci\" ON m.\"courseInstanceId\" = \"ci\".\"id\"  LEFT JOIN \"course\" \"c\" ON ci.\"courseId\" = \"c\".\"id\"  LEFT JOIN \"non_class_event\" \"nce\" ON m.\"nonClassEventId\" = \"nce\".\"id\"  LEFT JOIN \"non_class_parent\" \"ncp\" ON nce.\"nonClassParentId\" = \"ncp\".\"id\"  LEFT JOIN \"semester\" \"s\" ON COALESCE(ci.\"semesterId\", nce.\"semesterId\") = \"s\".\"id\""]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = \'VIEW\' AND "schema" = $1 AND "name" = $2', ['public', 'RoomBookingInfoView']);
+    await queryRunner.query('DROP VIEW "RoomBookingInfoView"');
+    await queryRunner.query('ALTER TABLE "non_class_event" ADD "title" character varying NOT NULL');
+    await queryRunner.query('ALTER TABLE "non_class_parent" ADD "courseId" uuid');
+    await queryRunner.query('ALTER TABLE "non_class_parent" ADD CONSTRAINT "FK_6b821019772b6920f70f81dcdca" FOREIGN KEY ("courseId") REFERENCES "course"("id") ON DELETE NO ACTION ON UPDATE NO ACTION');
+    await queryRunner.query(`CREATE VIEW "RoomBookingInfoView" AS SELECT "m"."day" AS "day", "r"."id" AS "roomId", "s"."term" AS "term", s."academicYear" AS "calendarYear", m."startTime" AS "startTime", m."endTime" AS "endTime", CASE
+               WHEN m."courseInstanceId" IS NOT NULL
+               THEN CONCAT_WS(' ', "c"."prefix", "c"."number")
+               WHEN m."nonClassEventId" IS NOT NULL
+               THEN "nce"."title"
+               END AS "meetingTitle" FROM "meeting" "m" LEFT JOIN "room" "r" ON "r"."id" = m."roomId"  LEFT JOIN "course_instance" "ci" ON m."courseInstanceId" = "ci"."id"  LEFT JOIN "course" "c" ON ci."courseId" = "c"."id"  LEFT JOIN "non_class_event" "nce" ON m."nonClassEventId" = "nce"."id"  LEFT JOIN "non_class_parent" "ncp" ON nce."nonClassParentId" = "ncp"."id"  LEFT JOIN "semester" "s" ON COALESCE(ci."semesterId", nce."semesterId") = "s"."id"`);
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'RoomBookingInfoView', "SELECT \"m\".\"day\" AS \"day\", \"r\".\"id\" AS \"roomId\", \"s\".\"term\" AS \"term\", s.\"academicYear\" AS \"calendarYear\", m.\"startTime\" AS \"startTime\", m.\"endTime\" AS \"endTime\", CASE\n               WHEN m.\"courseInstanceId\" IS NOT NULL\n               THEN CONCAT_WS(' ', \"c\".\"prefix\", \"c\".\"number\")\n               WHEN m.\"nonClassEventId\" IS NOT NULL\n               THEN \"nce\".\"title\"\n               END AS \"meetingTitle\" FROM \"meeting\" \"m\" LEFT JOIN \"room\" \"r\" ON \"r\".\"id\" = m.\"roomId\"  LEFT JOIN \"course_instance\" \"ci\" ON m.\"courseInstanceId\" = \"ci\".\"id\"  LEFT JOIN \"course\" \"c\" ON ci.\"courseId\" = \"c\".\"id\"  LEFT JOIN \"non_class_event\" \"nce\" ON m.\"nonClassEventId\" = \"nce\".\"id\"  LEFT JOIN \"non_class_parent\" \"ncp\" ON nce.\"nonClassParentId\" = \"ncp\".\"id\"  LEFT JOIN \"semester\" \"s\" ON COALESCE(ci.\"semesterId\", nce.\"semesterId\") = \"s\".\"id\""]);
+  }
+}

--- a/src/server/nonClassEvent/nonclassevent.entity.ts
+++ b/src/server/nonClassEvent/nonclassevent.entity.ts
@@ -13,16 +13,6 @@ import { Meeting } from '../meeting/meeting.entity';
 @Entity()
 export class NonClassEvent extends BaseEntity {
   /**
-   * The title of the non-class event. This type of event is usually used to
-   * schedule non-class meetings such as reading groups, seminars etc.
-   */
-  @Column({
-    type: 'varchar',
-    comment: 'The title of the non-class event. This type of event is typically used to schedule non-class meetings such as reading groups etc.',
-  })
-  public title: string;
-
-  /**
    * Parent entity to contain a group of related non-class events.
    * [[NonClassParent]] and [[NonClassEvent]] is analogous to [[Course]] and
    * [[CourseInstance]] (respectively)

--- a/src/server/nonClassParent/nonclassparent.entity.ts
+++ b/src/server/nonClassParent/nonclassparent.entity.ts
@@ -1,8 +1,7 @@
 import {
-  Entity, Column, ObjectType, ManyToOne, OneToMany,
+  Entity, Column, ObjectType, OneToMany,
 } from 'typeorm';
 import { BaseEntity } from '../base/base.entity';
-import { Course } from '../course/course.entity';
 import { NonClassEvent } from '../nonClassEvent/nonclassevent.entity';
 
 /**

--- a/src/server/nonClassParent/nonclassparent.entity.ts
+++ b/src/server/nonClassParent/nonclassparent.entity.ts
@@ -33,18 +33,6 @@ export class NonClassParent extends BaseEntity {
   public contact: string;
 
   /**
-   * The [[Course]] associated with this collection of non class events.
-   *
-   * ---
-   * Many [[NonClassParent]]s have one [[Course]]
-   */
-  @ManyToOne(
-    (): ObjectType<Course> => Course,
-    ({ nonClassParents }): NonClassParent[] => nonClassParents
-  )
-  public course: Course;
-
-  /**
    * Collection of scheduled events. These are typically events that occur
    * outside the normal teaching of classes (for example, office hours or
    * seminars)


### PR DESCRIPTION
This PR removes the `title` property from the `NonClassEvent` entity and the `course id` from the `NonClassParent`, as `NonClassParent` does not need to be tied to a course.
 
The `RoomBookingInfoView` was also updated so that the `title` displayed is from the `NonClassParent` rather than the `NonClassEvent,` since `title` is being removed from `NonClassEvent.`

A migration was generated for these changes.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #322

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
