### PR TITLE
Feature/387 area ordering

### DIFF
--- a/src/server/courseInstance/courseInstance.service.ts
+++ b/src/server/courseInstance/courseInstance.service.ts
@@ -95,9 +95,14 @@ export class CourseInstanceService {
         'fall_meetings_room',
         'fall_meetings_room.id = fall_meetings."roomId"'
       )
+      .leftJoin(Course, 'course', 'course.id=c.id')
       .where('fall."calendarYear" = :prevYear', { prevYear })
       .andWhere('spring."calendarYear" = :acadYear', { acadYear })
-      .orderBy('fall_instructors."instructorOrder"', 'ASC')
+      .orderBy('area', 'ASC')
+      .addOrderBy('course.prefix', 'ASC')
+      .addOrderBy('course."numberInteger"', 'ASC')
+      .addOrderBy('course."numberAlphabetical"', 'ASC')
+      .addOrderBy('fall_instructors."instructorOrder"', 'ASC')
       .addOrderBy('spring_instructors."instructorOrder"', 'ASC');
 
     return courseQuery.getMany() as Promise<CourseInstanceResponseDTO[]>;

--- a/tests/integration/server/courseInstance/courseInstance.service.test.ts
+++ b/tests/integration/server/courseInstance/courseInstance.service.test.ts
@@ -1,4 +1,6 @@
-import { strictEqual, notStrictEqual, deepStrictEqual } from 'assert';
+import {
+  strictEqual, notStrictEqual, deepStrictEqual, ok,
+} from 'assert';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule, getRepositoryToken, TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { CourseInstanceModule } from 'server/courseInstance/courseInstance.module';
@@ -197,6 +199,53 @@ describe('Course Instance Service', function () {
             });
           });
         });
+      });
+    });
+    describe('Ordering', function () {
+      it('should order by area => prefix => integer => letter', function () {
+        for (let i = 0; i < result.length; i++) {
+          if (result[i + 1]) {
+            const {
+              area: areaA,
+              catalogNumber: catalogNumberA,
+            } = result[i];
+            const {
+              area: areaB,
+              catalogNumber: catalogNumberB,
+            } = result[i + 1];
+            if (areaA === areaB) {
+              const [prefixA, ...numberA] = catalogNumberA.split(' ');
+              const [prefixB, ...numberB] = catalogNumberB.split(' ');
+              if (prefixA === prefixB) {
+                const integerA = parseInt(numberA.join('').replace(/\D*/g, ''), 10);
+                const integerB = parseInt(numberB.join('').replace(/\D*/g, ''), 10);
+                if (integerA === integerB) {
+                  const letterA = numberA.join().replace(/^\d*/g, '');
+                  const letterB = numberB.join().replace(/^\d*/g, '');
+                  ok(
+                    letterA < letterB,
+                    `${catalogNumberB} (${areaB}) sorted before ${catalogNumberA} (${areaA})`
+                  );
+                } else {
+                  ok(
+                    integerA < integerB,
+                    `${catalogNumberB} (${areaB}) sorted before ${catalogNumberA} (${areaA})`
+                  );
+                }
+              } else {
+                ok(
+                  prefixA < prefixB,
+                  `${catalogNumberB} (${areaB}) sorted before ${catalogNumberA} (${areaA})`
+                );
+              }
+            } else {
+              ok(
+                areaA < areaB,
+                `${catalogNumberB} (${areaB}) sorted before ${catalogNumberA} (${areaA})`
+              );
+            }
+          }
+        }
       });
     });
   });


### PR DESCRIPTION
This PR updates the API route that populates the Courses tab so that it now returns the list of courses sorted by:

1. area (alphabetically -- e.g. `"AC"` before `"CS"`)
2. prefix (alphabetically -- e.g. `"AC 209A"` before `"CS 50"`)
3. numeric portion of number (numerically -- e.g. `"CS 50"` before `"CS 109A"`)
3. non-numeric portion of number (alphabetically -- e.g. `"CS 109A"` before `"CS 109B"` ) 

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #387 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
