### PR TITLE
Meeting Modal: Remove Room

### DIFF
--- a/src/client/components/pages/Courses/MeetingTimesList.tsx
+++ b/src/client/components/pages/Courses/MeetingTimesList.tsx
@@ -325,7 +325,6 @@ export const MeetingTimesList
                           {currentEditMeeting.room && (
                             <BorderlessButton
                               alt={`Remove Room ${index + 1} on ${meetingTimeString}${meetingRoomString}`}
-                              id={`remove-room-${meeting.id}`}
                               variant={VARIANT.DANGER}
                               onClick={
                                 (): void => {

--- a/src/client/components/pages/Courses/MeetingTimesList.tsx
+++ b/src/client/components/pages/Courses/MeetingTimesList.tsx
@@ -3,7 +3,12 @@ import React, {
   ReactElement,
 } from 'react';
 import styled from 'styled-components';
-import { faAngleDown, faEdit, faTrash } from '@fortawesome/free-solid-svg-icons';
+import {
+  faAngleDown,
+  faEdit,
+  faTrash,
+  faTimesCircle,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import DAY, { dayEnumToString, days } from 'common/constants/day';
 import { meetingTimeSlots } from 'common/constants/timeslots';
@@ -317,6 +322,22 @@ export const MeetingTimesList
                           Room:
                           {currentEditMeeting.room
                         && currentEditMeeting.room.name}
+                          {currentEditMeeting.room && (
+                            <BorderlessButton
+                              alt={`Remove Room ${index + 1} on ${meetingTimeString}${meetingRoomString}`}
+                              id={`remove-room-${meeting.id}`}
+                              variant={VARIANT.DANGER}
+                              onClick={
+                                (): void => {
+                                  updateCurrentEditMeeting(
+                                    { room: null }
+                                  );
+                                }
+                              }
+                            >
+                              <FontAwesomeIcon icon={faTimesCircle} />
+                            </BorderlessButton>
+                          )}
                         </StyledRoom>
                         <StyledShowCloseButtons>
                           <Button

--- a/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
@@ -899,7 +899,7 @@ describe('Meeting Modal', function () {
                 });
               });
             });
-            describe.only('Remove Room Button', function () {
+            describe('Remove Room Button', function () {
               context('when a room is assigned to the meeting', function () {
                 it('renders a corresponding remove room icon', function () {
                   return findByLabelText(`Remove Room ${initialMeetingIndex + 1}`, { exact: false });

--- a/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
@@ -12,7 +12,7 @@ import {
   FindAllByText,
   within,
 } from '@testing-library/react';
-import { strictEqual, notStrictEqual } from 'assert';
+import { strictEqual, notStrictEqual, ok } from 'assert';
 import { TERM } from 'common/constants';
 import DAY, { dayEnumToString } from 'common/constants/day';
 import { TermKey } from 'common/constants/term';
@@ -27,7 +27,6 @@ import { cs50CourseInstance, freeRoom, bookedRoom } from 'testData';
 import * as roomAPI from 'client/api/rooms';
 import { Button, VARIANT } from 'mark-one';
 import MeetingModal from '../MeetingModal';
-import { ok } from 'assert';
 
 describe('Meeting Modal', function () {
   let getByText: BoundFunction<GetByText>;

--- a/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
@@ -27,6 +27,7 @@ import { cs50CourseInstance, freeRoom, bookedRoom } from 'testData';
 import * as roomAPI from 'client/api/rooms';
 import { Button, VARIANT } from 'mark-one';
 import MeetingModal from '../MeetingModal';
+import { ok } from 'assert';
 
 describe('Meeting Modal', function () {
   let getByText: BoundFunction<GetByText>;
@@ -135,8 +136,14 @@ describe('Meeting Modal', function () {
           const testMeetingDay = DAY.FRI;
           const cs50InitialMeeting = testCourseInstance[semKey].meetings
             .filter((meeting) => meeting.day === testMeetingDay)[0];
+          const initialMeetingIndex = testCourseInstance[semKey].meetings
+            .findIndex(({ id }) => id === cs50InitialMeeting.id);
           const cs50TuesdayMeetingId = testCourseInstance[semKey].meetings
             .filter((meeting) => meeting.day === DAY.TUE)[0].id;
+          const unassignedRoomMeeting = testCourseInstance[semKey].meetings
+            .filter((meeting) => meeting.room === null)[0];
+          const unassignedRoomMeetingIndex = testCourseInstance[semKey].meetings
+            .findIndex(({ id }) => id === unassignedRoomMeeting.id);
           beforeEach(async function () {
             const editCS50InitialMeetingButton = await waitForElement(() => document.getElementById('editMeetingButton' + cs50InitialMeeting.id));
             fireEvent.click(editCS50InitialMeetingButton);
@@ -889,6 +896,28 @@ describe('Meeting Modal', function () {
                       () => getByText(errorMessage, { exact: false })
                     );
                   });
+                });
+              });
+            });
+            describe.only('Remove Room Button', function () {
+              context('when a room is assigned to the meeting', function () {
+                it('renders a corresponding remove room icon', function () {
+                  return findByLabelText(`Remove Room ${initialMeetingIndex + 1}`, { exact: false });
+                });
+                context('when the remove room button is clicked', function () {
+                  it('removes the room', async function () {
+                    const removeRemoveButton = await findByLabelText(`Remove Room ${initialMeetingIndex + 1}`, { exact: false });
+                    fireEvent.click(removeRemoveButton);
+                    strictEqual(queryByText(`Room:${cs50InitialMeeting.room.name}`, { exact: false }), null);
+                  });
+                  it('clears the room scheduling table', function () {
+                    ok(queryByText('Add meeting time and click "Show Rooms" to view availability'));
+                  });
+                });
+              });
+              context('when a room is not assigned to the meeting', function () {
+                it('does not render a corresponding remove room icon', function () {
+                  strictEqual(queryByText(`Remove Room ${unassignedRoomMeetingIndex + 1}`, { exact: false }), null);
                 });
               });
             });

--- a/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
@@ -144,7 +144,7 @@ describe('Meeting Modal', function () {
           const unassignedRoomMeetingIndex = testCourseInstance[semKey].meetings
             .findIndex(({ id }) => id === unassignedRoomMeeting.id);
           beforeEach(async function () {
-            const editCS50InitialMeetingButton = await waitForElement(() => document.getElementById('editMeetingButton' + cs50InitialMeeting.id));
+            const editCS50InitialMeetingButton = await findByLabelText(`Edit Meeting ${initialMeetingIndex + 1}`, { exact: false });
             fireEvent.click(editCS50InitialMeetingButton);
           });
           context('when an edit button is clicked', function () {


### PR DESCRIPTION
This PR adds a remove room icon next to the room (if there is one selected) for the meeting that is currently being edited. If there is no room selected, a remove room icon does not appear. When the remove room icon is clicked, the room is removed and the room availability table is cleared in case it was open so that it doesn't show the old status of availability. 

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #352

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
