### PR TITLE
Bugfix/view relationships

### DIFF
--- a/src/server/courseInstance/ScheduleEntryView.entity.ts
+++ b/src/server/courseInstance/ScheduleEntryView.entity.ts
@@ -13,7 +13,9 @@ import { CourseInstance } from './courseinstance.entity';
 import { Meeting } from '../meeting/meeting.entity';
 import { Course } from '../course/course.entity';
 import { ScheduleBlockView } from './ScheduleBlockView.entity';
-import { RoomListingView } from '../location/RoomListingView.entity';
+import { Room } from '../location/room.entity';
+import { Building } from '../location/building.entity';
+import { Campus } from '../location/campus.entity';
 
 /**
  * [[CourseInstanceScheduleView]]s are used to generate the course timetable
@@ -28,14 +30,16 @@ import { RoomListingView } from '../location/RoomListingView.entity';
     .select('m.id', 'id')
     .addSelect('c.number', 'courseNumber')
     .addSelect('c.isUndergraduate', 'isUndergraduate')
-    .addSelect('r.name', 'room')
-    .addSelect('r.campus', 'campus')
+    .addSelect("CONCAT_WS(' ', b.name, r.name)", 'room')
+    .addSelect('campus.name', 'campus')
     .addSelect('CONCAT(c.prefix, m.day, TO_CHAR(m."startTime"::TIME, \'HH24MI\'), TO_CHAR(m."endTime"::TIME, \'HH24MI\'), s.term, s."academicYear")', 'blockId')
     .from(CourseInstance, 'ci')
     .leftJoin(Course, 'c', 'ci."courseId" = c.id')
     .innerJoin(Semester, 's', 's.id = ci."semesterId"')
     .innerJoin(Meeting, 'm', 'm."courseInstanceId" = ci.id')
-    .leftJoin(RoomListingView, 'r', 'r.id = m."roomId"')
+    .leftJoin(Room, 'r', 'r.id = m."roomId"')
+    .leftJoin(Building, 'b', 'b.id = r."buildingId"')
+    .leftJoin(Campus, 'campus', 'c.id = b."campusId"')
     .where(`c."isSEAS" <> '${IS_SEAS.N}'`),
 })
 export class ScheduleEntryView {

--- a/src/server/courseInstance/ScheduleEntryView.entity.ts
+++ b/src/server/courseInstance/ScheduleEntryView.entity.ts
@@ -10,7 +10,7 @@ import {
 import { Semester } from 'server/semester/semester.entity';
 import { IS_SEAS } from 'common/constants';
 import { CourseInstance } from './courseinstance.entity';
-import { MeetingListingView } from '../meeting/MeetingListingView.entity';
+import { Meeting } from '../meeting/meeting.entity';
 import { Course } from '../course/course.entity';
 import { ScheduleBlockView } from './ScheduleBlockView.entity';
 import { RoomListingView } from '../location/RoomListingView.entity';
@@ -34,7 +34,7 @@ import { RoomListingView } from '../location/RoomListingView.entity';
     .from(CourseInstance, 'ci')
     .leftJoin(Course, 'c', 'ci."courseId" = c.id')
     .innerJoin(Semester, 's', 's.id = ci."semesterId"')
-    .innerJoin(MeetingListingView, 'm', 'm."courseInstanceId" = ci.id')
+    .innerJoin(Meeting, 'm', 'm."courseInstanceId" = ci.id')
     .leftJoin(RoomListingView, 'r', 'r.id = m."roomId"')
     .where(`c."isSEAS" <> '${IS_SEAS.N}'`),
 })

--- a/src/server/migrations/1618340375981-RemoveViewDependencies.ts
+++ b/src/server/migrations/1618340375981-RemoveViewDependencies.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * This migration replaces the ScheduleEntryView created in
+ * 1603825601596-ScheduleViews.ts to remove the relation between the
+ * ScheduleEntryView and the MeetingListingView and RoomListingView, which was
+ * creating a dependency in the view definition and making it impossible to
+ * update the MeetingListingView in 1618340375982-NonClassEventViews.ts.
+ * Becuase that dependency breaks the migration:run process, the timestamp on
+ * this migration has been modified so that it will run BEFORE the
+ * NonClassEventViews migration.
+ *
+ * At a deeper level, the issue here is that TypeORM handles any changes to
+ * Views by dropping and recreating the view, rather than altering them in
+ * place. Since Views don't contain any actual data this doesn't result in any
+ * data loss, but it does make it much harder to handle relations among views.
+ */
+
+export class RemoveViewDependencies1618340375981 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = \'VIEW\' AND "schema" = $1 AND "name" = $2', ['public', 'ScheduleEntryView']);
+    await queryRunner.query('DROP VIEW "ScheduleEntryView"');
+    await queryRunner.query('CREATE VIEW "ScheduleEntryView" AS SELECT "c"."number" AS "courseNumber", "c"."isUndergraduate" AS "isUndergraduate", "m"."id" AS "id", "campus"."name" AS "campus", CONCAT_WS(\' \', "b"."name", "r"."name") AS "room", CONCAT("c"."prefix", "m"."day", TO_CHAR(m."startTime"::TIME, \'HH24MI\'), TO_CHAR(m."endTime"::TIME, \'HH24MI\'), "s"."term", s."academicYear") AS "blockId" FROM "course_instance" "ci" LEFT JOIN "course" "c" ON ci."courseId" = "c"."id"  INNER JOIN "semester" "s" ON "s"."id" = ci."semesterId"  INNER JOIN "meeting" "m" ON m."courseInstanceId" = "ci"."id"  LEFT JOIN "room" "r" ON "r"."id" = m."roomId"  LEFT JOIN "building" "b" ON "b"."id" = r."buildingId"  LEFT JOIN "campus" "campus" ON "campus"."id" = b."campusId" WHERE c."isSEAS" <> \'N\'');
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'ScheduleEntryView', "SELECT \"c\".\"number\" AS \"courseNumber\", \"c\".\"isUndergraduate\" AS \"isUndergraduate\", \"m\".\"id\" AS \"id\", \"campus\".\"name\" AS \"campus\", CONCAT_WS(' ', \"b\".\"name\", \"r\".\"name\") AS \"room\", CONCAT(\"c\".\"prefix\", \"m\".\"day\", TO_CHAR(m.\"startTime\"::TIME, 'HH24MI'), TO_CHAR(m.\"endTime\"::TIME, 'HH24MI'), \"s\".\"term\", s.\"academicYear\") AS \"blockId\" FROM \"course_instance\" \"ci\" LEFT JOIN \"course\" \"c\" ON ci.\"courseId\" = \"c\".\"id\"  INNER JOIN \"semester\" \"s\" ON \"s\".\"id\" = ci.\"semesterId\"  INNER JOIN \"meeting\" \"m\" ON m.\"courseInstanceId\" = \"ci\".\"id\"  LEFT JOIN \"room\" \"r\" ON \"r\".\"id\" = m.\"roomId\"  LEFT JOIN \"building\" \"b\" ON \"b\".\"id\" = r.\"buildingId\"  LEFT JOIN \"campus\" \"campus\" ON \"campus\".\"id\" = b.\"campusId\" WHERE c.\"isSEAS\" <> 'N'"]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = \'VIEW\' AND "schema" = $1 AND "name" = $2', ['public', 'ScheduleEntryView']);
+    await queryRunner.query('DROP VIEW "ScheduleEntryView"');
+    await queryRunner.query('CREATE VIEW "ScheduleEntryView" AS SELECT "c"."number" AS "courseNumber", "c"."isUndergraduate" AS "isUndergraduate", "m"."id" AS "id", "r"."name" AS "room", "r"."campus" AS "campus", CONCAT("c"."prefix", "m"."day", TO_CHAR(m."startTime"::TIME, \'HH24MI\'), TO_CHAR(m."endTime"::TIME, \'HH24MI\'), "s"."term", s."academicYear") AS "blockId" FROM "course_instance" "ci" LEFT JOIN "course" "c" ON ci."courseId" = "c"."id"  INNER JOIN "semester" "s" ON "s"."id" = ci."semesterId"  INNER JOIN "MeetingListingView" "m" ON m."courseInstanceId" = "ci"."id"  LEFT JOIN "RoomListingView" "r" ON "r"."id" = m."roomId" WHERE c."isSEAS" <> \'N\'');
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'ScheduleEntryView', "SELECT \"c\".\"number\" AS \"courseNumber\", \"c\".\"isUndergraduate\" AS \"isUndergraduate\", \"m\".\"id\" AS \"id\", \"r\".\"name\" AS \"room\", \"r\".\"campus\" AS \"campus\", CONCAT(\"c\".\"prefix\", \"m\".\"day\", TO_CHAR(m.\"startTime\"::TIME, 'HH24MI'), TO_CHAR(m.\"endTime\"::TIME, 'HH24MI'), \"s\".\"term\", s.\"academicYear\") AS \"blockId\" FROM \"course_instance\" \"ci\" LEFT JOIN \"course\" \"c\" ON ci.\"courseId\" = \"c\".\"id\"  INNER JOIN \"semester\" \"s\" ON \"s\".\"id\" = ci.\"semesterId\"  INNER JOIN \"MeetingListingView\" \"m\" ON m.\"courseInstanceId\" = \"ci\".\"id\"  LEFT JOIN \"RoomListingView\" \"r\" ON \"r\".\"id\" = m.\"roomId\" WHERE c.\"isSEAS\" <> 'N'"]);
+  }
+}


### PR DESCRIPTION
This changes the definition for the `ScheduleEntryView` so that it no longer relies on a JOIN with the `RoomListingView` and the `MeetingListingView`. Those relationships were causing the migration included in #328 to fail, because TypeORM handles changes to views by dropping and recreating them, rather than altering them in place.

Note that I did manually edit the timestamp of the new migration to force it to run before `1618340375982-NonClassEventViews.ts`. That seemed like the least invasive way to resolve the dependency issue. If you've somehow already run that migration, you'll need to `migration:revert` it before running this new one, or simply "nuke and pave" the postgres container and run all the migrations on an empty database.  

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [ ] Normal <!-- New piece of functionality -->
- [x] High <!-- Critical bug requiring urgent review -->

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
