### PR TITLE
Add meeting info popups to Schedule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "lodash.merge": "^4.6.2",
         "lodash.set": "^4.3.2",
         "loglevel": "^1.6.8",
-        "mark-one": "^0.4.3",
+        "mark-one": "^0.4.5",
         "morgan": "^1.10.0",
         "nestjs-redis": "^1.3.3",
         "nestjs-session": "^1.0.0",
@@ -10344,9 +10344,9 @@
       }
     },
     "node_modules/mark-one": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.4.3.tgz",
-      "integrity": "sha512-5j0U9xpkmFzpwTKaKUlr2Mmc42CZpRBBItgAkoi+9Fr6fO0nyaNV98fm8YO2aznFD+Beo1xKpw3Nj/RPGfJkRQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.4.5.tgz",
+      "integrity": "sha512-YowWOOEbVQvHZDPXcW7Z8mMxxkEMeO5xhI8NBR89H1BybiXmf/r/mE261IBLjeDwGRl8mfxcnCDIff8Q0WA6GA==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",
         "@openfonts/open-sans_all": "^1.43.0",
@@ -27132,9 +27132,9 @@
       }
     },
     "mark-one": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.4.3.tgz",
-      "integrity": "sha512-5j0U9xpkmFzpwTKaKUlr2Mmc42CZpRBBItgAkoi+9Fr6fO0nyaNV98fm8YO2aznFD+Beo1xKpw3Nj/RPGfJkRQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.4.5.tgz",
+      "integrity": "sha512-YowWOOEbVQvHZDPXcW7Z8mMxxkEMeO5xhI8NBR89H1BybiXmf/r/mE261IBLjeDwGRl8mfxcnCDIff8Q0WA6GA==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",
         "@openfonts/open-sans_all": "^1.43.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.set": "^4.3.2",
     "loglevel": "^1.6.8",
-    "mark-one": "^0.4.3",
+    "mark-one": "^0.4.5",
     "morgan": "^1.10.0",
     "nestjs-redis": "^1.3.3",
     "nestjs-session": "^1.0.0",

--- a/src/client/components/general/typography/HiddenText.tsx
+++ b/src/client/components/general/typography/HiddenText.tsx
@@ -6,5 +6,10 @@ import styled from 'styled-components';
  */
 
 export default styled.span`
-  display: none;
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
 `;

--- a/src/client/components/pages/Schedule/SchedulePage.tsx
+++ b/src/client/components/pages/Schedule/SchedulePage.tsx
@@ -11,6 +11,7 @@ import { VerticalSpace } from 'client/components/layout';
 import { termEnumToTitleCase } from 'common/utils/termHelperFunctions';
 import { toTitleCase } from 'common/utils/util';
 import ScheduleView from './ScheduleView';
+import { useStoredState } from '../../../hooks/useStoredState';
 
 /**
  * Parameters for how the schedule view should be displayed. Currently using
@@ -54,7 +55,10 @@ const SchedulePage: FunctionComponent = () => {
   /**
    * Keeps track of the currently selectedterm
    */
-  const [selectedSemester, setSelectedSemester] = useState<SemesterSelection>();
+  const [
+    selectedSemester,
+    setSelectedSemester,
+  ] = useStoredState<SemesterSelection>('SCHEDULE_SEMESTER_SELECTION');
 
   /**
    * Whether an API request is in progress

--- a/src/client/components/pages/Schedule/ScheduleView.tsx
+++ b/src/client/components/pages/Schedule/ScheduleView.tsx
@@ -1,9 +1,12 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import { ScheduleViewResponseDTO } from 'common/dto/schedule/schedule.dto';
 import DAY, { dayEnumToString } from 'common/constants/day';
+import { Popover } from 'mark-one';
 import {
-  WeekBlock, DayBlock, CourseListing, SessionBlock,
+  WeekBlock, DayBlock, CourseListing, SessionBlock, CourseListingButton,
 } from './blocks';
+import { PGTime } from '../../../../common/utils/PGTime';
+import { HiddenText } from '../../general';
 
 interface ScheduleViewProps {
   /**
@@ -61,6 +64,12 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
   // css-grid rows
   const numRows = ((lastHour - firstHour) * 60)
       / minuteResolution;
+
+  /**
+   * Track the prefix and catalog number of the course whose details should be shown.
+   */
+  const [currentPopover, setCurrentPopover] = useState('');
+
   return (
     <WeekBlock
       firstHour={firstHour}
@@ -68,6 +77,9 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
       numColumns={days.length}
       rowHeight={rowHeight}
       minuteResolution={minuteResolution}
+      onClick={() => {
+        setCurrentPopover(null);
+      }}
     >
       {days.map((day, col) => (
         <DayBlock
@@ -83,6 +95,8 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
             coursePrefix,
             startHour,
             startMinute,
+            endHour,
+            endMinute,
             duration,
             weekday,
             courses,
@@ -95,7 +109,9 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                 / minuteResolution
                 // Add one to account for the header row
               ) + 1;
-              const resolvedDuration = Math.round(duration / minuteResolution);
+              const resolvedDuration = Math.round(
+                duration / minuteResolution
+              );
               return [...blocks, (
                 <SessionBlock
                   key={sessionId}
@@ -103,11 +119,48 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                   startRow={resolvedStartRow}
                   duration={resolvedDuration}
                 >
-                  {courses.map(({ id: courseId, courseNumber }) => (
-                    <CourseListing key={courseId}>
-                      {courseNumber}
-                    </CourseListing>
-                  ))}
+                  {courses.map(({
+                    id: courseId,
+                    courseNumber,
+                    room,
+                  }) => {
+                    const catalogNumber = `${coursePrefix} ${courseNumber}`;
+                    const displayStartTime = PGTime.toDisplay(
+                      `${startHour}:${startMinute.toString().padStart(2, '0')}`
+                    );
+                    const displayEndTime = PGTime.toDisplay(
+                      `${endHour}:${endMinute.toString().padStart(2, '0')}`
+                    );
+                    return (
+                      <CourseListing key={courseId}>
+                        <CourseListingButton
+                          aria-hidden
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setCurrentPopover((current) => (
+                              current === courseId ? null : courseId
+                            ));
+                          }}
+                        >
+                          {courseNumber}
+                        </CourseListingButton>
+                        <Popover
+                          aria-hidden
+                          xOffset="0.5rem"
+                          yOffset="1rem"
+                          title={catalogNumber}
+                          isVisible={currentPopover === courseId}
+                        >
+                          <p>{day}</p>
+                          <p>{`${displayStartTime} - ${displayEndTime}`}</p>
+                          <p>{room}</p>
+                        </Popover>
+                        <HiddenText>
+                          {`${catalogNumber} on ${day}, ${displayStartTime} to ${displayEndTime} in ${room}`}
+                        </HiddenText>
+                      </CourseListing>
+                    );
+                  })}
                 </SessionBlock>
               )];
             }

--- a/src/client/components/pages/Schedule/ScheduleView.tsx
+++ b/src/client/components/pages/Schedule/ScheduleView.tsx
@@ -134,7 +134,8 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                     return (
                       <CourseListing key={courseId}>
                         <CourseListingButton
-                          aria-hidden
+                          aria-disabled
+                          aria-labelledby={`${courseId}-description`}
                           onClick={(event) => {
                             event.stopPropagation();
                             setCurrentPopover((current) => (
@@ -155,7 +156,7 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                           <p>{`${displayStartTime} - ${displayEndTime}`}</p>
                           <p>{room}</p>
                         </Popover>
-                        <HiddenText>
+                        <HiddenText id={`${courseId}-description`}>
                           {`${catalogNumber} on ${day}, ${displayStartTime} to ${displayEndTime} in ${room}`}
                         </HiddenText>
                       </CourseListing>

--- a/src/client/components/pages/Schedule/__tests__/ScheduleView.test.tsx
+++ b/src/client/components/pages/Schedule/__tests__/ScheduleView.test.tsx
@@ -155,11 +155,12 @@ describe('ScheduleView', function () {
       });
     });
     describe('Accessibility', function () {
-      it('Should not include any button roles on the page', function () {
-        // All buttons/popovers have aria-hidden set, so that screen readers
-        // will not show them
+      it('Should not include any active buttons on the page', function () {
         const buttonRoles = page.queryAllByRole('button');
-        strictEqual(buttonRoles.length, 0);
+        const activeButtons = buttonRoles.filter(
+          (button) => !button.getAttribute('aria-disabled')
+        );
+        strictEqual(activeButtons.length, 0);
       });
       it('Should still display the Popover text for each entry', function () {
         testCourseScheduleData.forEach(({

--- a/src/client/components/pages/Schedule/__tests__/ScheduleView.test.tsx
+++ b/src/client/components/pages/Schedule/__tests__/ScheduleView.test.tsx
@@ -1,56 +1,57 @@
 import React from 'react';
 import {
   render,
-  BoundFunction,
-  QueryByText,
-  AllByRole,
+  RenderResult,
+  fireEvent,
 } from 'test-utils';
 import { testCourseScheduleData } from 'testData';
 import { notStrictEqual, strictEqual, deepStrictEqual } from 'assert';
 import ScheduleView from '../ScheduleView';
+import { dayEnumToString } from '../../../../../common/constants/day';
+import { PGTime } from '../../../../../common/utils/PGTime';
+import { ScheduleViewResponseDTO, ScheduleEntry } from '../../../../../common/dto/schedule/schedule.dto';
 
 describe('ScheduleView', function () {
-  let queryByText: BoundFunction<QueryByText>;
-  let getAllByRole: BoundFunction<AllByRole>;
+  let page: RenderResult;
   describe('The Week View', function () {
     beforeEach(function () {
-      ({ queryByText } = render(
+      page = render(
         <ScheduleView
           schedule={testCourseScheduleData}
           firstHour={8}
           lastHour={20}
         />
-      ));
+      );
     });
     it('Should render morning hours in am time', function () {
-      const eleven = queryByText('11 AM');
+      const eleven = page.queryByText('11 AM');
       notStrictEqual(eleven, null);
     });
     it('Should render noon as 12pm', function () {
-      const noon = queryByText('12 PM');
+      const noon = page.queryByText('12 PM');
       notStrictEqual(noon, null);
     });
     it('Should render afternoon hours in pm time', function () {
-      const one = queryByText('1 PM');
+      const one = page.queryByText('1 PM');
       notStrictEqual(one, null);
     });
     it('Should not render the final hour', function () {
-      const two = queryByText('8 PM');
+      const two = page.queryByText('8 PM');
       strictEqual(two, null);
     });
   });
   describe('Rendering', function () {
     beforeEach(function () {
-      ({ getAllByRole } = render(
+      page = render(
         <ScheduleView
           schedule={testCourseScheduleData}
           firstHour={8}
           lastHour={20}
         />
-      ));
+      );
     });
     it('Should render the blocks with the course prefix', function () {
-      const prefixBlocks = getAllByRole('heading');
+      const prefixBlocks = page.getAllByRole('heading');
       const actualPrefixes = prefixBlocks.reduce<string[]>(
         (list, { tagName, textContent }) => {
           if (tagName === 'H4') {
@@ -64,16 +65,126 @@ describe('ScheduleView', function () {
       );
       deepStrictEqual(actualPrefixes, expectedPrefixes);
     });
-    it('Should render all of the courseNumbers in lists', function () {
-      const actualNumbers = getAllByRole('listitem')
-        .map(({ textContent }) => textContent);
+    it('Should render all of the courseNumbers in as buttons inside lists', function () {
       const expectedNumbers = testCourseScheduleData
         .reduce<string[]>((list, { courses }) => [
         ...list,
         ...courses.map(({ courseNumber }) => courseNumber),
       ],
       []);
+      const actualNumbers = page.getAllByRole('listitem')
+        .map((li) => li.firstChild.textContent);
       deepStrictEqual(actualNumbers, expectedNumbers);
+    });
+    describe('Popover details', function () {
+      let testBlock: ScheduleViewResponseDTO;
+      let testMeeting: ScheduleEntry;
+      beforeEach(function () {
+        ([testBlock] = testCourseScheduleData);
+        ([testMeeting] = testBlock.courses);
+      });
+      context('When clicking on a course', function () {
+        it('Should display the full course name', function () {
+          const fullName = `${testBlock.coursePrefix} ${testMeeting.courseNumber}`;
+          // first check that that the full name is not on the page
+          const nameElement = page.queryByText(fullName);
+          strictEqual(nameElement, null);
+          const [testListButton] = page.getAllByText(testMeeting.courseNumber);
+          fireEvent.click(testListButton);
+          // Now make sure the full name is on the page
+          return page.findByText(fullName);
+        });
+        it('Should display the day the meeting is held', function () {
+          // first check that that the day name only appears once on the page
+          // In the column header
+          let dayName = page.queryAllByText(
+            dayEnumToString(testBlock.weekday)
+          );
+          strictEqual(dayName.length, 1);
+          const [testListButton] = page.getAllByText(testMeeting.courseNumber);
+          fireEvent.click(testListButton);
+          // Now make sure the room name is on the page
+          dayName = page.queryAllByText(
+            dayEnumToString(testBlock.weekday)
+          );
+          strictEqual(dayName.length, 2);
+        });
+        it('Should display the start and end time', function () {
+          const {
+            startHour,
+            startMinute,
+            endHour,
+            endMinute,
+          } = testBlock;
+          // first check that that the full time is not on the page
+          const displayStartTime = PGTime.toDisplay(
+            `${startHour}:${startMinute.toString().padStart(2, '0')}`
+          );
+          const displayEndTime = PGTime.toDisplay(
+            `${endHour}:${endMinute.toString().padStart(2, '0')}`
+          );
+          const timeElem = page.queryByText(`${displayStartTime} - ${displayEndTime}`);
+          strictEqual(timeElem, null);
+          const [testListButton] = page.getAllByText(testMeeting.courseNumber);
+          fireEvent.click(testListButton);
+          // Now make sure the room name is on the page
+          return page.findByText(`${displayStartTime} - ${displayEndTime}`);
+        });
+        it('Should display the room name', function () {
+          // first check that that the room name is not on the page
+          const roomName = page.queryByText(testMeeting.room);
+          strictEqual(roomName, null);
+          const [testListButton] = page.getAllByText(testMeeting.courseNumber);
+          fireEvent.click(testListButton);
+          // Now make sure the room name is on the page
+          return page.findByText(testMeeting.room);
+        });
+      });
+      context('When clicking on a course, then clicking elsewhere', function () {
+        it('Should close the popover', function () {
+          const [testListButton] = page.getAllByText(testMeeting.courseNumber);
+          fireEvent.click(testListButton);
+          // first check that that the room name is not on the page
+          page.getByText(testMeeting.room);
+          const heading = page.getByText(testBlock.coursePrefix);
+          fireEvent.click(heading);
+          // Now make sure that the room name is gone.
+          const roomElem = page.queryByText(testMeeting.room);
+          strictEqual(roomElem, null);
+        });
+      });
+    });
+    describe('Accessibility', function () {
+      it('Should not include any button roles on the page', function () {
+        // All buttons/popovers have aria-hidden set, so that screen readers
+        // will not show them
+        const buttonRoles = page.queryAllByRole('button');
+        strictEqual(buttonRoles.length, 0);
+      });
+      it('Should still display the Popover text for each entry', function () {
+        testCourseScheduleData.forEach(({
+          coursePrefix,
+          weekday,
+          startHour,
+          startMinute,
+          endHour,
+          endMinute,
+          courses,
+        }) => {
+          courses.forEach(({ courseNumber, room }) => {
+            const day = dayEnumToString(weekday);
+            const catalogNumber = `${coursePrefix} ${courseNumber}`;
+            const displayStartTime = PGTime.toDisplay(
+              `${startHour}:${startMinute.toString().padStart(2, '0')}`
+            );
+            const displayEndTime = PGTime.toDisplay(
+              `${endHour}:${endMinute.toString().padStart(2, '0')}`
+            );
+            const accessibleText = `${catalogNumber} on ${day}, ${displayStartTime} to ${displayEndTime} in ${room}`;
+            page.getByText(accessibleText);
+          });
+        });
+      });
     });
   });
 });

--- a/src/client/components/pages/Schedule/blocks/CourseListingButton.tsx
+++ b/src/client/components/pages/Schedule/blocks/CourseListingButton.tsx
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+/**
+ * An essentially unstyled button used to trigger the Popover containing the
+ * course details
+ */
+const CourseListingButton = styled.button.attrs({
+  type: 'button',
+})`
+  background: transparent;
+  border: none;
+  font-size: inherit;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  cursor: pointer;
+  text-align: left;
+`;
+
+export default CourseListingButton;

--- a/src/client/components/pages/Schedule/blocks/WeekBlock.tsx
+++ b/src/client/components/pages/Schedule/blocks/WeekBlock.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, ReactEventHandler } from 'react';
 import styled from 'styled-components';
 import DayBlock from './DayBlock';
 import { PGTime } from '../../../../../common/utils/PGTime';
@@ -37,6 +37,11 @@ interface WeekBlockProps {
    * appear in the WeekView
    */
   numColumns: number;
+
+  /**
+   * A click handler that can be used to clear the currently popped-over course
+   */
+  onClick?: ReactEventHandler;
 }
 
 /**
@@ -127,6 +132,7 @@ const WeekBlock: FunctionComponent<WeekBlockProps> = ({
   children,
   minuteResolution,
   rowHeight,
+  onClick,
 }) => {
   // Because our grid-rows do not correspond 1:1 with minutes in the day, we
   // divide by our minute resolution value to determine where our hour and
@@ -138,6 +144,7 @@ const WeekBlock: FunctionComponent<WeekBlockProps> = ({
       numRows={numRows}
       rowHeight={rowHeight}
       numColumns={numColumns}
+      onClick={onClick}
     >
       {Array.from(
         // Generate a row every 15 minutes
@@ -174,6 +181,10 @@ const WeekBlock: FunctionComponent<WeekBlockProps> = ({
       {children}
     </WeekBlockWrapper>
   );
+};
+
+WeekBlock.defaultProps = {
+  onClick: () => {},
 };
 
 export default WeekBlock;

--- a/src/client/components/pages/Schedule/blocks/index.ts
+++ b/src/client/components/pages/Schedule/blocks/index.ts
@@ -1,4 +1,5 @@
 export { default as CourseListing } from './CourseListing';
+export { default as CourseListingButton } from './CourseListingButton';
 export { default as DayBlock } from './DayBlock';
 export { default as SessionBlock } from './SessionBlock';
 export { default as WeekBlock } from './WeekBlock';

--- a/src/common/__tests__/data/schedule.ts
+++ b/src/common/__tests__/data/schedule.ts
@@ -1,9 +1,10 @@
 import { DAY } from '../../constants';
+import { ScheduleViewResponseDTO } from '../../dto/schedule/schedule.dto';
 
 /**
  * A fake set of data for the Schedule interface in the UI
  */
-export const testCourseScheduleData = [
+export const testCourseScheduleData: ScheduleViewResponseDTO[] = [
   {
     id: 'CSMON09001015FALL2018',
     coursePrefix: 'CS',
@@ -18,8 +19,6 @@ export const testCourseScheduleData = [
         id: '0b4adc13-5a53-489d-97e5-8cce379148a7',
         courseNumber: '165',
         isUndergraduate: true,
-        startTime: '09:00:00',
-        endTime: '10:15:00',
         campus: 'Cambridge',
         room: 'LISE Lab for Integrated Science &amp; Engr LISE_300_Third Floor Open Area',
       },
@@ -27,8 +26,6 @@ export const testCourseScheduleData = [
         id: '737fda78-bae4-49ea-b166-96218b642dfe',
         courseNumber: '282r',
         isUndergraduate: false,
-        startTime: '09:00:00',
-        endTime: '10:15:00',
         campus: 'Cambridge',
         room: 'Science Center ScienceCtr_Hall D',
       },
@@ -48,8 +45,6 @@ export const testCourseScheduleData = [
         id: 'b234a6d1-2ade-45bc-91fb-690ca41877f9',
         courseNumber: '121',
         isUndergraduate: true,
-        startTime: '09:00:00',
-        endTime: '10:15:00',
         campus: 'Cambridge',
         room: 'Bauer Laboratory Bauer G18 SCRB Lobby',
       },

--- a/src/common/dto/schedule/schedule.dto.ts
+++ b/src/common/dto/schedule/schedule.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { DAY } from 'common/constants';
 
-abstract class ScheduleEntry {
+export abstract class ScheduleEntry {
   @ApiProperty({
     example: 'c7b1fa3f-c5b0-478d-a29c-7f85a4d80109',
   })


### PR DESCRIPTION
This puts in the place the initial Popover effect on the schedule page, displaying a single information box next to a course number when clicking on it. A future ticket (#504) will add boxes next to every meeting of the same course in the schedule.

This will still need an accessibility review, but the current implementation:

1. Hides the button containing the course number and the popover from screen readers
2. Replicates the popover text inside of a "HiddenText" block that should replace the entire content of the list item.

This should give screen readers access to the same information contained in the popover, without needing to go through the click-to-display process.


## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #503

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
