### PR TITLE
Add cascade property for Non Class entities

### DIFF
--- a/src/server/nonClassEvent/nonclassevent.entity.ts
+++ b/src/server/nonClassEvent/nonclassevent.entity.ts
@@ -57,7 +57,8 @@ export class NonClassEvent extends BaseEntity {
    */
   @OneToMany(
     (): ObjectType<Meeting> => Meeting,
-    ({ nonClassEvent }): NonClassEvent => nonClassEvent
+    ({ nonClassEvent }): NonClassEvent => nonClassEvent,
+    { cascade: ['insert'] }
   )
   public meetings: Meeting[];
 }

--- a/src/server/nonClassParent/nonclassparent.entity.ts
+++ b/src/server/nonClassParent/nonclassparent.entity.ts
@@ -41,7 +41,8 @@ export class NonClassParent extends BaseEntity {
    */
   @OneToMany(
     (): ObjectType<NonClassEvent> => NonClassEvent,
-    ({ nonClassParent }): NonClassParent => nonClassParent
+    ({ nonClassParent }): NonClassParent => nonClassParent,
+    { cascade: ['insert'] }
   )
   public nonClassEvents: NonClassEvent[];
 }


### PR DESCRIPTION
When creating `NonClassEvent`s in the course planner ETL, the `NonClassEvent` is not tied to a `NonClassParent` or a `Meeting`, presumably because the `cascade` property hasn't been set in these two `OneToMany` relationships in `NonClassEvent` and `NonClassParent`.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #322

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
