### PR TITLE
Add success messages and apply GlobalMessage component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.9",
+      "version": "0.4.2",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.13.1",
         "@fortawesome/fontawesome-svg-core": "^1.2.29",
@@ -32,7 +32,7 @@
         "lodash.get": "^4.4.2",
         "lodash.groupby": "^4.6.0",
         "loglevel": "^1.6.8",
-        "mark-one": "^0.3.4",
+        "mark-one": "^0.4.2",
         "morgan": "^1.10.0",
         "nestjs-redis": "^1.3.3",
         "nestjs-session": "^1.0.0",
@@ -1179,6 +1179,34 @@
         "react-dom": "*"
       }
     },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
+      "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0",
+        "react-test-renderer": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -1459,8 +1487,7 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "dev": true
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -1476,7 +1503,6 @@
       "version": "16.14.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.16.tgz",
       "integrity": "sha512-7waDQ0h1TkAk99S04wV0LUiiSXpT02lzrdDF4WZFqn2W0XE5ICXLBMtqXWZ688aX2dJislQ3knmZX/jH53RluQ==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1487,7 +1513,6 @@
       "version": "16.9.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
       "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
-      "dev": true,
       "dependencies": {
         "@types/react": "^16"
       }
@@ -1513,6 +1538,14 @@
         "@types/react-router": "*"
       }
     },
+    "node_modules/@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/redis": {
       "version": "2.8.32",
       "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
@@ -1525,8 +1558,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
@@ -9844,13 +9876,14 @@
       }
     },
     "node_modules/mark-one": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.3.4.tgz",
-      "integrity": "sha512-b8QaM/DW4ci5QJRrod8Wq/GI62yqVzs2FhUxBcCaFdto9DYusqEzLa9FgINfkPEtct1hGWXTN5DgSZ88+xZljg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.4.2.tgz",
+      "integrity": "sha512-/AtcFdpffR0RgB/d0XXb4EPRE4VzK+fAKb6Kozgq6nUOQ3PTXpfDqKJevLOj0zO/h2gzAHvKYCg25NtiRmBeUg==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",
         "@openfonts/open-sans_all": "^1.43.0",
         "@openfonts/roboto-mono_all": "^1.43.0",
+        "@testing-library/react-hooks": "^7.0.2",
         "aria-query": "^4.0.2",
         "canvas": "^2.8.0",
         "downshift": "^6.1.7",
@@ -12622,6 +12655,21 @@
       },
       "peerDependencies": {
         "react": "^16.14.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-hot-loader": {
@@ -19049,6 +19097,18 @@
         "@types/testing-library__react": "^9.1.2"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
+      "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      }
+    },
     "@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -19326,8 +19386,7 @@
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "dev": true
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -19343,7 +19402,6 @@
       "version": "16.14.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.16.tgz",
       "integrity": "sha512-7waDQ0h1TkAk99S04wV0LUiiSXpT02lzrdDF4WZFqn2W0XE5ICXLBMtqXWZ688aX2dJislQ3knmZX/jH53RluQ==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -19354,7 +19412,6 @@
       "version": "16.9.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
       "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
-      "dev": true,
       "requires": {
         "@types/react": "^16"
       }
@@ -19380,6 +19437,14 @@
         "@types/react-router": "*"
       }
     },
+    "@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/redis": {
       "version": "2.8.32",
       "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
@@ -19392,8 +19457,7 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/serve-static": {
       "version": "1.13.10",
@@ -26076,13 +26140,14 @@
       }
     },
     "mark-one": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.3.4.tgz",
-      "integrity": "sha512-b8QaM/DW4ci5QJRrod8Wq/GI62yqVzs2FhUxBcCaFdto9DYusqEzLa9FgINfkPEtct1hGWXTN5DgSZ88+xZljg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.4.2.tgz",
+      "integrity": "sha512-/AtcFdpffR0RgB/d0XXb4EPRE4VzK+fAKb6Kozgq6nUOQ3PTXpfDqKJevLOj0zO/h2gzAHvKYCg25NtiRmBeUg==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",
         "@openfonts/open-sans_all": "^1.43.0",
         "@openfonts/roboto-mono_all": "^1.43.0",
+        "@testing-library/react-hooks": "^7.0.2",
         "aria-query": "^4.0.2",
         "canvas": "^2.8.0",
         "downshift": "^6.1.7",
@@ -28327,6 +28392,14 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-hot-loader": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash.get": "^4.4.2",
     "lodash.groupby": "^4.6.0",
     "loglevel": "^1.6.8",
-    "mark-one": "^0.3.4",
+    "mark-one": "^0.4.2",
     "morgan": "^1.10.0",
     "nestjs-redis": "^1.3.3",
     "nestjs-session": "^1.0.0",

--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -114,13 +114,13 @@ const App: FunctionComponent = (): ReactElement => {
               <PageBody>
                 <AppHeader currentUser={currentUser} />
                 {currentMessage
-                    && (
-                      <Message
-                        messageCount={queue.length}
-                        messageText={currentMessage.text}
-                        messageType={currentMessage.variant}
-                      />
-                    )}
+                  && (
+                    <Message
+                      messageCount={queue.length}
+                      messageText={currentMessage.text}
+                      messageType={currentMessage.variant}
+                    />
+                  )}
                 <AppRouter />
               </PageBody>
             </MetadataContext.Provider>

--- a/src/client/components/layout/Message.tsx
+++ b/src/client/components/layout/Message.tsx
@@ -33,16 +33,6 @@ const Message: FunctionComponent<MessageProps> = ({
 
   const messageDispatch = useContext(MessageContext);
 
-  /**
-   * auto-clear non-error messages after 5 seconds
-   */
-
-  if (messageType !== MESSAGE_TYPE.ERROR) {
-    setTimeout((): void => {
-      messageDispatch({ type: MESSAGE_ACTION.CLEAR });
-    }, 5000);
-  }
-
   return (
     <div className={`app-message-${messageType}`}>
       <GlobalMessageWrapper>

--- a/src/client/components/layout/Message.tsx
+++ b/src/client/components/layout/Message.tsx
@@ -1,8 +1,9 @@
-import { GlobalMessage, VARIANT } from 'mark-one';
+import { GlobalMessage } from 'mark-one';
 import React, { useContext, ReactElement, FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { MESSAGE_TYPE, MESSAGE_ACTION } from '../../classes';
 import { MessageContext } from '../../context';
+import messageTypeToVariant from '../pages/utils/messageHelperFunctions';
 
 export interface MessageProps {
   messageCount: number;
@@ -46,7 +47,7 @@ const Message: FunctionComponent<MessageProps> = ({
     <div className={`app-message-${messageType}`}>
       <GlobalMessageWrapper>
         <GlobalMessage
-          variant={VARIANT.DANGER}
+          variant={messageTypeToVariant(messageType)}
           buttonAlt="Close alert dialog"
           buttonLabel={messageCount > 0 ? `Next (${messageCount})` : 'clear'}
           onClick={(): void => {

--- a/src/client/components/layout/Message.tsx
+++ b/src/client/components/layout/Message.tsx
@@ -1,4 +1,6 @@
+import { GlobalMessage, VARIANT } from 'mark-one';
 import React, { useContext, ReactElement, FunctionComponent } from 'react';
+import styled from 'styled-components';
 import { MESSAGE_TYPE, MESSAGE_ACTION } from '../../classes';
 import { MessageContext } from '../../context';
 
@@ -7,6 +9,17 @@ export interface MessageProps {
   messageText: string;
   messageType: MESSAGE_TYPE;
 }
+
+/**
+ * A wrapper component for the Global Message component to position it at the
+ * bottom of the page
+ */
+const GlobalMessageWrapper = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+`;
 
 const Message: FunctionComponent<MessageProps> = ({
   messageCount,
@@ -31,17 +44,18 @@ const Message: FunctionComponent<MessageProps> = ({
 
   return (
     <div className={`app-message-${messageType}`}>
-      <strong>{messageText}</strong>
-      <div>
-        <button
-          type="button"
+      <GlobalMessageWrapper>
+        <GlobalMessage
+          variant={VARIANT.DANGER}
+          buttonAlt="Close alert dialog"
+          buttonLabel={messageCount > 0 ? `Next (${messageCount})` : 'clear'}
           onClick={(): void => {
             messageDispatch({ type: MESSAGE_ACTION.CLEAR });
           }}
         >
-          {messageCount > 0 ? `Next (${messageCount})` : 'clear'}
-        </button>
-      </div>
+          {messageText}
+        </GlobalMessage>
+      </GlobalMessageWrapper>
     </div>
   );
 };

--- a/src/client/components/layout/__tests__/Message.test.tsx
+++ b/src/client/components/layout/__tests__/Message.test.tsx
@@ -56,7 +56,7 @@ describe('Message', function () {
       fireEvent.click(getByText('clear'));
       strictEqual(dispatchStub.callCount, 1);
     });
-    it('should automatically clear non-error messages after 5 seconds', function () {
+    it('should never automatically clear non-error messages', function () {
       render(
         <MessageContext.Provider value={dispatchStub}>
           <Message
@@ -67,11 +67,11 @@ describe('Message', function () {
         </MessageContext.Provider>
       );
       strictEqual(dispatchStub.callCount, 0);
-      clock.tick(5000);
-      strictEqual(dispatchStub.callCount, 1);
+      clock.tick(5000000);
+      strictEqual(dispatchStub.callCount, 0);
     });
 
-    it('should never automatically clear non-error messages', function () {
+    it('should never automatically clear error messages', function () {
       render(
         <MessageContext.Provider value={dispatchStub}>
           <Message

--- a/src/client/components/layout/__tests__/Message.test.tsx
+++ b/src/client/components/layout/__tests__/Message.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { strictEqual } from 'assert';
-import { render, fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers';
 import { stub, SinonStub } from 'sinon';
 import * as dummy from 'testData';
 import { MESSAGE_TYPE } from 'client/classes';
 import { MessageContext } from 'client/context';
+import { render } from 'test-utils';
 import Message, { MessageProps } from '../Message';
 
 describe('Message', function () {

--- a/src/client/components/pages/CourseAdmin.tsx
+++ b/src/client/components/pages/CourseAdmin.tsx
@@ -256,6 +256,11 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
           }}
           onSuccess={async (): Promise<void> => {
             await loadCourses();
+            // display a success message after successful update and loading of courses
+            dispatchMessage({
+              message: new AppMessage('Course was updated.', MESSAGE_TYPE.SUCCESS),
+              type: MESSAGE_ACTION.PUSH,
+            });
           }}
         />
       </div>

--- a/src/client/components/pages/Faculty/FacultyAbsenceModal.tsx
+++ b/src/client/components/pages/Faculty/FacultyAbsenceModal.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   ChangeEvent,
   Ref,
+  useContext,
 } from 'react';
 import {
   VARIANT,
@@ -22,6 +23,8 @@ import { FacultyAPI } from 'client/api';
 import { ABSENCE_TYPE } from 'common/constants';
 import { absenceEnumToTitleCase } from 'common/utils/facultyHelperFunctions';
 import { AbsenceResponseDTO } from 'common/dto/faculty/AbsenceResponse.dto';
+import { AppMessage, MESSAGE_TYPE, MESSAGE_ACTION } from 'client/classes';
+import { MessageContext } from 'client/context';
 
 interface AbsenceModalProps {
   /**
@@ -112,6 +115,11 @@ FunctionComponent<AbsenceModalProps> = ({
   };
 
   /**
+   * The current value for the message context
+   */
+  const dispatchMessage = useContext(MessageContext);
+
+  /**
    * Sets the absence information for the currently selected absence, clears
    * any previous errors from the modal, and sets the modal focus to its header
    */
@@ -170,6 +178,10 @@ FunctionComponent<AbsenceModalProps> = ({
           onClick={async (): Promise<void> => {
             try {
               await submitAbsenceForm();
+              dispatchMessage({
+                message: new AppMessage('Faculty absence was updated.', MESSAGE_TYPE.SUCCESS),
+                type: MESSAGE_ACTION.PUSH,
+              });
               onSuccess();
             } catch (error) {
               setAbsenceErrorMessage((error as Error).message);

--- a/src/client/components/pages/FacultyAdmin.tsx
+++ b/src/client/components/pages/FacultyAdmin.tsx
@@ -299,6 +299,11 @@ const FacultyAdmin: FunctionComponent = (): ReactElement => {
           onSuccess={async (): Promise<void> => {
             // wait for the faculty to load before allowing the dialog to close
             await loadFaculty();
+            // display a success message after successful update and loading of faculty
+            dispatchMessage({
+              message: new AppMessage('Faculty was updated.', MESSAGE_TYPE.SUCCESS),
+              type: MESSAGE_ACTION.PUSH,
+            });
           }}
         />
       </div>

--- a/src/client/components/pages/utils/__tests__/messageHelperFunctions.test.tsx
+++ b/src/client/components/pages/utils/__tests__/messageHelperFunctions.test.tsx
@@ -1,0 +1,31 @@
+import { strictEqual } from 'assert';
+import { MESSAGE_TYPE } from 'client/classes';
+import { VARIANT } from 'mark-one';
+import messageTypeToVariant from '../messageHelperFunctions';
+
+describe('Message Type to Variant Function', function () {
+  context('when message type is MESSAGE_TYPE.ERROR', function () {
+    it('should return the negative variant', function () {
+      strictEqual(
+        messageTypeToVariant(MESSAGE_TYPE.ERROR),
+        VARIANT.NEGATIVE
+      );
+    });
+  });
+  context('when message type is MESSAGE_TYPE.SUCCESS', function () {
+    it('should return the success variant', function () {
+      strictEqual(
+        messageTypeToVariant(MESSAGE_TYPE.SUCCESS),
+        VARIANT.POSITIVE
+      );
+    });
+  });
+  context('when message type is neither MESSAGE_TYPE.ERROR nor MESSAGE_TYPE.SUCCESS', function () {
+    it('should return the info variant', function () {
+      strictEqual(
+        messageTypeToVariant(MESSAGE_TYPE.INFO),
+        VARIANT.INFO
+      );
+    });
+  });
+});

--- a/src/client/components/pages/utils/messageHelperFunctions.ts
+++ b/src/client/components/pages/utils/messageHelperFunctions.ts
@@ -1,0 +1,19 @@
+import { MESSAGE_TYPE } from 'client/classes';
+import { VARIANT } from 'mark-one';
+
+/**
+ * Finds the corresponding variant of type VARIANT corresponding to the
+ * given message type
+ */
+const messageTypeToVariant = (messageType: MESSAGE_TYPE): VARIANT => {
+  switch (messageType) {
+    case MESSAGE_TYPE.ERROR:
+      return VARIANT.NEGATIVE;
+    case MESSAGE_TYPE.SUCCESS:
+      return VARIANT.POSITIVE;
+    default:
+      return VARIANT.INFO;
+  }
+};
+
+export default messageTypeToVariant;

--- a/tests/integration/client/faculty/faculty.test.tsx
+++ b/tests/integration/client/faculty/faculty.test.tsx
@@ -9,7 +9,8 @@ import {
   FindByText,
   QueryByText,
   GetByText,
-} from '@testing-library/react';
+  renderWithMessaging,
+} from 'test-utils';
 import {
   stub,
   SinonStub,
@@ -19,7 +20,6 @@ import {
   appliedMathFacultyScheduleResponse,
   facultyAbsenceResponse,
 } from 'testData';
-import { render } from 'test-utils';
 import { ABSENCE_TYPE } from 'common/constants';
 import FacultySchedule from 'client/components/pages/Faculty/FacultyPage';
 
@@ -50,7 +50,7 @@ describe('Faculty Schedule Modal Behavior', function () {
         findByText,
         queryByText,
         getByLabelText,
-      } = render(
+      } = renderWithMessaging(
         <FacultySchedule />
       )
       );
@@ -93,6 +93,14 @@ describe('Faculty Schedule Modal Behavior', function () {
             document.activeElement as HTMLElement,
             editAppliedMathFallAbsenceButton
           );
+        });
+      });
+      context('when the absence modal is submitted', function () {
+        it('should show a success message', async function () {
+          const submitButton = await findByText('Submit', { exact: false });
+          fireEvent.click(submitButton);
+          await wait(() => !queryByText('Sabbatical/Leave for', { exact: false }));
+          return findByText('Faculty absence was updated', { exact: false });
         });
       });
     });

--- a/tests/integration/e2e/CourseAdmin.test.tsx
+++ b/tests/integration/e2e/CourseAdmin.test.tsx
@@ -115,23 +115,31 @@ describe('End-to-end Course Admin updating', function () {
         fireEvent.change(isSEASSelect, { target: { value: `${physicsCourse.isSEAS}` } });
         fireEvent.change(termPatternSelect, { target: { value: `${physicsCourse.termPattern}` } });
       });
-      context('when the modal submit button is clicked', function () {
-        it('should not show the unsaved changes warning', async function () {
-          const submitButton = renderResult.getByText('Submit');
-          fireEvent.click(submitButton);
-          await waitForElementToBeRemoved(() => renderResult.queryByText('Submit'));
-          const modal = renderResult.queryByRole('dialog');
-          strictEqual(modal, null);
+      context('when the required fields are provided', function () {
+        context('when the modal submit button is clicked', function () {
+          it('should not show the unsaved changes warning', async function () {
+            const submitButton = renderResult.getByText('Submit');
+            fireEvent.click(submitButton);
+            await waitForElementToBeRemoved(() => renderResult.queryByText('Submit'));
+            const modal = renderResult.queryByRole('dialog');
+            strictEqual(modal, null);
+          });
+          it('should show a success message', async function () {
+            const submitButton = renderResult.getByText('Submit');
+            fireEvent.click(submitButton);
+            await waitForElementToBeRemoved(() => renderResult.queryByText('Submit'));
+            return renderResult.findByText('Course was updated', { exact: false });
+          });
         });
-      });
-      context('when the modal submit button is not clicked', function () {
-        it('should show the unsaved changes warning', async function () {
-          const windowConfirmStub = stub(window, 'confirm');
-          windowConfirmStub.returns(true);
-          // Attempt to close the modal without saving
-          const cancelButton = await renderResult.findByText('Cancel');
-          fireEvent.click(cancelButton);
-          strictEqual(windowConfirmStub.callCount, 1);
+        context('when the modal submit button is not clicked', function () {
+          it('should show the unsaved changes warning', async function () {
+            const windowConfirmStub = stub(window, 'confirm');
+            windowConfirmStub.returns(true);
+            // Attempt to close the modal without saving
+            const cancelButton = await renderResult.findByText('Cancel');
+            fireEvent.click(cancelButton);
+            strictEqual(windowConfirmStub.callCount, 1);
+          });
         });
       });
     });
@@ -143,32 +151,40 @@ describe('End-to-end Course Admin updating', function () {
         fireEvent.click(editButton);
         return renderResult.findByRole('dialog');
       });
-      context('when the modal submit button is clicked', function () {
-        it('should not show an unsaved changes warning', async function () {
-          // Set new isSEAS category for course entry
-          const isSEASSelector = await renderResult.findByLabelText('Is SEAS', { exact: false }) as HTMLSelectElement;
-          fireEvent.change(isSEASSelector,
-            { target: { value: IS_SEAS.N } });
-          const submitButton = renderResult.getByText('Submit');
-          fireEvent.click(submitButton);
-          await waitForElementToBeRemoved(() => renderResult.queryByText('Note: * denotes a required field'));
-          const modal = renderResult.queryByRole('dialog');
-          strictEqual(modal, null);
-        });
-      });
-      context('when the modal submit button is not clicked', function () {
-        context('when the user attempts to exit the modal', function () {
-          it('should show an unsaved changes warning', async function () {
+      context('when the required fields are provided', function () {
+        context('when the modal submit button is clicked', function () {
+          it('should not show an unsaved changes warning', async function () {
             // Set new isSEAS category for course entry
-            const isSEASSelector = await renderResult.findByLabelText('Is SEAS', { exact: false });
+            const isSEASSelector = await renderResult.findByLabelText('Is SEAS', { exact: false }) as HTMLSelectElement;
             fireEvent.change(isSEASSelector,
               { target: { value: IS_SEAS.N } });
-            const windowConfirmStub = stub(window, 'confirm');
-            windowConfirmStub.returns(true);
-            // Attempt to close the modal without saving
-            const cancelButton = await renderResult.findByText('Cancel');
-            fireEvent.click(cancelButton);
-            strictEqual(windowConfirmStub.callCount, 1);
+            const submitButton = renderResult.getByText('Submit');
+            fireEvent.click(submitButton);
+            await waitForElementToBeRemoved(() => renderResult.queryByText('Note: * denotes a required field'));
+            const modal = renderResult.queryByRole('dialog');
+            strictEqual(modal, null);
+          });
+          it('should show a success message', async function () {
+            const submitButton = renderResult.getByText('Submit');
+            fireEvent.click(submitButton);
+            await waitForElementToBeRemoved(() => renderResult.queryByText('Submit'));
+            return renderResult.findByText('Course was updated', { exact: false });
+          });
+        });
+        context('when the modal submit button is not clicked', function () {
+          context('when the user attempts to exit the modal', function () {
+            it('should show an unsaved changes warning', async function () {
+              // Set new isSEAS category for course entry
+              const isSEASSelector = await renderResult.findByLabelText('Is SEAS', { exact: false });
+              fireEvent.change(isSEASSelector,
+                { target: { value: IS_SEAS.N } });
+              const windowConfirmStub = stub(window, 'confirm');
+              windowConfirmStub.returns(true);
+              // Attempt to close the modal without saving
+              const cancelButton = await renderResult.findByText('Cancel');
+              fireEvent.click(cancelButton);
+              strictEqual(windowConfirmStub.callCount, 1);
+            });
           });
         });
       });

--- a/tests/integration/e2e/FacultyAdmin.test.tsx
+++ b/tests/integration/e2e/FacultyAdmin.test.tsx
@@ -123,23 +123,31 @@ describe('End-to-end Faculty Admin updating', function () {
         fireEvent.change(facultyCategorySelect,
           { target: { value: facultyMember.category } });
       });
-      context('when the modal submit button is clicked', function () {
-        it('should not show the unsaved changes warning', async function () {
-          const submitButton = renderResult.getByText('Submit');
-          fireEvent.click(submitButton);
-          await waitForElementToBeRemoved(() => renderResult.queryByText('Submit'));
-          const modal = renderResult.queryByRole('dialog');
-          strictEqual(modal, null);
+      context('when the required fields are provided', function () {
+        context('when the modal submit button is clicked', function () {
+          it('should not show the unsaved changes warning', async function () {
+            const submitButton = renderResult.getByText('Submit');
+            fireEvent.click(submitButton);
+            await waitForElementToBeRemoved(() => renderResult.queryByText('Submit'));
+            const modal = renderResult.queryByRole('dialog');
+            strictEqual(modal, null);
+          });
+          it('should show a success message', async function () {
+            const submitButton = renderResult.getByText('Submit');
+            fireEvent.click(submitButton);
+            await waitForElementToBeRemoved(() => renderResult.queryByText('Submit'));
+            return renderResult.findByText('Faculty was updated', { exact: false });
+          });
         });
-      });
-      context('when the modal submit button is not clicked', function () {
-        it('should show the unsaved changes warning', async function () {
-          const windowConfirmStub = stub(window, 'confirm');
-          windowConfirmStub.returns(true);
-          // Attempt to close the modal without saving
-          const cancelButton = await renderResult.findByText('Cancel');
-          fireEvent.click(cancelButton);
-          strictEqual(windowConfirmStub.callCount, 1);
+        context('when the modal submit button is not clicked', function () {
+          it('should show the unsaved changes warning', async function () {
+            const windowConfirmStub = stub(window, 'confirm');
+            windowConfirmStub.returns(true);
+            // Attempt to close the modal without saving
+            const cancelButton = await renderResult.findByText('Cancel');
+            fireEvent.click(cancelButton);
+            strictEqual(windowConfirmStub.callCount, 1);
+          });
         });
       });
     });
@@ -151,8 +159,8 @@ describe('End-to-end Faculty Admin updating', function () {
         fireEvent.click(editButton);
         return renderResult.findByRole('dialog');
       });
-      context('when the modal submit button is clicked', function () {
-        context('when the user attempts to exit the modal', function () {
+      context('when the required fields are provided', function () {
+        context('when the modal submit button is clicked', function () {
           it('should not show an unsaved changes warning', async function () {
             // Set new category for faculty entry
             const categorySelector = await renderResult.findByLabelText('Category', { exact: false });
@@ -165,21 +173,27 @@ describe('End-to-end Faculty Admin updating', function () {
             const modal = renderResult.queryByRole('dialog');
             strictEqual(modal, null);
           });
+          it('should show a success message', async function () {
+            const submitButton = renderResult.getByText('Submit');
+            fireEvent.click(submitButton);
+            await waitForElementToBeRemoved(() => renderResult.queryByText('Submit'));
+            return renderResult.findByText('Faculty was updated', { exact: false });
+          });
         });
-      });
-      context('when the modal submit button is not clicked', function () {
-        context('when the user attempts to exit the modal', function () {
-          it('should show an unsaved changes warning', async function () {
-            // Set new category for faculty entry
-            const categorySelector = await renderResult.findByLabelText('Category', { exact: false });
-            fireEvent.change(categorySelector,
-              { target: { value: FACULTY_TYPE.LADDER } });
-            const windowConfirmStub = stub(window, 'confirm');
-            windowConfirmStub.returns(true);
-            // Attempt to close the modal without saving
-            const cancelButton = await renderResult.findByText('Cancel');
-            fireEvent.click(cancelButton);
-            strictEqual(windowConfirmStub.callCount, 1);
+        context('when the modal submit button is not clicked', function () {
+          context('when the user attempts to exit the modal', function () {
+            it('should show an unsaved changes warning', async function () {
+              // Set new category for faculty entry
+              const categorySelector = await renderResult.findByLabelText('Category', { exact: false });
+              fireEvent.change(categorySelector,
+                { target: { value: FACULTY_TYPE.LADDER } });
+              const windowConfirmStub = stub(window, 'confirm');
+              windowConfirmStub.returns(true);
+              // Attempt to close the modal without saving
+              const cancelButton = await renderResult.findByText('Cancel');
+              fireEvent.click(cancelButton);
+              strictEqual(windowConfirmStub.callCount, 1);
+            });
           });
         });
       });


### PR DESCRIPTION
This PR adds success messages that were missing on successful save and applies the `Mark One` `GlobalMessage` component to all success messages. Tests were also added for the new success messages to make sure they were rendering properly at the right time. In order to check the content of the messages, `renderWithMessaging` was added, and it includes the `Message` component (the current `customRender` does not include the `Message` component).

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #422

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
