### PR TITLE
Enable SSL support for production deployment

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -9,6 +9,24 @@ CAS_URL=
 # The environment the app is running in. Can be "development" or "production"
 NODE_ENV=
 
+# Whether the app should listen via https on the SERVER_PORT. Should be "true"
+# to listen for https, and "false" for plain http. Leaving it blank, or using
+# any other value, will be be the same as "false". When set to true, you will
+# also need to provide the HTTPS_PUBLIC_CERT and HTTPS_PRIVATE_KEY values below
+HTTPS_ON=false
+
+# The Public certificate that will be used to serve the app over https when
+# HTTPS_ON is true. This can be left blank in development. Should be a string in
+# PEM format. See `cert` argument to tls.createSecureContext()
+# https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
+HTTPS_PUBLIC_CERT=
+
+# The Private key that will be used alongside the public cert when HTTPS_ON is
+# true. Can be left blank in development. Should be a string in PEM format. See
+# `key` argument to tls.createSecureContext()
+# https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
+HTTPS_PRIVATE_KEY=
+
 # The maximum level of log that should be shown. Must be one of the following
 # strings:
 #

--- a/.env-example
+++ b/.env-example
@@ -9,6 +9,22 @@ CAS_URL=
 # The environment the app is running in. Can be "development" or "production"
 NODE_ENV=
 
+# The HTTPS_ configurations below can generally be left blank in
+# development/testing, and only need to be set in production. The _CERT and
+# _KEY are meant to be used when connecting to the container from a
+# client-facing load balancer or proxy. That client-facing service will handle
+# the "real" https connection, while these HTTPS settings will just encrypt the
+# conenction between the container and the load balancer. Assuming that both
+# are under the same ownership, it's OK to provide a self-signed certificate
+# here.
+#
+# To generate a certificate and key locally, you can run:
+#
+# $ openssl req -x509 -newkey rsa:4096 -days 3650 -subj "/CN=localhost" -nodes -keyout private.key -out public.crt
+#
+# The contents of public.crt and private.key can then be copied into the _KEY
+# and _CERT variables below
+
 # Whether the app should listen via https on the SERVER_PORT. Should be "true"
 # to listen for https, and "false" for plain http. Leaving it blank, or using
 # any other value, will be be the same as "false". When set to true, you will

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     volumes:
       - "postgres_data:/var/lib/postgresql/data"
+      - "./init-postgres-ssl.sh:/docker-entrypoint-initdb.d/init-ssl.sh"
+    command: ["postgres", "-c", "ssl=on"]
   node:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,9 @@ services:
       - SERVER_URL
       - SERVER_PORT
       - SESSION_SECRET
+      - HTTPS_ON
+      - HTTPS_PRIVATE_KEY
+      - HTTPS_PUBLIC_CERT
     user: "1000:1000"
     ports:
       - "127.0.0.1:${SERVER_PORT}:${SERVER_PORT}"

--- a/init-postgres-ssl.sh
+++ b/init-postgres-ssl.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+(
+  echo "Generating ssl key and certificate"
+  umask 077
+  openssl req -x509\
+    -newkey rsa:4096\
+    -days 3650\
+    -subj "/CN=postres"\
+    -nodes\
+    -keyout /var/lib/postgresql/data/server.key\
+    -out /var/lib/postgresql/data/server.crt
+  echo "done!"
+)

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -13,6 +13,10 @@ module.exports = {
   username: DB_USERNAME,
   password: DB_PASSWORD,
   database: DB_DATABASE,
+  ssl: {
+    // We don't care if the certificate isn't signed by an official CA
+    rejectUnauthorized: false,
+  },
   entities: ['src/server/**/*.entity.ts'],
   migrations: ['src/server/migrations/*.ts'],
   cli: {

--- a/src/common/dto/nonClassMeetings/NonClassParentResponse.dto.ts
+++ b/src/common/dto/nonClassMeetings/NonClassParentResponse.dto.ts
@@ -1,5 +1,4 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { string } from 'testData';
 
 /**
  * DTO class representative of the shape of data returned from [[NonClasseventController.create]]
@@ -47,13 +46,13 @@ export class NonClassParentResponse {
 
   @ApiProperty({
     example: '2021-09-30T19:40:57.837Z',
-    type: string,
+    type: 'string',
   })
   public createdAt: Date;
 
   @ApiProperty({
     example: '2021-09-30T19:40:57.837Z',
-    type: string,
+    type: 'string',
   })
   public updatedAt: Date;
 }

--- a/src/server/config/config.service.ts
+++ b/src/server/config/config.service.ts
@@ -157,6 +157,10 @@ class ConfigService {
       password: DB_PASSWORD,
       host: DB_HOSTNAME,
       port: parseInt(DB_PORT),
+      ssl: {
+        // We don't care if the certificate isn't signed by an official CA,
+        rejectUnauthorized: false,
+      },
       entities: [
         Absence,
         Area,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -39,7 +39,6 @@ async function bootstrap(): Promise<void> {
     : null;
 
   const app = await NestFactory.create(AppModule, {
-    logger: false,
     httpsOptions,
   });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -29,10 +29,12 @@ async function bootstrap(): Promise<void> {
   const publicClientOrigin = new URL(PUBLIC_CLIENT_URL).origin;
   const serverPathname = new URL(SERVER_URL).pathname;
 
+  const key = HTTPS_PRIVATE_KEY.replace(/\s+(?!RSA|PRIVATE|KEY)/g, '\n');
+  const cert = HTTPS_PUBLIC_CERT.replace(/\s+(?!CERTIFICATE)/g, '\n');
   const httpsOptions = HTTPS_ON === 'true'
     ? {
-      key: HTTPS_PRIVATE_KEY,
-      cert: HTTPS_PUBLIC_CERT,
+      key,
+      cert,
     }
     : null;
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -15,6 +15,9 @@ const {
   NODE_ENV,
   CLIENT_URL,
   PUBLIC_CLIENT_URL,
+  HTTPS_ON,
+  HTTPS_PRIVATE_KEY,
+  HTTPS_PUBLIC_CERT,
 } = process.env;
 
 /**
@@ -26,8 +29,16 @@ async function bootstrap(): Promise<void> {
   const publicClientOrigin = new URL(PUBLIC_CLIENT_URL).origin;
   const serverPathname = new URL(SERVER_URL).pathname;
 
+  const httpsOptions = HTTPS_ON === 'true'
+    ? {
+      key: HTTPS_PRIVATE_KEY,
+      cert: HTTPS_PUBLIC_CERT,
+    }
+    : null;
+
   const app = await NestFactory.create(AppModule, {
     logger: false,
+    httpsOptions,
   });
 
   app.useLogger(app.get(LogService));

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -27,7 +27,7 @@ const {
 async function bootstrap(): Promise<void> {
   const clientOrigin = new URL(CLIENT_URL).origin;
   const publicClientOrigin = new URL(PUBLIC_CLIENT_URL).origin;
-  const serverPathname = new URL(SERVER_URL).pathname;
+  const serverPathname = new URL(SERVER_URL).pathname.replace(/\/$/, '');
 
   const key = HTTPS_PRIVATE_KEY.replace(/\s+(?!RSA|PRIVATE|KEY)/g, '\n');
   const cert = HTTPS_PUBLIC_CERT.replace(/\s+(?!CERTIFICATE)/g, '\n');


### PR DESCRIPTION
This PR rolls up a couple different changes that are needed to get the app up and running in production correctly, some of which came out of a working session I had with John Fisher (@jfisherseas). I considered breaking this into 3-4 separate PRs, but the two major ones are similar enough that I thought they could fit as one, and the other bits aren't pretty minor.

**Most importantly, these changes will require destroying and rebuilding the development database locally.**

## Serving the app over HTTPS

Our server container is going to run behind a load balancer in production, and that load balancer will handle incoming HTTPS connections from clients with a valid certificate. We also want to encrypt the traffic from the container to the load balancer, but we don't actually care whether the certificate between those two is valid.

To turn on HTTPS, we need to set `HTTPS_ON` to `"true"`, then provide the certificate and key as `HTTPS_PUBLIC_CERT` and `HTTPS_PRIVATE_KEY`, respectively. In production, those will come from AWS Secret Manager. To generate those values locally, you can run*:

```sh
# from https://wiki.archlinux.org/title/OpenSSL#Generate_a_self-signed_certificate_with_private_key_in_a_single_command
$ openssl req -x509 -newkey rsa:4096 -days 3650 -subj "/CN=localhost" -nodes -keyout private.key -out public.crt
```

and then copy the contents into the correct variables.

> \* I'm not actually sure if macOS has openssl installed by default, or if the option flags are the same. If that doesn't work, let me know and we can troubleshoot

You'll also need to change the `SERVER_URL` variable to use `https://`, so that the client will try to connect to the correct address. The browser may complain about the self-signed certificate, in which case you can try going directly to `{SERVER_URL}/health-check` and add an exception for the certificate (usually requires clicking on "Advanced", then "proceed anyway", or something like that).

## Connecting to the database over SSL

On a similar tack, we want to encrypt the connection from our container to the database and we don't actually care much about whether the certificate we use for that is valid. From the node side, we simply have to provide a value to the `ssl` key in the TypeORM connection options; in this case an object that sets `rejectUnauthorized: false`, which just means that we're OK with a self-signed certificate.

I went down the road of conditionally un-setting this in development and testing, but ultimately decided it would probably be better to just turn on SSL in all of our different datbases, so that our testing environment will more closely mirror production.

To that end, I've added the `init-postgres-ssl.sh` script, which is essentially running the same command as above to generate the certificate and key in the files that postgres expects. That gets mounted in the `initdb` directory on the container, and will be run automatically, **but only if container starts with an empty database**. So to enable it, you'll need to run:

```sh
$ docker-compose down postgres
$ docker volume rm course-planner_postgres_data
$ docker-compose up postgres
```

Then rerun the migrations and the `course-planner-etl`.

## Minor bugs

Outside those SSL changes, there was an errant import of `testData` in one of the DTOs that was breaking the app, a small change in the global prefix, and a change to the logger settings to get proper diagnostic information when things break.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #482 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
