### PR TITLE
Add new year in production only

### DIFF
--- a/src/server/semester/semester.module.ts
+++ b/src/server/semester/semester.module.ts
@@ -6,6 +6,7 @@ import { LogModule } from 'server/log/log.module';
 import { NonClassEvent } from 'server/nonClassEvent/nonclassevent.entity';
 import { Semester } from 'server/semester/semester.entity';
 import { SemesterService } from './semester.service';
+import { ConfigModule } from '../config/config.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { SemesterService } from './semester.service';
       Absence,
     ]),
     LogModule,
+    ConfigModule,
   ],
   providers: [
     SemesterService,

--- a/src/server/semester/semester.service.ts
+++ b/src/server/semester/semester.service.ts
@@ -12,6 +12,7 @@ import { Absence } from 'server/absence/absence.entity';
 import { MONTH } from 'common/constants/month';
 import { LogService } from 'server/log/log.service';
 import { Semester } from './semester.entity';
+import { ConfigService } from '../config/config.service';
 
 /**
  * @class SemesterService
@@ -34,6 +35,9 @@ export class SemesterService implements OnApplicationBootstrap {
 
   @Inject(LogService)
   private readonly logService: LogService;
+
+  @Inject(ConfigService)
+  private readonly config: ConfigService;
 
   /**
    * Resolves to an array containing all of the years that currently exist in the
@@ -260,13 +264,15 @@ export class SemesterService implements OnApplicationBootstrap {
 
   public onApplicationBootstrap(): Promise<void> {
     const today = new Date();
-    if (today.getMonth() === MONTH.JUN) {
+    if (this.config.isProduction && today.getMonth() === MONTH.JUN) {
       const yearToAdd = today.getFullYear() + 4;
       try {
         return this.addAcademicYear(yearToAdd);
       } catch (e) {
         this.logService.error(e);
       }
+    } else {
+      return Promise.resolve();
     }
   }
 }

--- a/tests/integration/server/faculty/faculty.controller.test.ts
+++ b/tests/integration/server/faculty/faculty.controller.test.ts
@@ -124,7 +124,7 @@ describe('Faculty API', function () {
       ],
     })
       .overrideProvider(ConfigService)
-      .useValue(new ConfigService({ NODE_ENV: 'production' }))
+      .useValue(new ConfigService())
 
       .overrideProvider(getRepositoryToken(Faculty))
       .useValue(mockFacultyRepository)


### PR DESCRIPTION
This is a quick fix for some tests that started failing on June 1, as our testModules started trying to add years that couldn't be created. It adds an additional check to make sure that we're running in Production before attempting to call the function, which resolved most of the failing tests. (The Faculty API test suite was forcing the `NODE_ENV` to be production, but that seemed unnecessary and removing it fixed the failures without breaking anything else.)

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [ ] Normal <!-- New piece of functionality -->
- [x] High <!-- Critical bug requiring urgent review -->

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
