### PR TITLE
Fix Display of Faculty Notes when 'notes' is null - Meeting Modal

### DIFF
--- a/src/client/components/pages/Courses/MeetingModal.tsx
+++ b/src/client/components/pages/Courses/MeetingModal.tsx
@@ -157,7 +157,7 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
                     </h4>
                     <p>
                       {
-                        instructor.notes === ''
+                        !instructor.notes || instructor.notes === ''
                           ? <StyledFacultyNote>No Notes</StyledFacultyNote>
                           : instructor.notes
                       }

--- a/src/client/components/pages/Courses/MeetingModal.tsx
+++ b/src/client/components/pages/Courses/MeetingModal.tsx
@@ -157,7 +157,7 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
                     </h4>
                     <p>
                       {
-                        !instructor.notes || instructor.notes === ''
+                        !instructor.notes
                           ? <StyledFacultyNote>No Notes</StyledFacultyNote>
                           : instructor.notes
                       }

--- a/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
@@ -48,7 +48,7 @@ describe('Meeting Modal', function () {
         context('when the faculty member has associated notes', function () {
           it('displays the faculty notes associated with the course instance', async function () {
             const facultyWithNotes = (testCourseInstance.fall.instructors
-              .filter((instructor) => (instructor.notes !== '')));
+              .filter((instructor) => (instructor.notes !== '' && instructor.notes !== null)));
             const expectedNotes = facultyWithNotes
               .map((faculty) => faculty.notes);
             return Promise.all(expectedNotes.map((note) => waitForElement(
@@ -57,12 +57,23 @@ describe('Meeting Modal', function () {
           });
         });
         context('when the faculty member does not have associated notes', function () {
-          it('displays the text "No Notes"', function () {
-            const facultyWithoutNotes = (testCourseInstance.fall.instructors
-              .filter((instructor) => (instructor.notes === '')));
-            const modalNotes = getByText('Faculty Notes', { exact: false }).nextElementSibling;
-            const noNotesLength = (modalNotes as HTMLElement).textContent.match(/s*No Notes\s*$/g).length;
-            strictEqual(facultyWithoutNotes.length, noNotesLength);
+          context('when faculty notes is an empty string', function () {
+            it('displays the text "No Notes"', function () {
+              const facultyWithoutNotes = (testCourseInstance.fall.instructors
+                .filter((instructor) => (instructor.notes === '')));
+              const modalNotes = getByText('Faculty Notes', { exact: false }).nextElementSibling;
+              const noNotesLength = (modalNotes as HTMLElement).textContent.match(/s*No Notes\s*$/g).length;
+              strictEqual(facultyWithoutNotes.length, noNotesLength);
+            });
+          });
+          context('when faculty notes is null', function () {
+            it('displays the text "No Notes"', function () {
+              const facultyWithNullNotes = (testCourseInstance.fall.instructors
+                .filter((instructor) => (instructor.notes === null)));
+              const modalNotes = getByText('Faculty Notes', { exact: false }).nextElementSibling;
+              const noNotesLength = (modalNotes as HTMLElement).textContent.match(/s*No Notes\s*$/g).length;
+              strictEqual(facultyWithNullNotes.length, noNotesLength);
+            });
           });
         });
       });

--- a/src/common/__tests__/data/courseInstances.ts
+++ b/src/common/__tests__/data/courseInstances.ts
@@ -60,6 +60,11 @@ export const cs50CourseInstance: CourseInstanceResponseDTO = {
         displayName: 'Waldo, James',
         notes: '',
       },
+      {
+        id: 'cec66944-8c43-4094-a05e-5fdccca2e04c',
+        displayName: 'Amin, Nada',
+        notes: null,
+      },
     ],
     meetings: [
       {


### PR DESCRIPTION
This PR fixes a bug in which there is no note displayed under an individual faculty member in the meeting modal when faculty `notes` is `null.`. This was occurring because the previous code was only checking whether `notes` was equal (`===`) to an empty string and not considering the case when `notes` is equal to `null.` The fix makes it so that if `notes` is equal to `null`, the text 'No Notes' will be displayed under the faculty member.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #331

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
