### PR TITLE
Make termPattern optional

### DIFF
--- a/src/common/dto/courses/UpdateCourse.dto.ts
+++ b/src/common/dto/courses/UpdateCourse.dto.ts
@@ -92,6 +92,7 @@ export abstract class UpdateCourseDTO {
     enum: TERM_PATTERN,
   })
   @IsEnum(TERM_PATTERN)
+  @IsOptional()
   public termPattern: TERM_PATTERN;
 
   @ApiProperty({

--- a/tests/integration/server/course/course.controller.test.ts
+++ b/tests/integration/server/course/course.controller.test.ts
@@ -252,23 +252,6 @@ describe('Course API', function () {
           deepStrictEqual(response.status, HttpStatus.BAD_REQUEST);
           strictEqual(errorFields.includes('isSEAS'), true);
         });
-        it('reports a validation error when term pattern is missing', async function () {
-          authStub.resolves(adminUser);
-
-          const response = await request(api)
-            .post('/api/courses')
-            .send({ title: computerScienceCourse.title });
-
-          const body = response.body as BadRequestInfo;
-
-          // Collects all of the field names that contain errors
-          const errorFields = [];
-          body.message.map((errorInfo) => errorFields.push(errorInfo.property));
-
-          deepStrictEqual(response.ok, false);
-          deepStrictEqual(response.status, HttpStatus.BAD_REQUEST);
-          strictEqual(errorFields.includes('termPattern'), true);
-        });
       });
       describe('User is not a member of the admin group', function () {
         it('is inaccessible to unauthorized users', async function () {
@@ -387,23 +370,6 @@ describe('Course API', function () {
           deepStrictEqual(response.ok, false);
           deepStrictEqual(response.status, HttpStatus.BAD_REQUEST);
           strictEqual(errorFields.includes('isSEAS'), true);
-        });
-        it('reports a validation error when term pattern is missing', async function () {
-          authStub.resolves(adminUser);
-
-          const response = await request(api)
-            .put(`/api/courses/${computerScienceCourse.id}`)
-            .send({ title: computerScienceCourse.title });
-
-          const body = response.body as BadRequestInfo;
-
-          // Collects all of the field names that contain errors
-          const errorFields = [];
-          body.message.map((errorInfo) => errorFields.push(errorInfo.property));
-
-          deepStrictEqual(response.ok, false);
-          deepStrictEqual(response.status, HttpStatus.BAD_REQUEST);
-          strictEqual(errorFields.includes('termPattern'), true);
         });
       });
       describe('User is not a member of the admin group', function () {


### PR DESCRIPTION
This PR makes the `termPattern` field of the `UpdateCourse` DTO. The requirement of this field to not be null was causing erroneous validation errors to be thrown when trying to update course instances that had a null value for this field. This null value was originating in data imported from the old course planner system indicating null values are a perfectly acceptable value for this field. The database schema also allows for this, so the API disallowing null values here is likely an oversight(especially since this value isn't actually used by the app).

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #499

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
