### PR TITLE
Fix addAcademicYear Unhandled Promise Rejection Warning

### DIFF
--- a/src/server/semester/semester.service.ts
+++ b/src/server/semester/semester.service.ts
@@ -262,12 +262,12 @@ export class SemesterService implements OnApplicationBootstrap {
     return null;
   }
 
-  public onApplicationBootstrap(): Promise<void> {
+  public async onApplicationBootstrap(): Promise<void> {
     const today = new Date();
     if (this.config.isProduction && today.getMonth() === MONTH.JUN) {
       const yearToAdd = today.getFullYear() + 4;
       try {
-        return this.addAcademicYear(yearToAdd);
+        return await this.addAcademicYear(yearToAdd);
       } catch (e) {
         this.logService.error(e);
       }


### PR DESCRIPTION
Originally without the `await` preceding the call of `addAcademicYear` in `onApplicationBootstrap`, the error thrown in `addAcademicYear` was not being handled properly. Adding this `await` makes it so that we can catch the error and log it appropriately.

The following error was getting thrown as a unhandled promise instead of getting logged: ```UnhandledPromiseRejectionWarning: Error: Cannot create requested academic year until preceding academic year is created."```

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [ ] Normal <!-- New piece of functionality -->
- [x] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #519

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
