### PR TITLE
Delete Meeting Time - Room Booking Modal (client)

### DIFF
--- a/src/client/components/pages/Courses/MeetingModal.tsx
+++ b/src/client/components/pages/Courses/MeetingModal.tsx
@@ -314,6 +314,22 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
     }
   };
 
+  /**
+   * A handler to delete a meeting from the current existing meetings of the
+   * course instance. If the deleted meeting was being edited at the time of
+   * deletion, the state of the currently edited meeting is set back to null so
+   * that no meetings are expanded in edit mode.
+   */
+  const removeMeeting = (meeting: CourseInstanceResponseMeeting) => {
+    if (currentEditMeeting !== null) {
+      setCurrentEditMeeting(null);
+    }
+    const updatedMeetings = allMeetings.filter(
+      (currentMeeting) => currentMeeting.id !== meeting.id
+    );
+    setAllMeetings(updatedMeetings);
+  };
+
   return (
     <Modal
       ariaLabelledBy="editMeeting"
@@ -338,6 +354,7 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
                 updateCurrentEditMeeting={updateCurrentEditMeeting}
                 closeCurrentEditMeeting={closeCurrentEditMeeting}
                 showRoomsHandler={searchForRooms}
+                removeMeeting={removeMeeting}
               />
               <h3>
                 Faculty Notes

--- a/src/client/components/pages/Courses/MeetingModal.tsx
+++ b/src/client/components/pages/Courses/MeetingModal.tsx
@@ -340,6 +340,7 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
   const removeMeeting = (meeting: CourseInstanceResponseMeeting) => {
     if (currentEditMeeting && meeting.id === currentEditMeeting.id) {
       setCurrentEditMeeting(null);
+      setShowRoomsData(null);
     }
     const updatedMeetings = allMeetings.filter(
       (currentMeeting) => currentMeeting.id !== meeting.id

--- a/src/client/components/pages/Courses/MeetingModal.tsx
+++ b/src/client/components/pages/Courses/MeetingModal.tsx
@@ -215,6 +215,23 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
   ] = useState('');
 
   /**
+   * Used to create a temporary unique ID for new meetings on the client.
+   * A permanent UUID will be assigned as a result of the server request
+   */
+  const [
+    newMeetingIdNumber,
+    setNewMeetingIdNumber,
+  ] = useState(1);
+
+  /**
+   * Updates the generated meeting id for newly created meetingsby increasing
+   * the current index by 1
+   */
+  const updateNewMeetingIdNumber = (): void => {
+    setNewMeetingIdNumber(newMeetingIdNumber + 1);
+  };
+
+  /**
    * Updates individual fields in the current meeting by merging passed props
    * and values into the object
    */
@@ -321,7 +338,7 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
    * that no meetings are expanded in edit mode.
    */
   const removeMeeting = (meeting: CourseInstanceResponseMeeting) => {
-    if (currentEditMeeting !== null) {
+    if (currentEditMeeting && meeting.id === currentEditMeeting.id) {
       setCurrentEditMeeting(null);
     }
     const updatedMeetings = allMeetings.filter(
@@ -354,6 +371,8 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
                 updateCurrentEditMeeting={updateCurrentEditMeeting}
                 closeCurrentEditMeeting={closeCurrentEditMeeting}
                 showRoomsHandler={searchForRooms}
+                newMeetingIdNumber={newMeetingIdNumber.toString()}
+                updateNewMeetingIdNumber={updateNewMeetingIdNumber}
                 removeMeeting={removeMeeting}
               />
               <h3>

--- a/src/client/components/pages/Courses/MeetingTimesList.tsx
+++ b/src/client/components/pages/Courses/MeetingTimesList.tsx
@@ -52,6 +52,11 @@ interface MeetingTimesListProps {
    * A handler to clear the current edit meeting, optionally opening a new one
    */
   closeCurrentEditMeeting: (newMeeting?: CourseInstanceResponseMeeting) => void;
+  /**
+   * A handler to delete a meeting from the current existing meetings of the
+   * course instance
+   */
+  removeMeeting: (meeting: CourseInstanceResponseMeeting) => void;
 }
 
 interface StyledMeetingRowProps {
@@ -156,6 +161,7 @@ export const MeetingTimesList
   closeCurrentEditMeeting,
   showRoomsHandler,
   meetingTimeError,
+  removeMeeting,
 }): ReactElement {
   return (
     <div className="meeting-times-section">
@@ -180,10 +186,12 @@ export const MeetingTimesList
                 <StyledDeleteButton>
                   <BorderlessButton
                     alt={`Delete Meeting ${index + 1} on ${meetingTimeString}${meetingRoomString}`}
-                    id={`deleteButton${meeting.id}`}
+                    id={`delete-button-${meeting.id}`}
                     variant={VARIANT.DANGER}
                     onClick={
-                      (): void => {}
+                      (): void => {
+                        removeMeeting(meeting);
+                      }
                     }
                   >
                     <FontAwesomeIcon icon={faTrash} />

--- a/src/client/components/pages/Courses/MeetingTimesList.tsx
+++ b/src/client/components/pages/Courses/MeetingTimesList.tsx
@@ -45,13 +45,21 @@ interface MeetingTimesListProps {
    */
   showRoomsHandler: () => void;
   /**
-   * Any validation erros that need to be addressed
+   * Any validation errors that need to be addressed
    */
   meetingTimeError: string;
   /**
    * A handler to clear the current edit meeting, optionally opening a new one
    */
   closeCurrentEditMeeting: (newMeeting?: CourseInstanceResponseMeeting) => void;
+  /**
+   * Used to create a temporary unique ID for new meetings on the client
+   */
+  newMeetingIdNumber: string;
+  /**
+   * A handler to update the meeting id number for the id of newly created meetings
+   */
+  updateNewMeetingIdNumber: () => void;
   /**
    * A handler to delete a meeting from the current existing meetings of the
    * course instance
@@ -162,6 +170,8 @@ export const MeetingTimesList
   showRoomsHandler,
   meetingTimeError,
   removeMeeting,
+  newMeetingIdNumber,
+  updateNewMeetingIdNumber,
 }): ReactElement {
   return (
     <div className="meeting-times-section">
@@ -365,12 +375,13 @@ export const MeetingTimesList
           id="addNewTimeButton"
           onClick={() => {
             closeCurrentEditMeeting({
-              id: `new-meeting-${allMeetings.length + 1}`,
+              id: `new-meeting-${newMeetingIdNumber}`,
               day: '' as DAY,
               startTime: '',
               endTime: '',
               room: null,
             });
+            updateNewMeetingIdNumber();
           }}
           variant={VARIANT.SECONDARY}
         >

--- a/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
@@ -934,18 +934,26 @@ describe('Meeting Modal', function () {
           });
         });
         describe('On Delete Behavior', function () {
+          const cs50FridayMeeting = testCourseInstance[semKey].meetings
+            .filter((meeting) => meeting.day === DAY.FRI)[0];
+          const cs50TuesdayMeeting = testCourseInstance[semKey].meetings
+            .filter((meeting) => meeting.day === DAY.TUE)[0];
+          const fridayMeetingIndex = testCourseInstance[semKey].meetings
+            .findIndex(({ id }) => id === cs50FridayMeeting.id);
+          const tuesdayMeetingIndex = testCourseInstance[semKey].meetings
+            .findIndex(({ id }) => id === cs50TuesdayMeeting.id);
           context('when a meeting time is being edited', function () {
-            const cs50FridayMeeting = testCourseInstance[semKey].meetings
-              .filter((meeting) => meeting.day === DAY.FRI)[0];
-            const cs50TuesdayMeeting = testCourseInstance[semKey].meetings
-              .filter((meeting) => meeting.day === DAY.TUE)[0];
             beforeEach(async function () {
-              const editCS50FridayMeetingButton = await waitForElement(() => document.getElementById('editMeetingButton' + cs50FridayMeeting.id));
+              const editCS50FridayMeetingButton = await waitForElement(
+                () => findByLabelText(`Edit Meeting ${fridayMeetingIndex + 1} on ${dayEnumToString(cs50FridayMeeting.day)}, ${cs50FridayMeeting.startTime} to ${cs50FridayMeeting.endTime}${cs50FridayMeeting.room.name === '' ? '' : ` in ${cs50FridayMeeting.room.name}`}`)
+              );
               fireEvent.click(editCS50FridayMeetingButton);
             });
             context('when the delete button of the meeting time being edited is clicked', function () {
               it('removes the meeting being edited', async function () {
-                const deleteCS50FridayMeetingButton = await waitForElement(() => document.getElementById('delete-button-' + cs50FridayMeeting.id));
+                const deleteCS50FridayMeetingButton = await waitForElement(
+                  () => findByLabelText(`Delete Meeting ${fridayMeetingIndex + 1} on ${dayEnumToString(cs50FridayMeeting.day)}, ${cs50FridayMeeting.startTime} to ${cs50FridayMeeting.endTime}${cs50FridayMeeting.room.name === '' ? '' : ` in ${cs50FridayMeeting.room.name}`}`)
+                );
                 fireEvent.click(deleteCS50FridayMeetingButton);
                 const meetingText = `${DAY.FRI}, ${cs50FridayMeeting.startTime} to ${cs50FridayMeeting.endTime}`;
                 strictEqual(queryByText(meetingText, { exact: false }), null);
@@ -953,7 +961,9 @@ describe('Meeting Modal', function () {
             });
             context('when the delete button of a meeting time not being edited is clicked', function () {
               it('removes the meeting linked to the clicked delete button', async function () {
-                const deleteCS50TuesdayMeetingButton = await waitForElement(() => document.getElementById('delete-button-' + cs50TuesdayMeeting.id));
+                const deleteCS50TuesdayMeetingButton = await waitForElement(
+                  () => findByLabelText(`Delete Meeting ${tuesdayMeetingIndex + 1} on ${dayEnumToString(cs50TuesdayMeeting.day)}, ${cs50TuesdayMeeting.startTime} to ${cs50TuesdayMeeting.endTime}${cs50TuesdayMeeting.room.name === '' ? '' : ` in ${cs50TuesdayMeeting.room.name}`}`)
+                );
                 fireEvent.click(deleteCS50TuesdayMeetingButton);
                 const meetingText = `${DAY.TUE}, ${cs50TuesdayMeeting.startTime} to ${cs50TuesdayMeeting.endTime}`;
                 strictEqual(queryByText(meetingText, { exact: false }), null);
@@ -964,8 +974,6 @@ describe('Meeting Modal', function () {
             const day = DAY.MON;
             const startTime = '4:00 PM';
             const endTime = '5:00 PM';
-            const cs50TuesdayMeeting = testCourseInstance[semKey].meetings
-              .filter((meeting) => meeting.day === DAY.TUE)[0];
             beforeEach(async function () {
               const addNewTimeButton = getByText('Add New Time');
               fireEvent.click(addNewTimeButton);
@@ -1002,7 +1010,9 @@ describe('Meeting Modal', function () {
             });
             context('when the delete button of a previously existing meeting is clicked', function () {
               it('removes the meeting linked to the clicked delete button', async function () {
-                const deleteCS50TuesdayMeetingButton = await waitForElement(() => document.getElementById('delete-button-' + cs50TuesdayMeeting.id));
+                const deleteCS50TuesdayMeetingButton = await waitForElement(
+                  () => findByLabelText(`Delete Meeting ${tuesdayMeetingIndex + 1} on ${dayEnumToString(cs50TuesdayMeeting.day)}, ${cs50TuesdayMeeting.startTime} to ${cs50TuesdayMeeting.endTime}${cs50TuesdayMeeting.room.name === '' ? '' : ` in ${cs50TuesdayMeeting.room.name}`}`)
+                );
                 fireEvent.click(deleteCS50TuesdayMeetingButton);
                 const meetingText = `${DAY.TUE}, ${cs50TuesdayMeeting.startTime} to ${cs50TuesdayMeeting.endTime}`;
                 strictEqual(queryByText(meetingText, { exact: false }), null);

--- a/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
@@ -980,10 +980,8 @@ describe('Meeting Modal', function () {
             context('when the delete button of the meeting currently being added is clicked', function () {
               it('removes the meeting currently being edited', async function () {
                 // The new meeting ids are determined by the length of the number of meetings.
-                const deleteButtonIndex = testCourseInstance[semKey]
-                  .meetings.length + 1;
                 const deleteNewMeetingButton = await waitForElement(
-                  () => document.getElementById(`delete-button-new-meeting-${deleteButtonIndex}`)
+                  () => document.getElementById('delete-button-new-meeting-1')
                 );
                 fireEvent.click(deleteNewMeetingButton);
                 const meetingText = `${day}, ${startTime} to ${endTime}`;
@@ -994,11 +992,8 @@ describe('Meeting Modal', function () {
               it('removes the newly added meeting', async function () {
                 const closeButton = getByText('Close');
                 fireEvent.click(closeButton);
-                // The new meeting ids are determined by the length of the number of meetings.
-                const deleteButtonIndex = testCourseInstance[semKey]
-                  .meetings.length + 1;
                 const deleteNewMeetingButton = await waitForElement(
-                  () => document.getElementById(`delete-button-new-meeting-${deleteButtonIndex}`)
+                  () => document.getElementById('delete-button-new-meeting-1')
                 );
                 fireEvent.click(deleteNewMeetingButton);
                 const meetingText = `${day}, ${startTime} to ${endTime}`;

--- a/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
@@ -968,6 +968,8 @@ describe('Meeting Modal', function () {
             const day = DAY.MON;
             const startTime = '4:00 PM';
             const endTime = '5:00 PM';
+            const newMeetingIndex = testCourseInstance[semKey]
+              .meetings.length + 1;
             beforeEach(async function () {
               const addNewTimeButton = getByText('Add New Time');
               fireEvent.click(addNewTimeButton);
@@ -975,15 +977,13 @@ describe('Meeting Modal', function () {
               // Fill out the new meeting entry and exit the editing stage
               fireEvent.change(dayDropdown,
                 { target: { value: day } });
-              const timepicker = await waitForElement(() => findByLabelText('Timeslot Button'));
+              const timepicker = await findByLabelText('Timeslot Button');
               fireEvent.click(timepicker);
               fireEvent.click(getByText(`${startTime}-${endTime}`));
             });
             context('when the delete button of the meeting currently being added is clicked', function () {
               it('removes the meeting currently being edited', async function () {
-                const deleteNewMeetingButton = await waitForElement(
-                  () => document.getElementById('delete-button-new-meeting-1')
-                );
+                const deleteNewMeetingButton = await findByLabelText(`Delete Meeting ${newMeetingIndex}`, { exact: false });
                 fireEvent.click(deleteNewMeetingButton);
                 const meetingText = `${day}, ${startTime} to ${endTime}`;
                 strictEqual(queryByText(meetingText, { exact: false }), null);
@@ -993,9 +993,7 @@ describe('Meeting Modal', function () {
               it('removes the newly added meeting', async function () {
                 const closeButton = getByText('Close');
                 fireEvent.click(closeButton);
-                const deleteNewMeetingButton = await waitForElement(
-                  () => document.getElementById('delete-button-new-meeting-1')
-                );
+                const deleteNewMeetingButton = await findByLabelText(`Delete Meeting ${newMeetingIndex}`, { exact: false });
                 fireEvent.click(deleteNewMeetingButton);
                 const meetingText = `${day}, ${startTime} to ${endTime}`;
                 strictEqual(queryByText(meetingText, { exact: false }), null);

--- a/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
@@ -944,16 +944,12 @@ describe('Meeting Modal', function () {
             .findIndex(({ id }) => id === cs50TuesdayMeeting.id);
           context('when a meeting time is being edited', function () {
             beforeEach(async function () {
-              const editCS50FridayMeetingButton = await waitForElement(
-                () => findByLabelText(`Edit Meeting ${fridayMeetingIndex + 1} on ${dayEnumToString(cs50FridayMeeting.day)}, ${cs50FridayMeeting.startTime} to ${cs50FridayMeeting.endTime}${cs50FridayMeeting.room.name === '' ? '' : ` in ${cs50FridayMeeting.room.name}`}`)
-              );
+              const editCS50FridayMeetingButton = await findByLabelText(`Edit Meeting ${fridayMeetingIndex + 1}`, { exact: false });
               fireEvent.click(editCS50FridayMeetingButton);
             });
             context('when the delete button of the meeting time being edited is clicked', function () {
               it('removes the meeting being edited', async function () {
-                const deleteCS50FridayMeetingButton = await waitForElement(
-                  () => findByLabelText(`Delete Meeting ${fridayMeetingIndex + 1} on ${dayEnumToString(cs50FridayMeeting.day)}, ${cs50FridayMeeting.startTime} to ${cs50FridayMeeting.endTime}${cs50FridayMeeting.room.name === '' ? '' : ` in ${cs50FridayMeeting.room.name}`}`)
-                );
+                const deleteCS50FridayMeetingButton = await findByLabelText(`Delete Meeting ${fridayMeetingIndex + 1}`, { exact: false });
                 fireEvent.click(deleteCS50FridayMeetingButton);
                 const meetingText = `${DAY.FRI}, ${cs50FridayMeeting.startTime} to ${cs50FridayMeeting.endTime}`;
                 strictEqual(queryByText(meetingText, { exact: false }), null);
@@ -961,9 +957,7 @@ describe('Meeting Modal', function () {
             });
             context('when the delete button of a meeting time not being edited is clicked', function () {
               it('removes the meeting linked to the clicked delete button', async function () {
-                const deleteCS50TuesdayMeetingButton = await waitForElement(
-                  () => findByLabelText(`Delete Meeting ${tuesdayMeetingIndex + 1} on ${dayEnumToString(cs50TuesdayMeeting.day)}, ${cs50TuesdayMeeting.startTime} to ${cs50TuesdayMeeting.endTime}${cs50TuesdayMeeting.room.name === '' ? '' : ` in ${cs50TuesdayMeeting.room.name}`}`)
-                );
+                const deleteCS50TuesdayMeetingButton = await findByLabelText(`Delete Meeting ${tuesdayMeetingIndex + 1}`, { exact: false });
                 fireEvent.click(deleteCS50TuesdayMeetingButton);
                 const meetingText = `${DAY.TUE}, ${cs50TuesdayMeeting.startTime} to ${cs50TuesdayMeeting.endTime}`;
                 strictEqual(queryByText(meetingText, { exact: false }), null);
@@ -987,7 +981,6 @@ describe('Meeting Modal', function () {
             });
             context('when the delete button of the meeting currently being added is clicked', function () {
               it('removes the meeting currently being edited', async function () {
-                // The new meeting ids are determined by the length of the number of meetings.
                 const deleteNewMeetingButton = await waitForElement(
                   () => document.getElementById('delete-button-new-meeting-1')
                 );
@@ -1010,9 +1003,7 @@ describe('Meeting Modal', function () {
             });
             context('when the delete button of a previously existing meeting is clicked', function () {
               it('removes the meeting linked to the clicked delete button', async function () {
-                const deleteCS50TuesdayMeetingButton = await waitForElement(
-                  () => findByLabelText(`Delete Meeting ${tuesdayMeetingIndex + 1} on ${dayEnumToString(cs50TuesdayMeeting.day)}, ${cs50TuesdayMeeting.startTime} to ${cs50TuesdayMeeting.endTime}${cs50TuesdayMeeting.room.name === '' ? '' : ` in ${cs50TuesdayMeeting.room.name}`}`)
-                );
+                const deleteCS50TuesdayMeetingButton = await findByLabelText(`Delete Meeting ${tuesdayMeetingIndex + 1}`, { exact: false });
                 fireEvent.click(deleteCS50TuesdayMeetingButton);
                 const meetingText = `${DAY.TUE}, ${cs50TuesdayMeeting.startTime} to ${cs50TuesdayMeeting.endTime}`;
                 strictEqual(queryByText(meetingText, { exact: false }), null);

--- a/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
@@ -933,6 +933,88 @@ describe('Meeting Modal', function () {
             });
           });
         });
+        describe('On Delete Behavior', function () {
+          context('when a meeting time is being edited', function () {
+            const cs50FridayMeeting = testCourseInstance[semKey].meetings
+              .filter((meeting) => meeting.day === DAY.FRI)[0];
+            const cs50TuesdayMeeting = testCourseInstance[semKey].meetings
+              .filter((meeting) => meeting.day === DAY.TUE)[0];
+            beforeEach(async function () {
+              const editCS50FridayMeetingButton = await waitForElement(() => document.getElementById('editMeetingButton' + cs50FridayMeeting.id));
+              fireEvent.click(editCS50FridayMeetingButton);
+            });
+            context('when the delete button of the meeting time being edited is clicked', function () {
+              it('removes the meeting being edited', async function () {
+                const deleteCS50FridayMeetingButton = await waitForElement(() => document.getElementById('delete-button-' + cs50FridayMeeting.id));
+                fireEvent.click(deleteCS50FridayMeetingButton);
+                const meetingText = `${DAY.FRI}, ${cs50FridayMeeting.startTime} to ${cs50FridayMeeting.endTime}`;
+                strictEqual(queryByText(meetingText, { exact: false }), null);
+              });
+            });
+            context('when the delete button of a meeting time not being edited is clicked', function () {
+              it('removes the meeting linked to the clicked delete button', async function () {
+                const deleteCS50TuesdayMeetingButton = await waitForElement(() => document.getElementById('delete-button-' + cs50TuesdayMeeting.id));
+                fireEvent.click(deleteCS50TuesdayMeetingButton);
+                const meetingText = `${DAY.TUE}, ${cs50TuesdayMeeting.startTime} to ${cs50TuesdayMeeting.endTime}`;
+                strictEqual(queryByText(meetingText, { exact: false }), null);
+              });
+            });
+          });
+          context('when a meeting is being added', function () {
+            const day = DAY.MON;
+            const startTime = '4:00 PM';
+            const endTime = '5:00 PM';
+            const cs50TuesdayMeeting = testCourseInstance[semKey].meetings
+              .filter((meeting) => meeting.day === DAY.TUE)[0];
+            beforeEach(async function () {
+              const addNewTimeButton = getByText('Add New Time');
+              fireEvent.click(addNewTimeButton);
+              const dayDropdown = getByLabelText('Meeting Day', { exact: false }) as HTMLSelectElement;
+              // Fill out the new meeting entry and exit the editing stage
+              fireEvent.change(dayDropdown,
+                { target: { value: day } });
+              const timepicker = await waitForElement(() => findByLabelText('Timeslot Button'));
+              fireEvent.click(timepicker);
+              fireEvent.click(getByText(`${startTime}-${endTime}`));
+            });
+            context('when the delete button of the meeting currently being added is clicked', function () {
+              it('removes the meeting currently being edited', async function () {
+                // The new meeting ids are determined by the length of the number of meetings.
+                const deleteButtonIndex = testCourseInstance[semKey]
+                  .meetings.length + 1;
+                const deleteNewMeetingButton = await waitForElement(
+                  () => document.getElementById(`delete-button-new-meeting-${deleteButtonIndex}`)
+                );
+                fireEvent.click(deleteNewMeetingButton);
+                const meetingText = `${day}, ${startTime} to ${endTime}`;
+                strictEqual(queryByText(meetingText, { exact: false }), null);
+              });
+            });
+            context('when the delete button of the newly added meeting is clicked', function () {
+              it('removes the newly added meeting', async function () {
+                const closeButton = getByText('Close');
+                fireEvent.click(closeButton);
+                // The new meeting ids are determined by the length of the number of meetings.
+                const deleteButtonIndex = testCourseInstance[semKey]
+                  .meetings.length + 1;
+                const deleteNewMeetingButton = await waitForElement(
+                  () => document.getElementById(`delete-button-new-meeting-${deleteButtonIndex}`)
+                );
+                fireEvent.click(deleteNewMeetingButton);
+                const meetingText = `${day}, ${startTime} to ${endTime}`;
+                strictEqual(queryByText(meetingText, { exact: false }), null);
+              });
+            });
+            context('when the delete button of a previously existing meeting is clicked', function () {
+              it('removes the meeting linked to the clicked delete button', async function () {
+                const deleteCS50TuesdayMeetingButton = await waitForElement(() => document.getElementById('delete-button-' + cs50TuesdayMeeting.id));
+                fireEvent.click(deleteCS50TuesdayMeetingButton);
+                const meetingText = `${DAY.TUE}, ${cs50TuesdayMeeting.startTime} to ${cs50TuesdayMeeting.endTime}`;
+                strictEqual(queryByText(meetingText, { exact: false }), null);
+              });
+            });
+          });
+        });
       });
     });
     describe('On Close Behavior', function () {


### PR DESCRIPTION
This PR adds functionality for the delete buttons for the meeting times in the room booking modal. The `removeMeeting` handler updates the state of all meetings, which lives in the `MeetingModal.` This handler is passed down to the `MeetingTimesList` component.

The tests check that the appropriate meeting is deleted regardless of whether the user is creating or editing meetings and whether the user is deleting the meeting currently being edited, a previously existing meeting, or a newly added meeting. 

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #318

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
