### PR TITLE
Parse course.number into integer and alphabetical portions

### DIFF
--- a/src/server/course/course.entity.ts
+++ b/src/server/course/course.entity.ts
@@ -199,7 +199,7 @@ export class Course extends BaseEntity {
   @BeforeInsert()
   @BeforeUpdate()
   parseCourseNumber():void {
-    const numberMatch = /^(?<int>\d+)?(?<alpha>[a-zA-Z]+)?$/.exec(this.number);
+    const numberMatch = /(?<int>\d+)?(?<alpha>[a-zA-Z\s]+)?/.exec(this.number);
     if (numberMatch && 'groups' in numberMatch) {
       const { alpha, int } = numberMatch.groups;
       this.numberInteger = int

--- a/src/server/course/course.entity.ts
+++ b/src/server/course/course.entity.ts
@@ -21,6 +21,7 @@ import { Area } from '../area/area.entity';
  */
 
 @Entity()
+@Index(['prefix', 'numberInteger', 'numberAlphabetical'])
 export class Course extends BaseEntity {
   /**
    * The long title for the course

--- a/src/server/course/course.entity.ts
+++ b/src/server/course/course.entity.ts
@@ -5,6 +5,8 @@ import {
   ManyToOne,
   ObjectType,
   Index,
+  BeforeInsert,
+  BeforeUpdate,
 } from 'typeorm';
 import { TERM_PATTERN, IS_SEAS } from 'common/constants';
 import { BaseEntity } from '../base/base.entity';
@@ -193,4 +195,20 @@ export class Course extends BaseEntity {
     }
   )
   public area: Area;
+
+  @BeforeInsert()
+  @BeforeUpdate()
+  parseCourseNumber():void {
+    const numberMatch = /^(?<int>\d+)?(?<alpha>[a-zA-Z]+)?$/.exec(this.number);
+    if (numberMatch && 'groups' in numberMatch) {
+      const { alpha, int } = numberMatch.groups;
+      this.numberInteger = int
+        ? parseInt(int, 10)
+        : null;
+      this.numberAlphabetical = alpha || null;
+    } else {
+      this.numberInteger = null;
+      this.numberAlphabetical = null;
+    }
+  }
 }

--- a/src/server/course/course.entity.ts
+++ b/src/server/course/course.entity.ts
@@ -196,6 +196,11 @@ export class Course extends BaseEntity {
   )
   public area: Area;
 
+  /**
+   * Before inserting or updating a course, this will parse the [[number]]
+   * string and save the integer and alphabetical portions in the respective
+   * [[numberInteger]] and [[numberAlphabetical]] fields.
+   */
   @BeforeInsert()
   @BeforeUpdate()
   parseCourseNumber():void {

--- a/src/server/course/course.entity.ts
+++ b/src/server/course/course.entity.ts
@@ -58,6 +58,45 @@ export class Course extends BaseEntity {
   public number: string;
 
   /**
+   * The numerical part of the course number (e.g. - the 109 in CS 109b). This
+   * is needed to facilitate numerical sorting such that "CS 50" appears before
+   * "CS 109b".
+   *
+   * This field is not selected by default, so queries will need to explicitly
+   * include it.
+   *
+   * @example `50`
+   * @example `109`
+   */
+
+  @Column({
+    type: 'integer',
+    comment: 'Only the numerical portion of a course number (e.g. - 109 in "CS 109b")',
+    select: false,
+    nullable: true,
+  })
+  public numberInteger: number;
+
+  /**
+   * The alphabetical part of the course number (e.g. - the 109 in CS 109b). This
+   * is needed in conjunction with the numberInteger column to facilitate
+   * numerical sorting such that "CS 109a" appears before "CS 109a".
+   *
+   * This field is not selected by default, so queries will need to explicitly
+   * include it.
+   *
+   * @example `"b"`
+   */
+
+  @Column({
+    type: 'text',
+    comment: 'Only the alphabetical portion, if any, of a course number (e.g. the "a" of "CS 109a")',
+    select: false,
+    nullable: true,
+  })
+  public numberAlphabetical: string;
+
+  /**
    * Indicates whether or not this course is an undergraduate course.
    */
   @Column({

--- a/src/server/course/course.entity.ts
+++ b/src/server/course/course.entity.ts
@@ -83,7 +83,7 @@ export class Course extends BaseEntity {
   /**
    * The alphabetical part of the course number (e.g. - the 109 in CS 109b). This
    * is needed in conjunction with the numberInteger column to facilitate
-   * numerical sorting such that "CS 109a" appears before "CS 109a".
+   * numerical sorting such that "CS 109a" appears before "CS 109b".
    *
    * This field is not selected by default, so queries will need to explicitly
    * include it.

--- a/src/server/migrations/1623944858236-SplitCourseNumber.ts
+++ b/src/server/migrations/1623944858236-SplitCourseNumber.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * This migration adds new fields to the Course entity representing only the
+ * numerical and alphabetical portions of the course number, for use in
+ * sorting. The existing "number" field will remain for display purposes.
+ */
+export class SplitCourseNumber1623944858236 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "course" ADD "numberInteger" integer');
+    await queryRunner.query('COMMENT ON COLUMN "course"."numberInteger" IS \'Only the numerical portion of a course number (e.g. - 109 in "CS 109b")\'');
+    await queryRunner.query('ALTER TABLE "course" ADD "numberAlphabetical" text');
+    await queryRunner.query('COMMENT ON COLUMN "course"."numberAlphabetical" IS \'Only the alphabetical portion, if any, of a course number (e.g. the "a" of "CS 109a")\'');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('COMMENT ON COLUMN "course"."numberAlphabetical" IS \'Only the alphabetical portion, if any, of a course number (e.g. the "a" of "CS 109a")\'');
+    await queryRunner.query('ALTER TABLE "course" DROP COLUMN "numberAlphabetical"');
+    await queryRunner.query('COMMENT ON COLUMN "course"."numberInteger" IS \'Only the numerical portion of a course number (e.g. - 109 in "CS 109b")\'');
+    await queryRunner.query('ALTER TABLE "course" DROP COLUMN "numberInteger"');
+  }
+}

--- a/src/server/migrations/1623944858236-SplitCourseNumber.ts
+++ b/src/server/migrations/1623944858236-SplitCourseNumber.ts
@@ -11,9 +11,11 @@ export class SplitCourseNumber1623944858236 implements MigrationInterface {
     await queryRunner.query('COMMENT ON COLUMN "course"."numberInteger" IS \'Only the numerical portion of a course number (e.g. - 109 in "CS 109b")\'');
     await queryRunner.query('ALTER TABLE "course" ADD "numberAlphabetical" text');
     await queryRunner.query('COMMENT ON COLUMN "course"."numberAlphabetical" IS \'Only the alphabetical portion, if any, of a course number (e.g. the "a" of "CS 109a")\'');
+    await queryRunner.query('CREATE INDEX "IDX_e258df1717c66365e7a8345fdc" ON "course" ("prefix", "numberInteger", "numberAlphabetical")');
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX "IDX_e258df1717c66365e7a8345fdc"');
     await queryRunner.query('COMMENT ON COLUMN "course"."numberAlphabetical" IS \'Only the alphabetical portion, if any, of a course number (e.g. the "a" of "CS 109a")\'');
     await queryRunner.query('ALTER TABLE "course" DROP COLUMN "numberAlphabetical"');
     await queryRunner.query('COMMENT ON COLUMN "course"."numberInteger" IS \'Only the numerical portion of a course number (e.g. - 109 in "CS 109b")\'');

--- a/tests/integration/server/course/course.entity.test.ts
+++ b/tests/integration/server/course/course.entity.test.ts
@@ -181,34 +181,6 @@ describe('Course Entity', function () {
           strictEqual(numberAlphabetical, null);
         });
       });
-      context('When a course number is is not formatted [NUMBER][LETTER]', function () {
-        beforeEach(async function () {
-          testCourse = Object.assign(testCourse, {
-            number: 'a901',
-          });
-          savedCourse = await courseRepository.save(testCourse);
-          ({
-            numberInteger,
-            numberAlphabetical,
-          } = await courseRepository.findOne(
-            savedCourse.id,
-            {
-              select: [
-                'id',
-                'numberInteger',
-                'numberAlphabetical',
-              ],
-            }
-
-          ));
-        });
-        it('Should set the numberInteger field to null', function () {
-          strictEqual(numberInteger, null);
-        });
-        it('Should set the numberAlphabetical field to null', function () {
-          strictEqual(numberAlphabetical, null);
-        });
-      });
       context('When a course number is an empty string', function () {
         beforeEach(async function () {
           testCourse = Object.assign(testCourse, {
@@ -325,32 +297,6 @@ describe('Course Entity', function () {
         context('When the new course number has only special character', function () {
           beforeEach(async function () {
             savedCourse.number = '???';
-            await courseRepository.save(savedCourse);
-            const savedUpdatedCourse = await courseRepository.findOne(
-              savedCourse.id,
-              {
-                select: [
-                  'id',
-                  'numberInteger',
-                  'numberAlphabetical',
-                ],
-              }
-            );
-            ({
-              numberInteger,
-              numberAlphabetical,
-            } = savedUpdatedCourse);
-          });
-          it('Should set the numberInteger field to null', function () {
-            strictEqual(numberInteger, null);
-          });
-          it('Should set the numberAlphabetical field to null', function () {
-            strictEqual(numberAlphabetical, null);
-          });
-        });
-        context('When the new course number is not formatted as [NUMBER][LETTER]', function () {
-          beforeEach(async function () {
-            savedCourse.number = 'a901';
             await courseRepository.save(savedCourse);
             const savedUpdatedCourse = await courseRepository.findOne(
               savedCourse.id,

--- a/tests/integration/server/course/course.entity.test.ts
+++ b/tests/integration/server/course/course.entity.test.ts
@@ -1,0 +1,438 @@
+import { TestingModule, Test } from '@nestjs/testing';
+import { Course } from 'server/course/course.entity';
+import { Repository } from 'typeorm';
+import { TypeOrmModule, TypeOrmModuleOptions, getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigModule } from 'server/config/config.module';
+import { ConfigService } from 'server/config/config.service';
+import { Area } from 'server/area/area.entity';
+import { strictEqual } from 'assert';
+import { CourseModule } from 'server/course/course.module';
+import MockDB from '../../../mocks/database/MockDB';
+import { AuthModule } from '../../../../src/server/auth/auth.module';
+import { TestingStrategy } from '../../../mocks/authentication/testing.strategy';
+import { AUTH_MODE } from '../../../../src/common/constants';
+
+describe('Course Entity', function () {
+  let courseRepository: Repository<Course>;
+  let testCourse: Course;
+  let savedCourse: Course;
+  let db: MockDB;
+  let testModule: TestingModule;
+
+  before(async function () {
+    db = new MockDB();
+    await db.init();
+  });
+
+  after(async function () {
+    await db.stop();
+  });
+
+  beforeEach(async function () {
+    testModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule,
+        TypeOrmModule.forRootAsync({
+          imports: [ConfigModule],
+          useFactory: (
+            config: ConfigService
+          ): TypeOrmModuleOptions => ({
+            ...config.dbOptions,
+            synchronize: true,
+            retryAttempts: 10,
+            retryDelay: 10000,
+          }),
+          inject: [ConfigService],
+        }),
+        AuthModule.register({
+          strategies: [TestingStrategy],
+          defaultStrategy: AUTH_MODE.TEST,
+        }),
+        CourseModule,
+      ],
+    })
+      .overrideProvider(ConfigService)
+      .useValue(new ConfigService(db.connectionEnv))
+      .compile();
+
+    courseRepository = testModule.get(getRepositoryToken(Course));
+    await testModule.createNestApplication().init();
+  });
+
+  afterEach(async function () {
+    await testModule.close();
+  });
+  describe('Entity Listeners', function () {
+    beforeEach(function () {
+      const testArea = new Area();
+      testArea.name = 'CS';
+      testCourse = courseRepository.create({
+        area: testArea,
+        prefix: 'CS',
+        title: 'Testing Course',
+        number: '109a',
+      });
+    });
+    describe('BeforeInsert', function () {
+      let numberAlphabetical: string;
+      let numberInteger: number;
+      context('When a course number has alpha and numeric portions', function () {
+        beforeEach(async function () {
+          savedCourse = await courseRepository.save(testCourse);
+          ({
+            numberInteger,
+            numberAlphabetical,
+          } = await courseRepository.findOne(
+            savedCourse.id,
+            {
+              select: [
+                'id',
+                'numberInteger',
+                'numberAlphabetical',
+              ],
+            }
+          ));
+        });
+        it('Should populate the numberInteger field', function () {
+          strictEqual(numberInteger, 109);
+        });
+        it('Should populate the numberAlphabetical field', function () {
+          strictEqual(numberAlphabetical, 'a');
+        });
+      });
+      context('When a course number has only numeric portions', function () {
+        beforeEach(async function () {
+          testCourse = Object.assign(testCourse, {
+            number: '50',
+          });
+          savedCourse = await courseRepository.save(testCourse);
+          ({
+            numberInteger,
+            numberAlphabetical,
+          } = await courseRepository.findOne(
+            savedCourse.id,
+            {
+              select: [
+                'id',
+                'numberInteger',
+                'numberAlphabetical',
+              ],
+            }
+          ));
+        });
+        it('Should populate the numberInteger field', function () {
+          strictEqual(numberInteger, 50);
+        });
+        it('Should set the numberAlphabetical field to null', function () {
+          strictEqual(numberAlphabetical, null);
+        });
+      });
+      context('When a course number has only alpha portions', function () {
+        beforeEach(async function () {
+          testCourse = Object.assign(testCourse, {
+            number: 'XXX',
+          });
+          savedCourse = await courseRepository.save(testCourse);
+          ({
+            numberInteger,
+            numberAlphabetical,
+          } = await courseRepository.findOne(
+            savedCourse.id,
+            {
+              select: [
+                'id',
+                'numberInteger',
+                'numberAlphabetical',
+              ],
+            }
+          ));
+        });
+        it('Should set the numberInteger field to null', function () {
+          strictEqual(numberInteger, null);
+        });
+        it('Should populate the numberAlphabetical field', function () {
+          strictEqual(numberAlphabetical, 'XXX');
+        });
+      });
+      context('When a course number is all special characters', function () {
+        beforeEach(async function () {
+          testCourse = Object.assign(testCourse, {
+            number: '???',
+          });
+          savedCourse = await courseRepository.save(testCourse);
+          ({
+            numberInteger,
+            numberAlphabetical,
+          } = await courseRepository.findOne(
+            savedCourse.id,
+            {
+              select: [
+                'id',
+                'numberInteger',
+                'numberAlphabetical',
+              ],
+            }
+          ));
+        });
+        it('Should set the numberInteger field to null', function () {
+          strictEqual(numberInteger, null);
+        });
+        it('Should set the numberAlphabetical field to null', function () {
+          strictEqual(numberAlphabetical, null);
+        });
+      });
+      context('When a course number is is not formatted [NUMBER][LETTER]', function () {
+        beforeEach(async function () {
+          testCourse = Object.assign(testCourse, {
+            number: 'a901',
+          });
+          savedCourse = await courseRepository.save(testCourse);
+          ({
+            numberInteger,
+            numberAlphabetical,
+          } = await courseRepository.findOne(
+            savedCourse.id,
+            {
+              select: [
+                'id',
+                'numberInteger',
+                'numberAlphabetical',
+              ],
+            }
+
+          ));
+        });
+        it('Should set the numberInteger field to null', function () {
+          strictEqual(numberInteger, null);
+        });
+        it('Should set the numberAlphabetical field to null', function () {
+          strictEqual(numberAlphabetical, null);
+        });
+      });
+      context('When a course number is an empty string', function () {
+        beforeEach(async function () {
+          testCourse = Object.assign(testCourse, {
+            number: '',
+          });
+          savedCourse = await courseRepository.save(testCourse);
+          ({
+            numberInteger,
+            numberAlphabetical,
+          } = await courseRepository.findOne(
+            savedCourse.id,
+            {
+              select: [
+                'id',
+                'numberInteger',
+                'numberAlphabetical',
+              ],
+            }
+          ));
+        });
+        it('Should set the numberInteger field to null', function () {
+          strictEqual(numberInteger, null);
+        });
+        it('Should set the numberAlphabetical field to null', function () {
+          strictEqual(numberAlphabetical, null);
+        });
+      });
+    });
+    describe('BeforeUpdate', function () {
+      let numberAlphabetical: string;
+      let numberInteger: number;
+      beforeEach(async function () {
+        savedCourse = await courseRepository.save(testCourse);
+      });
+      context('When the course number changes', function () {
+        context('When the new course number has alpha and numeric portions', function () {
+          beforeEach(async function () {
+            savedCourse.number = '91r';
+            await courseRepository.save(savedCourse);
+            const savedUpdatedCourse = await courseRepository.findOne(
+              savedCourse.id,
+              {
+                select: [
+                  'id',
+                  'numberInteger',
+                  'numberAlphabetical',
+                ],
+              }
+            );
+            ({
+              numberInteger,
+              numberAlphabetical,
+            } = savedUpdatedCourse);
+          });
+          it('Should populate the numberInteger field', function () {
+            strictEqual(numberInteger, 91);
+          });
+          it('Should populate the numberAlphabetical field', function () {
+            strictEqual(numberAlphabetical, 'r');
+          });
+        });
+        context('When the new course number has only numeric portions', function () {
+          beforeEach(async function () {
+            savedCourse.number = '50';
+            await courseRepository.save(savedCourse);
+            const savedUpdatedCourse = await courseRepository.findOne(
+              savedCourse.id,
+              {
+                select: [
+                  'id',
+                  'numberInteger',
+                  'numberAlphabetical',
+                ],
+              }
+            );
+            ({
+              numberInteger,
+              numberAlphabetical,
+            } = savedUpdatedCourse);
+          });
+          it('Should populate the numberInteger field', function () {
+            strictEqual(numberInteger, 50);
+          });
+          it('Should set the numberAlphabetical field to null', function () {
+            strictEqual(numberAlphabetical, null);
+          });
+        });
+        context('When the new course number has only alpha portions', function () {
+          beforeEach(async function () {
+            savedCourse.number = 'XXX';
+            await courseRepository.save(savedCourse);
+            const savedUpdatedCourse = await courseRepository.findOne(
+              savedCourse.id,
+              {
+                select: [
+                  'id',
+                  'numberInteger',
+                  'numberAlphabetical',
+                ],
+              }
+            );
+            ({
+              numberInteger,
+              numberAlphabetical,
+            } = savedUpdatedCourse);
+          });
+          it('Should set the numberInteger field to null', function () {
+            strictEqual(numberInteger, null);
+          });
+          it('Should populate the numberAlphabetical field', function () {
+            strictEqual(numberAlphabetical, 'XXX');
+          });
+        });
+        context('When the new course number has only special character', function () {
+          beforeEach(async function () {
+            savedCourse.number = '???';
+            await courseRepository.save(savedCourse);
+            const savedUpdatedCourse = await courseRepository.findOne(
+              savedCourse.id,
+              {
+                select: [
+                  'id',
+                  'numberInteger',
+                  'numberAlphabetical',
+                ],
+              }
+            );
+            ({
+              numberInteger,
+              numberAlphabetical,
+            } = savedUpdatedCourse);
+          });
+          it('Should set the numberInteger field to null', function () {
+            strictEqual(numberInteger, null);
+          });
+          it('Should set the numberAlphabetical field to null', function () {
+            strictEqual(numberAlphabetical, null);
+          });
+        });
+        context('When the new course number is not formatted as [NUMBER][LETTER]', function () {
+          beforeEach(async function () {
+            savedCourse.number = 'a901';
+            await courseRepository.save(savedCourse);
+            const savedUpdatedCourse = await courseRepository.findOne(
+              savedCourse.id,
+              {
+                select: [
+                  'id',
+                  'numberInteger',
+                  'numberAlphabetical',
+                ],
+              }
+            );
+            ({
+              numberInteger,
+              numberAlphabetical,
+            } = savedUpdatedCourse);
+          });
+          it('Should set the numberInteger field to null', function () {
+            strictEqual(numberInteger, null);
+          });
+          it('Should set the numberAlphabetical field to null', function () {
+            strictEqual(numberAlphabetical, null);
+          });
+        });
+        context('When the new course number is an empty string', function () {
+          beforeEach(async function () {
+            savedCourse.number = '';
+            await courseRepository.save(savedCourse);
+            const savedUpdatedCourse = await courseRepository.findOne(
+              savedCourse.id,
+              {
+                select: [
+                  'id',
+                  'numberInteger',
+                  'numberAlphabetical',
+                ],
+              }
+            );
+            ({
+              numberInteger,
+              numberAlphabetical,
+            } = savedUpdatedCourse);
+          });
+          it('Should set the numberInteger field to null', function () {
+            strictEqual(numberInteger, null);
+          });
+          it('Should set the numberAlphabetical field to null', function () {
+            strictEqual(numberAlphabetical, null);
+          });
+        });
+      });
+      context('When the course number does not change', function () {
+        let title: string;
+        beforeEach(async function () {
+          savedCourse.title = 'Updated Course';
+          await courseRepository.save(savedCourse);
+          const savedUpdatedCourse = await courseRepository.findOne(
+            savedCourse.id,
+            {
+              select: [
+                'id',
+                'title',
+                'numberInteger',
+                'numberAlphabetical',
+              ],
+            }
+          );
+          ({
+            numberInteger,
+            numberAlphabetical,
+            title,
+          } = savedUpdatedCourse);
+        });
+        it('Should update the fields that changed', function () {
+          strictEqual(title, 'Updated Course');
+        });
+        it('Should not change the numberInteger field', function () {
+          strictEqual(numberInteger, 109);
+        });
+        it('Should not change the numberAlphabetical field', function () {
+          strictEqual(numberAlphabetical, 'a');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds two additional fields to our `Course` entity, `numberInteger` and `numberAlphabetical`, These will make sorting courses much more straightforward, since we'll be ensure that, for example, "CS 50" is sorted before "CS 109a". 

This also implements an event listener on the `@BeforeInsert` and `@BeforeUpdate` events that will parse the `number` string and populate those fields automatically, so that none of our other code needs to change as a result of this.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [ ] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #178 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
