### PR TITLE
Add Show Retired Checkbox Filter

### DIFF
--- a/src/client/components/general/flex/MenuFlex.tsx
+++ b/src/client/components/general/flex/MenuFlex.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+/**
+ * A wrapper around the elements of options above the Courses table , used for
+ * adding secondary layers of flex positioning.
+ */
+export default styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
+  align-self: center;
+`;

--- a/src/client/components/general/flex/MenuFlex.tsx
+++ b/src/client/components/general/flex/MenuFlex.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
 /**
- * A wrapper around the elements of options above the Courses table , used for
- * adding secondary layers of flex positioning.
+ * A wrapper used to add a secondary layer of flex positioning for a group
+ * of options.
  */
 export default styled.div`
   display: flex;

--- a/src/client/components/general/flex/index.ts
+++ b/src/client/components/general/flex/index.ts
@@ -1,3 +1,4 @@
 export { default as CellLayout } from './CellLayout';
 export { default as HeaderFlex } from './HeaderFlex';
 export { default as ButtonLayout } from './ButtonLayout';
+export { default as MenuFlex } from './MenuFlex';

--- a/src/client/components/pages/Courses/CoursesPage.tsx
+++ b/src/client/components/pages/Courses/CoursesPage.tsx
@@ -442,15 +442,6 @@ const CoursesPage: FunctionComponent = (): ReactElement => {
             {' '}
             Customize View
           </Button>
-          <Checkbox
-            id="showRetiredCheckbox"
-            name="showRetiredCheckbox"
-            label="Show Retired"
-            checked={showRetired}
-            onChange={() => setShowRetired(!showRetired)}
-            labelPosition={POSITION.RIGHT}
-            hideError
-          />
           <Dropdown
             id="academic-year-selector"
             name="academic-year-selector"
@@ -465,6 +456,15 @@ const CoursesPage: FunctionComponent = (): ReactElement => {
                 setSelectedAcademicYear(parseInt(value, 10));
               }
             }
+          />
+          <Checkbox
+            id="showRetiredCheckbox"
+            name="showRetiredCheckbox"
+            label="Show Retired"
+            checked={showRetired}
+            onChange={() => setShowRetired(!showRetired)}
+            labelPosition={POSITION.RIGHT}
+            hideError
           />
         </MenuFlex>
       </VerticalSpace>

--- a/src/client/components/pages/Courses/CoursesPage.tsx
+++ b/src/client/components/pages/Courses/CoursesPage.tsx
@@ -431,7 +431,7 @@ const CoursesPage: FunctionComponent = (): ReactElement => {
                   label="Show Retired"
                   checked={showRetired}
                   onChange={() => setShowRetired(!showRetired)}
-                  labelPosition={POSITION.LEFT}
+                  labelPosition={POSITION.RIGHT}
                   hideError
                 />
               </MenuFlex>

--- a/src/client/components/pages/Courses/CoursesPage.tsx
+++ b/src/client/components/pages/Courses/CoursesPage.tsx
@@ -11,7 +11,9 @@ import React, {
 } from 'react';
 import {
   Button,
+  Checkbox,
   LoadSpinner,
+  POSITION,
   VARIANT,
 } from 'mark-one';
 import { MessageContext } from 'client/context';
@@ -27,6 +29,7 @@ import { ViewResponse } from 'common/dto/view/ViewResponse.dto';
 import { VerticalSpace } from 'client/components/layout';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faWrench } from '@fortawesome/free-solid-svg-icons';
+import { MenuFlex } from 'client/components/general';
 import CourseInstanceTable from './CourseInstanceTable';
 import ViewModal from './ViewModal';
 import SemesterTable from './SemesterTable';
@@ -76,13 +79,6 @@ const defaultView: ViewResponse = {
     COURSE_TABLE_COLUMN.NOTES,
   ],
 };
-
-/*
- * TODO
- * Until the functionality for setting "Show Retired Courses" is implemented
- * this will be hard-coded here
- */
-const showRetired = false;
 
 // TODO: Get the actual current academic year instead of hard coding
 const acadYear = 2019;
@@ -186,6 +182,13 @@ const CoursesPage: FunctionComponent = (): ReactElement => {
   const [activeFilters, setActiveFilters] = useState<FilterState>(emptyFilters);
 
   /**
+   * Controls whether the retired courses are shown in the Course Instance table.
+   * By default, the "Show Retired Courses" checkbox is unchecked, meaning that
+   * the retired courses are not shown unless the checkbox is checked.
+   */
+  const [showRetired, setShowRetired] = useState(false);
+
+  /**
    * Handles keeping track of the group of filters as the user interacts with
    * the filter dropdowns
    */
@@ -284,7 +287,7 @@ const CoursesPage: FunctionComponent = (): ReactElement => {
       );
     }
     return courses;
-  }, [currentCourses, activeFilters]);
+  }, [currentCourses, activeFilters, showRetired]);
 
   /**
    * Track the current timeout from our debouncing process, below
@@ -408,19 +411,30 @@ const CoursesPage: FunctionComponent = (): ReactElement => {
                   onChange={toggleColumn}
                 />
               </ViewModal>
-              <Button
-                variant={VARIANT.INFO}
-                forwardRef={customizeViewButtonRef}
-                onClick={() => {
-                  setViewModalVisible(true);
-                }}
-              >
-                <FontAwesomeIcon
-                  icon={faWrench}
+              <MenuFlex>
+                <Button
+                  variant={VARIANT.INFO}
+                  forwardRef={customizeViewButtonRef}
+                  onClick={() => {
+                    setViewModalVisible(true);
+                  }}
+                >
+                  <FontAwesomeIcon
+                    icon={faWrench}
+                  />
+                  {' '}
+                  Customize View
+                </Button>
+                <Checkbox
+                  id="showRetiredCheckbox"
+                  name="showRetiredCheckbox"
+                  label="Show Retired"
+                  checked={showRetired}
+                  onChange={() => setShowRetired(!showRetired)}
+                  labelPosition={POSITION.LEFT}
+                  hideError
                 />
-                {' '}
-                Customize View
-              </Button>
+              </MenuFlex>
             </VerticalSpace>
             <CourseInstanceTable
               academicYear={acadYear}

--- a/src/client/components/pages/Courses/__tests__/CoursesPage.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/CoursesPage.test.tsx
@@ -122,6 +122,7 @@ describe('Course Page', function () {
       });
     });
     afterEach(function () {
+      clock.runAll();
       clock.uninstall();
     });
     context('when the area dropdown filter is changed', function () {

--- a/src/client/components/pages/Courses/__tests__/CoursesPage.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/CoursesPage.test.tsx
@@ -15,11 +15,12 @@ import {
   fireEvent,
   AllByRole,
   within,
+  GetByText,
 } from 'test-utils';
 import { CourseAPI } from 'client/api';
 import { AppMessage, MESSAGE_TYPE, MESSAGE_ACTION } from 'client/classes';
 import { MessageReducerAction } from 'client/context';
-import { am105CourseInstance, cs50CourseInstance } from 'testData';
+import { am105CourseInstance, cs50CourseInstance, es247RetiredCourseInstance } from 'testData';
 import { isSEASEnumToString, IS_SEAS, OFFERED } from 'common/constants';
 import { offeredEnumToString } from 'common/constants/offered';
 import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers';
@@ -92,6 +93,8 @@ describe('Course Page', function () {
   describe('Filtering data', function () {
     let getAllByRole: BoundFunction<AllByRole>;
     let findByText: BoundFunction<FindByText>;
+    let getByLabelText: BoundFunction<GetByText>;
+    let queryByText: BoundFunction<QueryByText>;
     const areaFilterLabel = 'The table will be filtered as selected in this area dropdown filter';
     const isSEASFilterLabel = 'The table will be filtered as selected in this isSEAS dropdown filter';
     const fallOfferedFilterLabel = 'The table will be filtered as selected in this fall offered dropdown filter';
@@ -106,8 +109,14 @@ describe('Course Page', function () {
       getStub.resolves([
         { ...cs50CourseInstance },
         { ...am105CourseInstance },
+        { ...es247RetiredCourseInstance },
       ]);
-      ({ getAllByRole, findByText } = render(<CoursesPage />));
+      ({
+        getAllByRole,
+        findByText,
+        getByLabelText,
+        queryByText,
+      } = render(<CoursesPage />));
       clock = FakeTimers.install({
         toFake: ['setTimeout'],
       });
@@ -235,6 +244,25 @@ describe('Course Page', function () {
         // a fake time to make 200 ms pass after changing the filter value.
         clock.tick(200);
         strictEqual(filterInstructorsSpy.callCount, 1);
+      });
+    });
+    context('when the show retired button is not checked', function () {
+      it('does not show the retired courses', function () {
+        // First, make sure that the Show Retired checkbox is not initially checked
+        const retiredCheckbox = getByLabelText('Show Retired', { exact: false }) as HTMLInputElement;
+        strictEqual(retiredCheckbox.checked, false, 'The "Show Retired" checkbox is checked when it should initially be unchecked');
+        strictEqual(
+          queryByText(es247RetiredCourseInstance.catalogNumber), null
+        );
+      });
+    });
+    context('when the show retired button is checked', function () {
+      it('shows the retired courses', async function () {
+        // First, make sure that the Show Retired checkbox is not initially checked
+        const retiredCheckbox = getByLabelText('Show Retired', { exact: false }) as HTMLInputElement;
+        strictEqual(retiredCheckbox.checked, false, 'The "Show Retired" checkbox is checked when it should initially be unchecked');
+        fireEvent.click(retiredCheckbox);
+        return findByText(es247RetiredCourseInstance.catalogNumber);
       });
     });
   });

--- a/src/common/__tests__/data/courseInstances.ts
+++ b/src/common/__tests__/data/courseInstances.ts
@@ -293,6 +293,59 @@ export const ac209aCourseInstance: CourseInstanceResponseDTO = {
 };
 
 /**
+ * The data object representing the retired Fracture Mechanics course, ES 247,
+ * in the 2018 academic year.
+ */
+export const es247RetiredCourseInstance: CourseInstanceResponseDTO = {
+  id: '4a2909c7-92d1-4613-b53b-cf75fdef7d26',
+  title: 'Fracture Mechanics',
+  area: 'ES',
+  isUndergraduate: true,
+  catalogNumber: 'ES 247',
+  sameAs: '',
+  isSEAS: IS_SEAS.Y,
+  notes: null,
+  termPattern: TERM_PATTERN.SPRING,
+  fall: {
+    id: 'c4bd3649-0841-4a7a-a317-8d856821e16e',
+    calendarYear: '2018',
+    offered: OFFERED.RETIRED,
+    preEnrollment: null,
+    studyCardEnrollment: null,
+    actualEnrollment: null,
+    instructors: [],
+    meetings: [],
+  },
+  spring: {
+    id: 'a16fa199-8b57-4082-b02c-207cd998ac8a',
+    calendarYear: '2017',
+    offered: OFFERED.RETIRED,
+    preEnrollment: null,
+    studyCardEnrollment: 140,
+    actualEnrollment: 123,
+    instructors: [
+      {
+        id: '373b53a0-8bc7-4af0-be21-5e0479a2215d',
+        displayName: 'Suo, Zhigang',
+      },
+    ],
+    meetings: [
+      {
+        id: 'f5fa6fbb-c1d7-47c3-ac0f-39d32628b64a',
+        day: DAY.FRI,
+        startTime: '10:00:00',
+        endTime: '12:00:00',
+        room: {
+          id: '1a2f2a93-132c-4bef-bf2d-4f431703f91d',
+          campus: 'Cambridge',
+          name: '1414 Massachusetts Avenue 437',
+        },
+      },
+    ],
+  },
+};
+
+/**
  * Data representing the graduate intro to data science course, AC 209A, in the
  * 2019 academic year. This course is offered in the fall, has multiple
  * meetings and multiple instructors, and has notes and sameAs data.


### PR DESCRIPTION
This PR adds a checkbox filter for the `retired` field and replaces the hard coded `showRetired` value with a state value that changes as you interact with the checkbox. By default, the field is unchecked, meaning that retired courses are not shown initially.

I also added a `MenuFlex` component (not sure if the naming of this component is the best) used to add space between each of the options above the Course Instance table. As more items are added within `MenuFlex`, this component should continue to space each of those items evenly. 

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #450 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
