### PR TITLE
Fix table alias in expression

### DIFF
--- a/src/server/courseInstance/ScheduleEntryView.entity.ts
+++ b/src/server/courseInstance/ScheduleEntryView.entity.ts
@@ -39,7 +39,7 @@ import { Campus } from '../location/campus.entity';
     .innerJoin(Meeting, 'm', 'm."courseInstanceId" = ci.id')
     .leftJoin(Room, 'r', 'r.id = m."roomId"')
     .leftJoin(Building, 'b', 'b.id = r."buildingId"')
-    .leftJoin(Campus, 'campus', 'c.id = b."campusId"')
+    .leftJoin(Campus, 'campus', 'campus.id = b."campusId"')
     .where(`c."isSEAS" <> '${IS_SEAS.N}'`),
 })
 export class ScheduleEntryView {


### PR DESCRIPTION
This Should fix the issue where new migrations try to re-create the Schedule Entry View.

Previously I had changed the ScheduleEntryView definition so that it would no longer depend on the Room Listing View. In doing so I had introduced a bug by using "c" as the identifier for campus, when that was already being used for "course". While fixing that, I must have made some kind of merge/rebase error that kept "c" in the view definition, but changed it in the migration. So TypeORM keeps seeing that difference and trying to generate a new migration that replaces "c".

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #___

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
