### PR TITLE
Update Mark-One version to 0.4.6 to fix meeting timeslot bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "lodash.merge": "^4.6.2",
         "lodash.set": "^4.3.2",
         "loglevel": "^1.6.8",
-        "mark-one": "^0.4.5",
+        "mark-one": "^0.4.6",
         "morgan": "^1.10.0",
         "nestjs-redis": "^1.3.3",
         "nestjs-session": "^1.0.0",
@@ -10344,9 +10344,9 @@
       }
     },
     "node_modules/mark-one": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.4.5.tgz",
-      "integrity": "sha512-YowWOOEbVQvHZDPXcW7Z8mMxxkEMeO5xhI8NBR89H1BybiXmf/r/mE261IBLjeDwGRl8mfxcnCDIff8Q0WA6GA==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.4.6.tgz",
+      "integrity": "sha512-9F56P+cfSvxfLAmvyAew29wb78Xw8KzxdV+NNijH5uXHBtIXwetfRZ7ZpGlrDcvLY9llnh9fI0yqstks6oSMbw==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",
         "@openfonts/open-sans_all": "^1.43.0",
@@ -27132,9 +27132,9 @@
       }
     },
     "mark-one": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.4.5.tgz",
-      "integrity": "sha512-YowWOOEbVQvHZDPXcW7Z8mMxxkEMeO5xhI8NBR89H1BybiXmf/r/mE261IBLjeDwGRl8mfxcnCDIff8Q0WA6GA==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.4.6.tgz",
+      "integrity": "sha512-9F56P+cfSvxfLAmvyAew29wb78Xw8KzxdV+NNijH5uXHBtIXwetfRZ7ZpGlrDcvLY9llnh9fI0yqstks6oSMbw==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",
         "@openfonts/open-sans_all": "^1.43.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.set": "^4.3.2",
     "loglevel": "^1.6.8",
-    "mark-one": "^0.4.5",
+    "mark-one": "^0.4.6",
     "morgan": "^1.10.0",
     "nestjs-redis": "^1.3.3",
     "nestjs-session": "^1.0.0",


### PR DESCRIPTION
This PR is to integrate the changes made in PR [#134](https://github.com/seas-computing/mark-one/pull/134) to remove the padding from the `DropListItem` component. The padding was removed to fix the bug where users were clicking on the padding of each timeslot dropdown item and seeing the menu collapse without the item itself not populating in the start and end time slots of the meeting modal.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #515

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
