### PR TITLE
Update RenameAcademicYearToCalendarYear migration to revert drop of ScheduleBlockView

### DIFF
--- a/src/server/migrations/1627061779480-RenameAcademicYearToCalendarYear.ts
+++ b/src/server/migrations/1627061779480-RenameAcademicYearToCalendarYear.ts
@@ -13,8 +13,6 @@ implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'NonClassEventView']);
     await queryRunner.query('DROP VIEW "NonClassEventView"');
-    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'ScheduleBlockView']);
-    await queryRunner.query('DROP VIEW "ScheduleBlockView"');
     await queryRunner.query('ALTER TABLE "non_class_parent" ALTER COLUMN "contactName" DROP NOT NULL');
     await queryRunner.query('CREATE VIEW "NonClassEventView" AS SELECT "event"."id" AS "id", "s"."term" AS "term", event."nonClassParentId" AS "nonClassParentId", s."calendarYear" AS "calendarYear", event."semesterId" AS "semesterId" FROM "non_class_event" "event" LEFT JOIN "SemesterView" "s" ON "s"."id" = event."semesterId"');
     await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'NonClassEventView', 'SELECT "event"."id" AS "id", "s"."term" AS "term", event."nonClassParentId" AS "nonClassParentId", s."calendarYear" AS "calendarYear", event."semesterId" AS "semesterId" FROM "non_class_event" "event" LEFT JOIN "SemesterView" "s" ON "s"."id" = event."semesterId"']);


### PR DESCRIPTION
This PR removes the lines of the RenameAcademicYearToCalendarYear migration that drops the `ScheduleBlockView.` This view is needed for the Schedule tab of Course Planner. 

This view is needed for the Schedule tab of Course Planner.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #391

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
