### PR TITLE
Unsaved Changes Warning: Course Admin & Faculty Admin Modals

### DIFF
--- a/src/client/components/layout/AppRouter.tsx
+++ b/src/client/components/layout/AppRouter.tsx
@@ -15,11 +15,12 @@ import {
   Schedule,
   NonClassMeetings,
 } from '../pages';
-import { UserContext } from '../../context';
+import { MetadataContext, UserContext } from '../../context';
 
 const AppRouter: FunctionComponent = (): ReactElement => {
   const currentUser = useContext(UserContext);
-  if (currentUser) {
+  const currentMetadata = useContext(MetadataContext);
+  if (currentUser && currentMetadata?.currentAcademicYear) {
     return (
       <Switch>
         <Redirect exact from="/" to="/courses" />

--- a/src/client/components/pages/CourseAdmin.tsx
+++ b/src/client/components/pages/CourseAdmin.tsx
@@ -220,6 +220,7 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
                 <TableCell>
                   <BorderlessButton
                     id={computeEditCourseButtonId(course)}
+                    alt={`Edit course information for ${course.title}`}
                     variant={VARIANT.INFO}
                     onClick={
                       (): void => {

--- a/src/client/components/pages/Courses/CourseModal.tsx
+++ b/src/client/components/pages/Courses/CourseModal.tsx
@@ -112,6 +112,17 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
   const metadata = useContext(MetadataContext);
 
   /**
+   * Keeps track of whether the user has altered fields in the form to determine
+   * whether to show a confirmation dialog on modal close
+   */
+  const [
+    isChanged,
+    setIsChanged,
+  ] = useState(false);
+
+  const confirmMessage = "You have unsaved changes. Click 'OK' to disregard changes, or 'Cancel' to continue editing.";
+
+  /**
    * Manages the current state of the Course Admin modal form fields
    */
   const [form, setFormFields] = useState({
@@ -143,6 +154,7 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
       [target.name]:
       value,
     });
+    setIsChanged(true);
   };
 
   /**
@@ -237,10 +249,53 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
       setCourseModalFocus();
     }
   }, [isVisible, currentCourse]);
+
+  /**
+   * Used to add the before unload listener in the case that a form field is changed
+   */
+  useEffect(() => {
+    /**
+     * Checks to see if there are any unsaved changes in the modal when the user
+     * refreshes the page. If there are unsaved changes, the browser displays a
+     * warning message to confirm the page reload. If the user selects cancel, the
+     * user can continue making changes in the modal.
+     */
+    const onBeforeUnload = (event: Event) => {
+      if (!isChanged) return;
+      event.preventDefault();
+      // Need to disable this rule for browser compatibility reasons
+      // eslint-disable-next-line no-param-reassign
+      event.returnValue = false;
+      return confirmMessage;
+    };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload);
+    };
+  }, [isChanged]);
+
+  /**
+   * Called when the modal is closed. If there are any unsaved changes,
+   * a warning message appears, and the user must confirm discarding the unsaved
+   * changes in order to close the modal. If the user selects cancel, the user
+   * can continue making changes in the modal.
+   */
+  const onModalClose = () => {
+    if (isChanged) {
+      // eslint-disable-next-line no-alert
+      if (window.confirm(confirmMessage)) {
+        setIsChanged(false);
+        onClose();
+      }
+    } else {
+      onClose();
+    }
+  };
+
   return (
     <Modal
       ariaLabelledBy="editCourse"
-      closeHandler={onClose}
+      closeHandler={onModalClose}
       isVisible={isVisible}
     >
       <ModalHeader
@@ -480,7 +535,7 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
           Submit
         </Button>
         <Button
-          onClick={onClose}
+          onClick={onModalClose}
           variant={VARIANT.SECONDARY}
         >
           Cancel

--- a/src/client/components/pages/Courses/CourseModal.tsx
+++ b/src/client/components/pages/Courses/CourseModal.tsx
@@ -111,8 +111,6 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
    */
   const metadata = useContext(MetadataContext);
 
-  console.log('Metadata areas in CourseModal: ', metadata.areas); // fdo
-
   /**
    * Keeps track of whether the user has altered fields in the form to determine
    * whether to show a confirmation dialog on modal close
@@ -301,8 +299,6 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
       value: area,
       label: area,
     })));
-
-  console.log('Area options in Course Modal: ', areaOptions); // fdo
 
   return (
     <Modal

--- a/src/client/components/pages/Courses/CourseModal.tsx
+++ b/src/client/components/pages/Courses/CourseModal.tsx
@@ -111,6 +111,8 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
    */
   const metadata = useContext(MetadataContext);
 
+  console.log('Metadata areas in CourseModal: ', metadata.areas); // fdo
+
   /**
    * Keeps track of whether the user has altered fields in the form to determine
    * whether to show a confirmation dialog on modal close
@@ -292,6 +294,16 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
     }
   };
 
+  const areaOptions = [{ value: '', label: '' }]
+    .concat(metadata.areas.map((area): {
+      value: string;label: string;
+    } => ({
+      value: area,
+      label: area,
+    })));
+
+  console.log('Area options in Course Modal: ', areaOptions); // fdo
+
   return (
     <Modal
       ariaLabelledBy="editCourse"
@@ -339,15 +351,7 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
               label={displayNames.existingArea}
               isLabelVisible={false}
               // Insert an empty option so that no area is pre-selected in dropdown
-              options={
-                [{ value: '', label: '' }]
-                  .concat(metadata.areas.map((area): {
-                    value: string;label: string;
-                  } => ({
-                    value: area,
-                    label: area,
-                  })))
-              }
+              options={areaOptions}
             />
             <RadioButton
               label="Create a new area"
@@ -527,6 +531,7 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
               return;
             }
             if (onClose != null) {
+              setIsChanged(false);
               onClose();
             }
           }}

--- a/src/client/components/pages/Faculty/__tests__/FacultyModal.test.tsx
+++ b/src/client/components/pages/Faculty/__tests__/FacultyModal.test.tsx
@@ -37,13 +37,13 @@ describe('Faculty Modal', function () {
           ));
         });
         it('renders a modal with all empty form fields', function () {
-          const courseAreaSelect = getByLabelText('Area', { exact: false }) as HTMLSelectElement;
-          const huidInput = getByLabelText('HUID', { exact: false }) as HTMLInputElement;
-          const firstNameInput = getByLabelText('First name', { exact: false }) as HTMLInputElement;
-          const lastNameInput = getByLabelText('Last name', { exact: false }) as HTMLInputElement;
-          const facultyCategorySelect = getByLabelText('Category', { exact: false }) as HTMLSelectElement;
-          const jointWithInput = getByLabelText('Joint with', { exact: false }) as HTMLInputElement;
-          const notesInput = getByLabelText('Notes', { exact: false }) as HTMLInputElement;
+          const courseAreaSelect = getByLabelText('Edit Faculty Course Area', { exact: false }) as HTMLSelectElement;
+          const huidInput = getByLabelText('Edit Faculty HUID', { exact: false }) as HTMLInputElement;
+          const firstNameInput = getByLabelText('Edit Faculty First Name', { exact: false }) as HTMLInputElement;
+          const lastNameInput = getByLabelText('Edit Faculty Last Name', { exact: false }) as HTMLInputElement;
+          const facultyCategorySelect = getByLabelText('Edit Faculty Category', { exact: false }) as HTMLSelectElement;
+          const jointWithInput = getByLabelText('Edit Faculty Joint With', { exact: false }) as HTMLInputElement;
+          const notesInput = getByLabelText('Edit Faculty Notes', { exact: false }) as HTMLInputElement;
           strictEqual(courseAreaSelect.value, '');
           strictEqual(huidInput.value, '');
           strictEqual(firstNameInput.value, '');
@@ -66,13 +66,13 @@ describe('Faculty Modal', function () {
           ));
         });
         it('populates the modal fields according to the current faculty selected', function () {
-          const courseAreaSelect = getByLabelText('Area', { exact: false }) as HTMLSelectElement;
-          const huidInput = getByLabelText('HUID', { exact: false }) as HTMLInputElement;
-          const firstNameInput = getByLabelText('First name', { exact: false }) as HTMLInputElement;
-          const lastNameInput = getByLabelText('Last name', { exact: false }) as HTMLInputElement;
-          const facultyCategorySelect = getByLabelText('Category', { exact: false }) as HTMLSelectElement;
-          const jointWithInput = getByLabelText('Joint with', { exact: false }) as HTMLInputElement;
-          const notesInput = getByLabelText('Notes', { exact: false }) as HTMLInputElement;
+          const courseAreaSelect = getByLabelText('Edit Faculty Course Area', { exact: false }) as HTMLSelectElement;
+          const huidInput = getByLabelText('Edit Faculty HUID', { exact: false }) as HTMLInputElement;
+          const firstNameInput = getByLabelText('Edit Faculty First Name', { exact: false }) as HTMLInputElement;
+          const lastNameInput = getByLabelText('Edit Faculty Last Name', { exact: false }) as HTMLInputElement;
+          const facultyCategorySelect = getByLabelText('Edit Faculty Category', { exact: false }) as HTMLSelectElement;
+          const jointWithInput = getByLabelText('Edit Faculty Joint With', { exact: false }) as HTMLInputElement;
+          const notesInput = getByLabelText('Edit Faculty Notes', { exact: false }) as HTMLInputElement;
           strictEqual(
             courseAreaSelect.value,
             appliedMathFacultyMemberResponse.area.name
@@ -118,7 +118,7 @@ describe('Faculty Modal', function () {
       });
       describe('Area', function () {
         it('is a required field', async function () {
-          const courseAreaSelect = getByLabelText('Area', { exact: false }) as HTMLSelectElement;
+          const courseAreaSelect = getByLabelText('Edit Faculty Course Area', { exact: false }) as HTMLSelectElement;
           fireEvent.change(courseAreaSelect, { target: { value: '' } });
           const submitButton = getByText('Submit');
           fireEvent.click(submitButton);
@@ -130,7 +130,7 @@ describe('Faculty Modal', function () {
       });
       describe('HUID', function () {
         it('is a required field', async function () {
-          const huidInput = getByLabelText('HUID', { exact: false }) as HTMLInputElement;
+          const huidInput = getByLabelText('Edit Faculty HUID', { exact: false }) as HTMLInputElement;
           fireEvent.change(huidInput, { target: { value: '' } });
           const submitButton = getByText('Submit');
           fireEvent.click(submitButton);
@@ -140,7 +140,7 @@ describe('Faculty Modal', function () {
           );
         });
         it('raises an appropriate error message when not valid', async function () {
-          const huidInput = getByLabelText('HUID', { exact: false }) as HTMLInputElement;
+          const huidInput = getByLabelText('Edit Faculty HUID', { exact: false }) as HTMLInputElement;
           fireEvent.change(huidInput, { target: { value: '123' } });
           const submitButton = getByText('Submit');
           fireEvent.click(submitButton);
@@ -169,7 +169,7 @@ describe('Faculty Modal', function () {
       });
       describe('First name', function () {
         it('is not a required field', function () {
-          const firstNameInput = getByLabelText('First name', { exact: false }) as HTMLInputElement;
+          const firstNameInput = getByLabelText('Edit Faculty First Name', { exact: false }) as HTMLInputElement;
           fireEvent.change(firstNameInput, { target: { value: '' } });
           const submitButton = getByText('Submit');
           fireEvent.click(submitButton);
@@ -178,7 +178,7 @@ describe('Faculty Modal', function () {
       });
       describe('Last name', function () {
         it('is a required field', async function () {
-          const lastNameInput = getByLabelText('Last name', { exact: false }) as HTMLInputElement;
+          const lastNameInput = getByLabelText('Edit Faculty Last Name', { exact: false }) as HTMLInputElement;
           fireEvent.change(lastNameInput, { target: { value: '' } });
           const submitButton = getByText('Submit');
           fireEvent.click(submitButton);
@@ -190,7 +190,7 @@ describe('Faculty Modal', function () {
       });
       describe('Category', function () {
         it('is a required field', async function () {
-          const facultyCategorySelect = getByLabelText('Category', { exact: false }) as HTMLSelectElement;
+          const facultyCategorySelect = getByLabelText('Edit Faculty Category', { exact: false }) as HTMLSelectElement;
           fireEvent.change(facultyCategorySelect, { target: { value: '' } });
           const submitButton = getByText('Submit');
           fireEvent.click(submitButton);
@@ -202,7 +202,7 @@ describe('Faculty Modal', function () {
       });
       describe('Joint With', function () {
         it('is not a required field', function () {
-          const jointWithInput = getByLabelText('Joint with', { exact: false }) as HTMLInputElement;
+          const jointWithInput = getByLabelText('Edit Faculty Joint With', { exact: false }) as HTMLInputElement;
           fireEvent.change(jointWithInput, { target: { value: '' } });
           const submitButton = getByText('Submit');
           fireEvent.click(submitButton);
@@ -211,7 +211,7 @@ describe('Faculty Modal', function () {
       });
       describe('Notes', function () {
         it('is not a required field', function () {
-          const notesInput = getByLabelText('Notes', { exact: false }) as HTMLInputElement;
+          const notesInput = getByLabelText('Edit Faculty Notes', { exact: false }) as HTMLInputElement;
           fireEvent.change(notesInput, { target: { value: '' } });
           const submitButton = getByText('Submit');
           fireEvent.click(submitButton);
@@ -296,22 +296,22 @@ describe('Faculty Modal', function () {
                 onSuccess={onSuccessStub}
               />
             ));
-            const courseAreaSelect = getByLabelText('Area', { exact: false }) as HTMLSelectElement;
+            const courseAreaSelect = getByLabelText('Edit Faculty Course Area', { exact: false }) as HTMLSelectElement;
             fireEvent.change(
               courseAreaSelect,
               { target: { value: appliedMathFacultyMemberResponse.area.name } }
             );
-            const huidInput = getByLabelText('HUID', { exact: false }) as HTMLInputElement;
+            const huidInput = getByLabelText('Edit Faculty HUID', { exact: false }) as HTMLInputElement;
             fireEvent.change(
               huidInput,
               { target: { value: appliedMathFacultyMemberResponse.HUID } }
             );
-            const lastNameInput = getByLabelText('Last name', { exact: false }) as HTMLInputElement;
+            const lastNameInput = getByLabelText('Edit Faculty Last Name', { exact: false }) as HTMLInputElement;
             fireEvent.change(
               lastNameInput,
               { target: { value: appliedMathFacultyMemberResponse.lastName } }
             );
-            const facultyCategorySelect = getByLabelText('Category', { exact: false }) as HTMLSelectElement;
+            const facultyCategorySelect = getByLabelText('Edit Faculty Category', { exact: false }) as HTMLSelectElement;
             fireEvent.change(
               facultyCategorySelect,
               { target: { value: appliedMathFacultyMemberResponse.category } }

--- a/src/client/components/pages/FacultyAdmin.tsx
+++ b/src/client/components/pages/FacultyAdmin.tsx
@@ -192,8 +192,8 @@ const FacultyAdmin: FunctionComponent = (): ReactElement => {
                       })))
                   }
                   value={facultyAreaValue}
-                  name="facultyArea"
-                  id="facultyArea"
+                  name="filterByFacultyArea"
+                  id="filterByFacultyArea"
                   label="The table will be filtered as selected in the faculty area dropdown filter"
                   isLabelVisible={false}
                   hideError
@@ -204,8 +204,8 @@ const FacultyAdmin: FunctionComponent = (): ReactElement => {
               </TableHeadingCell>
               <TableHeadingCell scope="col">
                 <TextInput
-                  id="huid"
-                  name="huid"
+                  id="filterByHUID"
+                  name="filterByHUID"
                   value={HUIDValue}
                   placeholder="Filter by HUID"
                   label="The table will be filtered as characters are typed in this HUID filter field"
@@ -218,8 +218,8 @@ const FacultyAdmin: FunctionComponent = (): ReactElement => {
               </TableHeadingCell>
               <TableHeadingCell scope="col">
                 <TextInput
-                  id="lastName"
-                  name="lastName"
+                  id="filterLastName"
+                  name="filterByLastName"
                   value={lastNameValue}
                   placeholder="Filter by Last Name"
                   label="The table will be filtered as characters are typed in this last name filter field"
@@ -232,8 +232,8 @@ const FacultyAdmin: FunctionComponent = (): ReactElement => {
               </TableHeadingCell>
               <TableHeadingCell scope="col">
                 <TextInput
-                  id="firstName"
-                  name="firstName"
+                  id="filterByFirstName"
+                  name="filterByFirstName"
                   value={firstNameValue}
                   placeholder="Filter by First Name"
                   label="The table will be filtered as characters are typed in this first name filter field"

--- a/src/client/components/pages/FacultyAdmin.tsx
+++ b/src/client/components/pages/FacultyAdmin.tsx
@@ -263,6 +263,7 @@ const FacultyAdmin: FunctionComponent = (): ReactElement => {
                   <TableCell alignment={ALIGN.CENTER}>
                     <BorderlessButton
                       id={computeEditFacultyButtonId(faculty)}
+                      alt={`Edit faculty information for ${faculty.firstName} ${faculty.lastName}`}
                       variant={VARIANT.INFO}
                       onClick={
                         (): void => {

--- a/src/client/components/pages/FacultyModal.tsx
+++ b/src/client/components/pages/FacultyModal.tsx
@@ -398,6 +398,7 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
               // leave the modal visible after an error
               return;
             }
+            setIsChanged(false);
             onClose();
           }}
           variant={VARIANT.PRIMARY}

--- a/src/client/components/pages/FacultyModal.tsx
+++ b/src/client/components/pages/FacultyModal.tsx
@@ -290,7 +290,7 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
           <Dropdown
             id="courseArea"
             name="courseArea"
-            label="Area"
+            label="Edit Faculty Course Area"
             // Insert an empty option so that no area is pre-selected in dropdown
             options={
               [{ value: '', label: '' }]
@@ -309,7 +309,7 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
           <TextInput
             id="HUID"
             name="HUID"
-            label="HUID"
+            label="Edit Faculty HUID"
             labelPosition={POSITION.TOP}
             placeholder="e.g. 12345678"
             onChange={updateFormFields}
@@ -320,7 +320,7 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
           <TextInput
             id="firstName"
             name="firstName"
-            label="First name"
+            label="Edit Faculty First Name"
             labelPosition={POSITION.TOP}
             placeholder="e.g. Jane"
             onChange={updateFormFields}
@@ -329,7 +329,7 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
           <TextInput
             id="lastName"
             name="lastName"
-            label="Last name"
+            label="Edit Faculty Last Name"
             labelPosition={POSITION.TOP}
             placeholder="e.g. Smith"
             onChange={updateFormFields}
@@ -340,7 +340,7 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
           <Dropdown
             id="category"
             name="category"
-            label="Category"
+            label="Edit Faculty Category"
             /**
              * Insert an empty option so that no category is pre-selected in dropdown
              */
@@ -362,7 +362,7 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
           <TextInput
             id="jointWith"
             name="jointWith"
-            label="Joint with..."
+            label="Edit Faculty Joint With..."
             labelPosition={POSITION.TOP}
             placeholder="Add 'Joint With' entry"
             onChange={updateFormFields}
@@ -371,7 +371,7 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
           <TextInput
             id="notes"
             name="notes"
-            label="Notes"
+            label="Edit Faculty Notes"
             labelPosition={POSITION.TOP}
             placeholder="e.g. Prefers Room X"
             onChange={updateFormFields}

--- a/src/client/components/pages/FacultyModal.tsx
+++ b/src/client/components/pages/FacultyModal.tsx
@@ -392,7 +392,7 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
               // leave the modal visible after an error
               return;
             }
-            onModalClose();
+            onClose();
           }}
           variant={VARIANT.PRIMARY}
         >

--- a/src/client/components/pages/FacultyModal.tsx
+++ b/src/client/components/pages/FacultyModal.tsx
@@ -68,9 +68,9 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
   const metadata = useContext(MetadataContext);
 
   /**
- * Keeps track of whether the user has altered fields in the form to determine
- * whether to show a confirmation dialog on modal close
- */
+   * Keeps track of whether the user has altered fields in the form to determine
+   * whether to show a confirmation dialog on modal close
+   */
   const [
     isChanged,
     setIsChanged,
@@ -225,6 +225,12 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
       setFacultyErrorMessage('');
       setFacultyModalFocus();
     }
+  }, [isVisible, currentFaculty]);
+
+  /**
+   * Used to add the before unload listener in the case that a form field is changed
+   */
+  useEffect(() => {
     /**
      * Checks to see if there are any unsaved changes in the modal when the user
      * refreshes the page. If there are unsaved changes, the browser displays a
@@ -243,7 +249,7 @@ const FacultyModal: FunctionComponent<FacultyModalProps> = function ({
     return () => {
       window.removeEventListener('beforeunload', onBeforeUnload);
     };
-  }, [isVisible, currentFaculty, isChanged]);
+  }, [isChanged]);
 
   /**
    * Called when the modal is closed. If there are any unsaved changes,

--- a/src/common/__tests__/utils/customRender.tsx
+++ b/src/common/__tests__/utils/customRender.tsx
@@ -51,6 +51,7 @@ const customRender = (
   }
   if (!metadataContext) {
     metadataContext = testMetadata;
+    console.log('Test metadata areas in customRender: ', testMetadata.areas); // fdo
   }
   if (!routerEntries) {
     routerEntries = ['/'];

--- a/src/common/__tests__/utils/customRender.tsx
+++ b/src/common/__tests__/utils/customRender.tsx
@@ -51,7 +51,6 @@ const customRender = (
   }
   if (!metadataContext) {
     metadataContext = testMetadata;
-    console.log('Test metadata areas in customRender: ', testMetadata.areas); // fdo
   }
   if (!routerEntries) {
     routerEntries = ['/'];

--- a/tests/integration/e2e/CourseAdmin.test.tsx
+++ b/tests/integration/e2e/CourseAdmin.test.tsx
@@ -1,0 +1,151 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import React from 'react';
+import {
+  stub,
+} from 'sinon';
+import {
+  render,
+  RenderResult,
+  fireEvent,
+  waitForElementToBeRemoved,
+  wait,
+} from '@testing-library/react';
+import { TypeOrmModule, TypeOrmModuleOptions, getRepositoryToken } from '@nestjs/typeorm';
+import request from 'client/api/request';
+import { SessionModule } from 'nestjs-session';
+import * as dummy from 'testData';
+import { Repository } from 'typeorm';
+import { UserController } from 'server/user/user.controller';
+import { MemoryRouter } from 'react-router-dom';
+import App from 'client/components/App';
+import { strictEqual } from 'assert';
+import { MetadataModule } from 'server/metadata/metadata.module';
+import { Course } from 'server/course/course.entity';
+import { CourseModule } from 'server/course/course.module';
+import mockAdapter from '../../mocks/api/adapter';
+import MockDB from '../../mocks/database/MockDB';
+import { ConfigModule } from '../../../src/server/config/config.module';
+import { ConfigService } from '../../../src/server/config/config.service';
+import { AuthModule } from '../../../src/server/auth/auth.module';
+import { TestingStrategy } from '../../mocks/authentication/testing.strategy';
+import { AUTH_MODE, IS_SEAS } from '../../../src/common/constants';
+import { BadRequestExceptionPipe } from '../../../src/server/utils/BadRequestExceptionPipe';
+import { PopulationModule } from '../../mocks/database/population/population.module';
+
+describe('End-to-end Course Admin updating', function () {
+  let db: MockDB;
+  let testModule: TestingModule;
+  let courseRepository: Repository<Course>;
+  const title = 'Introduction to Soft Matter';
+  before(async function () {
+    db = new MockDB();
+    return db.init();
+  });
+  after(async function () {
+    return db.stop();
+  });
+  beforeEach(async function () {
+    stub(TestingStrategy.prototype, 'login').resolves(dummy.adminUser);
+    const fakeConfig = new ConfigService(db.connectionEnv);
+    testModule = await Test.createTestingModule({
+      imports: [
+        SessionModule.forRoot({
+          session: {
+            secret: dummy.safeString,
+            resave: true,
+            saveUninitialized: true,
+          },
+        }),
+        ConfigModule,
+        TypeOrmModule.forRootAsync({
+          imports: [ConfigModule],
+          useFactory: (
+            config: ConfigService
+          ): TypeOrmModuleOptions => ({
+            ...config.dbOptions,
+            synchronize: true,
+            autoLoadEntities: true,
+            retryAttempts: 10,
+            retryDelay: 10000,
+          }),
+          inject: [ConfigService],
+        }),
+        AuthModule.register({
+          strategies: [TestingStrategy],
+          defaultStrategy: AUTH_MODE.TEST,
+        }),
+        PopulationModule,
+        CourseModule,
+        MetadataModule,
+      ],
+      controllers: [
+        UserController,
+      ],
+    })
+      .overrideProvider(ConfigService)
+      .useValue(fakeConfig)
+      .compile();
+    courseRepository = testModule.get(
+      getRepositoryToken(Course)
+    );
+    const nestApp = await testModule
+      .createNestApplication()
+      .useGlobalPipes(new BadRequestExceptionPipe())
+      .init();
+    const api = nestApp.getHttpServer();
+    request.defaults.adapter = mockAdapter(api);
+  });
+  afterEach(async function () {
+    return testModule.close();
+  });
+  describe('Updating Courses', function () {
+    let renderResult: RenderResult;
+    beforeEach(async function () {
+      await courseRepository.findOneOrFail({ title });
+      renderResult = render(
+        <MemoryRouter initialEntries={['/course-admin']}>
+          <App />
+        </MemoryRouter>
+      );
+    });
+    context('Updating existing course information', function () {
+      beforeEach(async function () {
+        await renderResult.findByText(title);
+        const editButton = await renderResult.findByLabelText(`Edit course information for ${title}`,
+          { exact: false });
+        fireEvent.click(editButton);
+        return renderResult.findByRole('dialog');
+      });
+      context('when the modal submit button is clicked', function () {
+        it('should not show an unsaved changes warning', async function () {
+          // Set new isSEAS category for course entry
+          const isSEASSelector = await renderResult.findByLabelText('Is SEAS', { exact: false }) as HTMLSelectElement;
+          fireEvent.change(isSEASSelector,
+            { target: { value: IS_SEAS.N } });
+          await wait(() => {}, { timeout: 1000 }); // fdo
+          const submitButton = renderResult.getByText('Submit');
+          fireEvent.click(submitButton);
+          await waitForElementToBeRemoved(() => renderResult.queryByText('Note: * denotes a required field'));
+          const modal = renderResult.queryByRole('dialog');
+          strictEqual(modal, null);
+        });
+      });
+      context('when the modal submit button is not clicked', function () {
+        context('when the user attempts to exit the modal', function () {
+          it('should show an unsaved changes warning', async function () {
+            // Set new isSEAS category for course entry
+            const isSEASSelector = await renderResult.findByLabelText('Is SEAS', { exact: false });
+            fireEvent.change(isSEASSelector,
+              { target: { value: IS_SEAS.N } });
+            const windowConfirmStub = stub(window, 'confirm');
+            windowConfirmStub.returns(true);
+            // Attempt to close the modal without saving
+            const cancelButton = await renderResult.findByText('Cancel');
+            fireEvent.click(cancelButton);
+            strictEqual(windowConfirmStub.callCount, 1);
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/integration/e2e/CourseAdmin.test.tsx
+++ b/tests/integration/e2e/CourseAdmin.test.tsx
@@ -24,7 +24,6 @@ import { Course } from 'server/course/course.entity';
 import { CourseModule } from 'server/course/course.module';
 import { physicsCourse } from 'testData';
 import mockAdapter from '../../mocks/api/adapter';
-import MockDB from '../../mocks/database/MockDB';
 import { ConfigModule } from '../../../src/server/config/config.module';
 import { ConfigService } from '../../../src/server/config/config.service';
 import { AuthModule } from '../../../src/server/auth/auth.module';
@@ -34,20 +33,13 @@ import { BadRequestExceptionPipe } from '../../../src/server/utils/BadRequestExc
 import { PopulationModule } from '../../mocks/database/population/population.module';
 
 describe('End-to-end Course Admin updating', function () {
-  let db: MockDB;
   let testModule: TestingModule;
   let courseRepository: Repository<Course>;
   const title = 'Introduction to Soft Matter';
-  before(async function () {
-    db = new MockDB();
-    return db.init();
-  });
-  after(async function () {
-    return db.stop();
-  });
+
   beforeEach(async function () {
     stub(TestingStrategy.prototype, 'login').resolves(dummy.adminUser);
-    const fakeConfig = new ConfigService(db.connectionEnv);
+    const fakeConfig = new ConfigService(this.database.connectionEnv);
     testModule = await Test.createTestingModule({
       imports: [
         SessionModule.forRoot({

--- a/tests/integration/e2e/CourseAdmin.test.tsx
+++ b/tests/integration/e2e/CourseAdmin.test.tsx
@@ -121,13 +121,9 @@ describe('End-to-end Course Admin updating', function () {
         const isSEASSelect = renderResult.getByLabelText('Is SEAS', { exact: false }) as HTMLSelectElement;
         const termPatternSelect = renderResult.getByLabelText('Term Pattern', { exact: false }) as HTMLSelectElement;
         fireEvent.change(existingAreaSelect, { target: { value: `${physicsCourse.area.name}` } });
-        console.log('Area value: ', existingAreaSelect.value);
         fireEvent.change(courseTitleInput, { target: { value: `${physicsCourse.title}` } });
-        console.log('Title value: ', courseTitleInput.value);
         fireEvent.change(isSEASSelect, { target: { value: `${physicsCourse.isSEAS}` } });
-        console.log('isSEAS value: ', isSEASSelect.value);
         fireEvent.change(termPatternSelect, { target: { value: `${physicsCourse.termPattern}` } });
-        console.log('Term Pattern value: ', termPatternSelect.value);
       });
       context('when the modal submit button is clicked', function () {
         it.only('should not show the unsaved changes warning', async function () {

--- a/tests/integration/e2e/CourseAdmin.test.tsx
+++ b/tests/integration/e2e/CourseAdmin.test.tsx
@@ -32,7 +32,6 @@ import { TestingStrategy } from '../../mocks/authentication/testing.strategy';
 import { AUTH_MODE, IS_SEAS } from '../../../src/common/constants';
 import { BadRequestExceptionPipe } from '../../../src/server/utils/BadRequestExceptionPipe';
 import { PopulationModule } from '../../mocks/database/population/population.module';
-import { CourseAdmin } from 'client/components/pages';
 
 describe('End-to-end Course Admin updating', function () {
   let db: MockDB;
@@ -112,6 +111,7 @@ describe('End-to-end Course Admin updating', function () {
     });
     context('Creating a course', function () {
       beforeEach(async function () {
+        await renderResult.findByText(title, { exact: false });
         await renderResult.findByText('Create New Course');
         const createCourseButton = await renderResult.findByText('Create New Course', { exact: false });
         fireEvent.click(createCourseButton);
@@ -126,10 +126,10 @@ describe('End-to-end Course Admin updating', function () {
         fireEvent.change(termPatternSelect, { target: { value: `${physicsCourse.termPattern}` } });
       });
       context('when the modal submit button is clicked', function () {
-        it.only('should not show the unsaved changes warning', async function () {
+        it('should not show the unsaved changes warning', async function () {
           const submitButton = renderResult.getByText('Submit');
           fireEvent.click(submitButton);
-          await waitForElementToBeRemoved(() => renderResult.queryByText('Select an existing area'));
+          await waitForElementToBeRemoved(() => renderResult.queryByText('Submit'));
           const modal = renderResult.queryByRole('dialog');
           strictEqual(modal, null);
         });

--- a/tests/integration/e2e/FacultyAdmin.test.tsx
+++ b/tests/integration/e2e/FacultyAdmin.test.tsx
@@ -1,0 +1,136 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import React from 'react';
+import {
+  stub,
+} from 'sinon';
+import {
+  render,
+  RenderResult,
+  fireEvent,
+} from '@testing-library/react';
+import { TypeOrmModule, TypeOrmModuleOptions, getRepositoryToken } from '@nestjs/typeorm';
+import request from 'client/api/request';
+import { SessionModule } from 'nestjs-session';
+import * as dummy from 'testData';
+import { Repository } from 'typeorm';
+import { Faculty } from 'server/faculty/faculty.entity';
+import { UserController } from 'server/user/user.controller';
+import { MemoryRouter } from 'react-router-dom';
+import App from 'client/components/App';
+import { strictEqual } from 'assert';
+import { MetadataModule } from 'server/metadata/metadata.module';
+import mockAdapter from '../../mocks/api/adapter';
+import MockDB from '../../mocks/database/MockDB';
+import { ConfigModule } from '../../../src/server/config/config.module';
+import { ConfigService } from '../../../src/server/config/config.service';
+import { AuthModule } from '../../../src/server/auth/auth.module';
+import { TestingStrategy } from '../../mocks/authentication/testing.strategy';
+import { AUTH_MODE, FACULTY_TYPE } from '../../../src/common/constants';
+import { FacultyModule } from '../../../src/server/faculty/faculty.module';
+import { BadRequestExceptionPipe } from '../../../src/server/utils/BadRequestExceptionPipe';
+import { PopulationModule } from '../../mocks/database/population/population.module';
+
+describe('End-to-end Faculty Admin updating', function () {
+  let db: MockDB;
+  let testModule: TestingModule;
+  let facultyRepository: Repository<Faculty>;
+  const facultyName = 'David Malan';
+  const [firstName, lastName] = facultyName.split(' ');
+  before(async function () {
+    db = new MockDB();
+    return db.init();
+  });
+  after(async function () {
+    return db.stop();
+  });
+  beforeEach(async function () {
+    stub(TestingStrategy.prototype, 'login').resolves(dummy.adminUser);
+    const fakeConfig = new ConfigService(db.connectionEnv);
+    testModule = await Test.createTestingModule({
+      imports: [
+        SessionModule.forRoot({
+          session: {
+            secret: dummy.safeString,
+            resave: true,
+            saveUninitialized: true,
+          },
+        }),
+        ConfigModule,
+        TypeOrmModule.forRootAsync({
+          imports: [ConfigModule],
+          useFactory: (
+            config: ConfigService
+          ): TypeOrmModuleOptions => ({
+            ...config.dbOptions,
+            synchronize: true,
+            autoLoadEntities: true,
+            retryAttempts: 10,
+            retryDelay: 10000,
+          }),
+          inject: [ConfigService],
+        }),
+        AuthModule.register({
+          strategies: [TestingStrategy],
+          defaultStrategy: AUTH_MODE.TEST,
+        }),
+        PopulationModule,
+        FacultyModule,
+        MetadataModule,
+      ],
+      controllers: [
+        UserController,
+      ],
+    })
+      .overrideProvider(ConfigService)
+      .useValue(fakeConfig)
+      .compile();
+    facultyRepository = testModule.get(
+      getRepositoryToken(Faculty)
+    );
+    const nestApp = await testModule
+      .createNestApplication()
+      .useGlobalPipes(new BadRequestExceptionPipe())
+      .init();
+    const api = nestApp.getHttpServer();
+    request.defaults.adapter = mockAdapter(api);
+  });
+  afterEach(async function () {
+    return testModule.close();
+  });
+  describe('Updating Faculty', function () {
+    let renderResult: RenderResult;
+    beforeEach(async function () {
+      await facultyRepository.findOneOrFail({ lastName });
+      renderResult = render(
+        <MemoryRouter initialEntries={['/faculty-admin']}>
+          <App />
+        </MemoryRouter>
+      );
+    });
+    context('Updating existing faculty information', function () {
+      beforeEach(async function () {
+        await renderResult.findByText(lastName);
+        const editButton = await renderResult.findByLabelText(`Edit faculty information for ${firstName} ${lastName}`,
+          { exact: false });
+        fireEvent.click(editButton);
+        return renderResult.findByRole('dialog');
+      });
+      context('when the modal save button is not clicked', function () {
+        context('when the user attempts to exit the modal', function () {
+          it('should show an unsaved changes warning', async function () {
+            // Set new category for faculty entry
+            const categorySelector = await renderResult.findByLabelText('Category', { exact: false });
+            fireEvent.change(categorySelector,
+              { target: { value: FACULTY_TYPE.LADDER } });
+            const windowConfirmStub = stub(window, 'confirm');
+            windowConfirmStub.returns(true);
+            // Attempt to close the modal without saving
+            const cancelButton = await renderResult.findByText('Cancel');
+            fireEvent.click(cancelButton);
+            strictEqual(windowConfirmStub.callCount, 1);
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/integration/e2e/FacultyAdmin.test.tsx
+++ b/tests/integration/e2e/FacultyAdmin.test.tsx
@@ -7,6 +7,7 @@ import {
   render,
   RenderResult,
   fireEvent,
+  waitForElementToBeRemoved,
 } from '@testing-library/react';
 import { TypeOrmModule, TypeOrmModuleOptions, getRepositoryToken } from '@nestjs/typeorm';
 import request from 'client/api/request';
@@ -115,7 +116,23 @@ describe('End-to-end Faculty Admin updating', function () {
         fireEvent.click(editButton);
         return renderResult.findByRole('dialog');
       });
-      context('when the modal save button is not clicked', function () {
+      context('when the modal submit button is clicked', function () {
+        context('when the user attempts to exit the modal', function () {
+          it('should not show an unsaved changes warning', async function () {
+            // Set new category for faculty entry
+            const categorySelector = await renderResult.findByLabelText('Category', { exact: false });
+            fireEvent.change(categorySelector,
+              { target: { value: FACULTY_TYPE.LADDER } });
+            // click save
+            const submitButton = renderResult.getByText('Submit');
+            fireEvent.click(submitButton);
+            await waitForElementToBeRemoved(() => renderResult.queryByText('Submit'));
+            const modal = renderResult.queryByRole('dialog');
+            strictEqual(modal, null);
+          });
+        });
+      });
+      context('when the modal submit button is not clicked', function () {
         context('when the user attempts to exit the modal', function () {
           it('should show an unsaved changes warning', async function () {
             // Set new category for faculty entry

--- a/tests/integration/e2e/FacultyAdmin.test.tsx
+++ b/tests/integration/e2e/FacultyAdmin.test.tsx
@@ -21,7 +21,6 @@ import App from 'client/components/App';
 import { strictEqual } from 'assert';
 import { MetadataModule } from 'server/metadata/metadata.module';
 import mockAdapter from '../../mocks/api/adapter';
-import MockDB from '../../mocks/database/MockDB';
 import { ConfigModule } from '../../../src/server/config/config.module';
 import { ConfigService } from '../../../src/server/config/config.service';
 import { AuthModule } from '../../../src/server/auth/auth.module';
@@ -32,21 +31,14 @@ import { BadRequestExceptionPipe } from '../../../src/server/utils/BadRequestExc
 import { PopulationModule } from '../../mocks/database/population/population.module';
 
 describe('End-to-end Faculty Admin updating', function () {
-  let db: MockDB;
   let testModule: TestingModule;
   let facultyRepository: Repository<Faculty>;
   const facultyName = 'David Malan';
   const [firstName, lastName] = facultyName.split(' ');
-  before(async function () {
-    db = new MockDB();
-    return db.init();
-  });
-  after(async function () {
-    return db.stop();
-  });
+
   beforeEach(async function () {
     stub(TestingStrategy.prototype, 'login').resolves(dummy.adminUser);
-    const fakeConfig = new ConfigService(db.connectionEnv);
+    const fakeConfig = new ConfigService(this.database.connectionEnv);
     testModule = await Test.createTestingModule({
       imports: [
         SessionModule.forRoot({

--- a/tests/mocks/database/population/course.population.ts
+++ b/tests/mocks/database/population/course.population.ts
@@ -78,6 +78,7 @@ export class CoursePopulationService
         course.private = courseData.private;
         course.sameAs = courseData.sameAs;
         course.isSEAS = courseData.isSEAS;
+        course.termPattern = courseData.termPattern;
         course.area = allAreas.find(
           ({ name }): boolean => name === courseData.area
         );


### PR DESCRIPTION
This PR adds the unsaved changes warning to the Course Admin modal and Faculty Admin modal. If the user makes a change in the create or edit modals and tries to exit the modal before submitting the form, they will receive this unsaved changes warning. Otherwise, if no changes are made or the user clicks the submit button, they will not receive this warning. 

While writing end to end integration tests for the Course Admin modal, I found that the `termPattern` was not being populated, so the course population was updated to include the `termPattern.`

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #370

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
