### PR TITLE
Import HTTP status codes from api/

### DIFF
--- a/src/client/components/pages/Courses/EnrollmentModal.tsx
+++ b/src/client/components/pages/Courses/EnrollmentModal.tsx
@@ -23,10 +23,9 @@ import {
 import CourseInstanceResponseDTO, { Instance } from 'common/dto/courses/CourseInstanceResponse';
 import { TERM } from 'common/constants';
 import { TermKey } from 'common/constants/term';
-import { updateCourseInstance } from 'client/api';
+import { HTTP_STATUS, updateCourseInstance } from 'client/api';
 import CourseInstanceUpdateDTO from 'common/dto/courses/CourseInstanceUpdate.dto';
 import { AxiosError } from 'axios';
-import { HttpStatus } from '@nestjs/common';
 import { EnrollmentField } from './tableFields';
 import { BadRequestInfo } from './CourseModal';
 
@@ -275,7 +274,7 @@ const EnrollmentModal: FunctionComponent<EnrollmentModalProps> = ({
           const {
             response,
           } = error as AxiosError;
-          if (response.status === HttpStatus.BAD_REQUEST) {
+          if (response.status === HTTP_STATUS.BAD_REQUEST) {
             const errors = [
               ...(response.data as BadRequestInfo).message,
             ].map(

--- a/src/client/components/pages/Courses/__tests__/EnrollmentModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/EnrollmentModal.test.tsx
@@ -10,8 +10,8 @@ import {
 import { render } from 'test-utils';
 import { cs50CourseInstance } from 'testData';
 import request from 'client/api/request';
+import { HTTP_STATUS } from 'client/api';
 import { TERM } from 'common/constants';
-import { HttpStatus } from '@nestjs/common';
 import { AxiosResponse } from 'axios';
 import EnrollmentModal from '../EnrollmentModal';
 
@@ -44,9 +44,9 @@ describe('Enrollment Modal', function () {
       // Set the fake API up to reject
       putStub.rejects({
         response: {
-          status: HttpStatus.BAD_REQUEST,
+          status: HTTP_STATUS.BAD_REQUEST,
           data: {
-            statusCode: HttpStatus.BAD_REQUEST,
+            statusCode: HTTP_STATUS.BAD_REQUEST,
             error: 'Bad Request',
             message: [
               {
@@ -65,9 +65,9 @@ describe('Enrollment Modal', function () {
       // Set the fake API up to reject
       putStub.rejects({
         response: {
-          status: HttpStatus.INTERNAL_SERVER_ERROR,
+          status: HTTP_STATUS.INTERNAL_SERVER_ERROR,
           data: {
-            statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+            statusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR,
             message: 'Internal server error',
           },
         } as Partial<AxiosResponse>,


### PR DESCRIPTION
HTTP status codes were re-defined in api/ for client-side code rather than importing the enum defined in `@nestjs/core`. This is because importing `@nestjs/core` in client-side code caused build failures.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #517

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
