### PR TITLE
Add Instructional Text to Multi Year Plan tab for info.seas only

### DIFF
--- a/src/client/components/layout/InstructionalTextBox.tsx
+++ b/src/client/components/layout/InstructionalTextBox.tsx
@@ -8,6 +8,9 @@ const StyledInstructionalTextBox = styled.div`
   padding: ${fromTheme('ws', 'xsmall')};
   font-family: ${fromTheme('font', 'note', 'family')};
   font-size: ${fromTheme('font', 'note', 'size')};
+  & p {
+    margin-bottom: 0.5em;
+  }
 `;
 
 export default StyledInstructionalTextBox;

--- a/src/client/components/layout/InstructionalTextBox.tsx
+++ b/src/client/components/layout/InstructionalTextBox.tsx
@@ -1,0 +1,13 @@
+import { fromTheme } from 'mark-one';
+import styled from 'styled-components';
+
+const StyledInstructionalTextBox = styled.div`
+  border: ${fromTheme('border', 'light')};
+  margin-top: ${fromTheme('ws', 'xsmall')};
+  margin-bottom: ${fromTheme('ws', 'xsmall')};
+  padding: ${fromTheme('ws', 'xsmall')};
+  font-family: ${fromTheme('font', 'note', 'family')};
+  font-size: ${fromTheme('font', 'note', 'size')};
+`;
+
+export default StyledInstructionalTextBox;

--- a/src/client/components/layout/InstructionalTextBox.tsx
+++ b/src/client/components/layout/InstructionalTextBox.tsx
@@ -1,7 +1,7 @@
 import { fromTheme } from 'mark-one';
 import styled from 'styled-components';
 
-const StyledInstructionalTextBox = styled.div`
+const InstructionalTextBox = styled.div`
   border: ${fromTheme('border', 'light')};
   margin-top: ${fromTheme('ws', 'xsmall')};
   margin-bottom: ${fromTheme('ws', 'xsmall')};
@@ -13,4 +13,4 @@ const StyledInstructionalTextBox = styled.div`
   }
 `;
 
-export default StyledInstructionalTextBox;
+export default InstructionalTextBox;

--- a/src/client/components/pages/MultiYearPlan.tsx
+++ b/src/client/components/pages/MultiYearPlan.tsx
@@ -224,33 +224,36 @@ const MultiYearPlan: FunctionComponent = (): ReactElement => {
         )
         : (
           <>
-            <StyledInstructionalTextBox>
-              <p>How to use this site:</p>
-              <p>
-                This site provides a snapshot of the current and 4-year course
-                plan for courses offered by the Harvard School of Engineering
-                and Applied Sciences. It also lists some specific courses in
-                Earth and Planetary Sciences (EPS) that are typically taught by
-                faculty with SEAS appointments.
-              </p>
-              <p>
-                <b>
-                  Disclaimer: this course plan can change frequently and
-                  should be considered as a tentative, unofficial
-                  guideline only.
-                </b>
-              </p>
-              <p>
-                <a href="https://courses.my.harvard.edu/" target="_blank" rel="noreferrer">
-                  Courses.my.harvard.edu
-                </a>
-                {' '}
-                is the official listing of courses. If a course is blank it
-                means it does not have an assigned instructor yet and/or it is
-                not planned to be offered.
-              </p>
-              <p>Direct questions to: seas-course-planner@g.harvard.edu</p>
-            </StyledInstructionalTextBox>
+            {window.location.hostname === publicHostname
+              && (
+                <StyledInstructionalTextBox>
+                  <p>How to use this site:</p>
+                  <p>
+                    This site provides a snapshot of the current and 4-year
+                    course plan for courses offered by the Harvard School of
+                    Engineering and Applied Sciences. It also lists some
+                    specific courses in Earth and Planetary Sciences (EPS)
+                    that are typically taught by faculty with SEAS appointments.
+                  </p>
+                  <p>
+                    <b>
+                      Disclaimer: this course plan can change frequently and
+                      should be considered as a tentative, unofficial
+                      guideline only.
+                    </b>
+                  </p>
+                  <p>
+                    <a href="https://courses.my.harvard.edu/" target="_blank" rel="noreferrer">
+                      Courses.my.harvard.edu
+                    </a>
+                    {' '}
+                    is the official listing of courses. If a course is blank
+                    it means it does not have an assigned instructor yet
+                    and/or it is planned to be offered.
+                  </p>
+                  <p>Direct questions to: seas-course-planner@g.harvard.edu</p>
+                </StyledInstructionalTextBox>
+              )}
             <Table>
               <TableHead>
                 <TableRow isStriped>

--- a/src/client/components/pages/MultiYearPlan.tsx
+++ b/src/client/components/pages/MultiYearPlan.tsx
@@ -211,6 +211,8 @@ const MultiYearPlan: FunctionComponent = (): ReactElement => {
   // Calculate the list of semesters once first to avoid recalculation
   const semesters = getSemestersFromYear(metadata.currentAcademicYear);
 
+  const publicHostname = new URL(process.env.PUBLIC_CLIENT_URL).hostname;
+
   return (
     <div className="multi-year-plan">
       {fetching
@@ -220,94 +222,118 @@ const MultiYearPlan: FunctionComponent = (): ReactElement => {
           </div>
         )
         : (
-          <Table>
-            <TableHead>
-              <TableRow isStriped>
-                <TableHeadingCell scope="col">Catalog Prefix</TableHeadingCell>
-                <TableHeadingCell scope="col">Catalog Number</TableHeadingCell>
-                <TableHeadingCell scope="col">Title</TableHeadingCell>
-                <>
-                  {yearsHeaders(currentMultiYearPlanList, semesters)}
-                </>
-              </TableRow>
-              <TableRow isStriped>
-                <TableHeadingCell scope="col">
-                  <Dropdown
-                    options={
-                      [{ value: 'All', label: 'All' }]
-                        .concat(metadata.catalogPrefixes.map((prefix) => ({
-                          value: prefix,
-                          label: prefix,
-                        })))
-                    }
-                    value={catalogPrefixValue}
-                    name="catalogPrefixValue"
-                    id="catalogPrefixValue"
-                    label="The table will be filtered as selected in the catalog prefix dropdown filter"
-                    isLabelVisible={false}
-                    hideError
-                    onChange={(event:React.ChangeEvent<HTMLInputElement>) => {
-                      setCatalogPrefixValue(event.currentTarget.value);
-                    }}
-                  />
-                </TableHeadingCell>
-                <TableHeadingCell scope="col">
-                  <TextInput
-                    id="catalogNumberValue"
-                    name="catalogNumberValue"
-                    value={catalogNumberValue}
-                    placeholder="Filter by Catalog Number"
-                    label="The table will be filtered as characters are typed in this catalog number filter field"
-                    isLabelVisible={false}
-                    hideError
-                    onChange={(event:React.ChangeEvent<HTMLInputElement>) => {
-                      setCatalogNumberValue(event.currentTarget.value);
-                    }}
-                  />
-                </TableHeadingCell>
-                <TableHeadingCell scope="col">
-                  <TextInput
-                    id="courseTitleValue"
-                    name="courseTitleValue"
-                    value={courseTitleValue}
-                    placeholder="Filter by Course Title"
-                    label="The table will be filtered as characters are typed in this course title filter field"
-                    isLabelVisible={false}
-                    hideError
-                    onChange={(event:React.ChangeEvent<HTMLInputElement>) => {
-                      setCourseTitleValue(event.currentTarget.value);
-                    }}
-                  />
-                </TableHeadingCell>
-                <>
-                  {instructorFilters(currentMultiYearPlanList, semesters)}
-                </>
-              </TableRow>
-            </TableHead>
-            <TableBody isScrollable>
-              {filteredMultiYearPlans()
-                .map((course, courseIndex): TableRow => (
-                  <TableRow isStriped={courseIndex % 2 === 1} key={course.id}>
-                    <TableCell
-                      verticalAlignment={VALIGN.TOP}
-                      backgroundColor={getCatPrefixColor(course.catalogPrefix)}
-                    >
-                      {course.catalogPrefix}
-                    </TableCell>
-                    <TableRowHeadingCell verticalAlignment={VALIGN.TOP} scope="row">
-                      {course.catalogNumber}
-                    </TableRowHeadingCell>
-                    <TableCell verticalAlignment={VALIGN.TOP}>
-                      {course.title}
-                    </TableCell>
-                    <>
-                      {courseInstance(course, semesters)}
-                    </>
-                  </TableRow>
-                ))}
-            </TableBody>
-          </Table>
-
+          <>
+            <div>
+              <p>How to use this site:</p>
+              <p>
+                This site provides a snapshot of the current and 4-year course
+                plan for courses offered by the Harvard School of Engineering
+                and Applied Sciences. It also lists some specific courses in
+                Earth and Planetary Sciences (EPS) that are typically taught by
+                faculty with SEAS appointments.
+              </p>
+              <p>
+                <b>
+                  Disclaimer: this course plan can change frequently and
+                  should be considered as a tentative, unofficial
+                  guideline only.
+                </b>
+              </p>
+              <p>
+                Courses.my.harvard.edu is the official listing of courses.
+                If a course is blank it means it does not have an assigned
+                instructor yet and/or it is not planned to be offered.
+              </p>
+              <p>Direct questions to: seas-course-planner@g.harvard.edu</p>
+            </div>
+            <Table>
+              <TableHead>
+                <TableRow isStriped>
+                  <TableHeadingCell scope="col">Catalog Prefix</TableHeadingCell>
+                  <TableHeadingCell scope="col">Catalog Number</TableHeadingCell>
+                  <TableHeadingCell scope="col">Title</TableHeadingCell>
+                  <>
+                    {yearsHeaders(currentMultiYearPlanList, semesters)}
+                  </>
+                </TableRow>
+                <TableRow isStriped>
+                  <TableHeadingCell scope="col">
+                    <Dropdown
+                      options={
+                        [{ value: 'All', label: 'All' }]
+                          .concat(metadata.catalogPrefixes.map((prefix) => ({
+                            value: prefix,
+                            label: prefix,
+                          })))
+                      }
+                      value={catalogPrefixValue}
+                      name="catalogPrefixValue"
+                      id="catalogPrefixValue"
+                      label="The table will be filtered as selected in the catalog prefix dropdown filter"
+                      isLabelVisible={false}
+                      hideError
+                      onChange={(event:React.ChangeEvent<HTMLInputElement>) => {
+                        setCatalogPrefixValue(event.currentTarget.value);
+                      }}
+                    />
+                  </TableHeadingCell>
+                  <TableHeadingCell scope="col">
+                    <TextInput
+                      id="catalogNumberValue"
+                      name="catalogNumberValue"
+                      value={catalogNumberValue}
+                      placeholder="Filter by Catalog Number"
+                      label="The table will be filtered as characters are typed in this catalog number filter field"
+                      isLabelVisible={false}
+                      hideError
+                      onChange={(event:React.ChangeEvent<HTMLInputElement>) => {
+                        setCatalogNumberValue(event.currentTarget.value);
+                      }}
+                    />
+                  </TableHeadingCell>
+                  <TableHeadingCell scope="col">
+                    <TextInput
+                      id="courseTitleValue"
+                      name="courseTitleValue"
+                      value={courseTitleValue}
+                      placeholder="Filter by Course Title"
+                      label="The table will be filtered as characters are typed in this course title filter field"
+                      isLabelVisible={false}
+                      hideError
+                      onChange={(event:React.ChangeEvent<HTMLInputElement>) => {
+                        setCourseTitleValue(event.currentTarget.value);
+                      }}
+                    />
+                  </TableHeadingCell>
+                  <>
+                    {instructorFilters(currentMultiYearPlanList, semesters)}
+                  </>
+                </TableRow>
+              </TableHead>
+              <TableBody isScrollable>
+                {filteredMultiYearPlans()
+                  .map((course, courseIndex): TableRow => (
+                    <TableRow isStriped={courseIndex % 2 === 1} key={course.id}>
+                      <TableCell
+                        verticalAlignment={VALIGN.TOP}
+                        backgroundColor={getCatPrefixColor(course.catalogPrefix)}
+                      >
+                        {course.catalogPrefix}
+                      </TableCell>
+                      <TableRowHeadingCell verticalAlignment={VALIGN.TOP} scope="row">
+                        {course.catalogNumber}
+                      </TableRowHeadingCell>
+                      <TableCell verticalAlignment={VALIGN.TOP}>
+                        {course.title}
+                      </TableCell>
+                      <>
+                        {courseInstance(course, semesters)}
+                      </>
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
+          </>
         )}
     </div>
   );

--- a/src/client/components/pages/MultiYearPlan.tsx
+++ b/src/client/components/pages/MultiYearPlan.tsx
@@ -34,6 +34,7 @@ import { getSemestersFromYear, SemesterInfo } from 'common/utils/multiYearPlanHe
 import { getCatPrefixColor } from '../../../common/constants';
 import { listFilter } from './Filter';
 import { filterPlansByInstructors } from './utils/filterByInstructorValues';
+import StyledInstructionalTextBox from '../layout/InstructionalTextBox';
 
 /**
  * The component represents the Multi Year Plan page, which will be rendered at
@@ -223,7 +224,7 @@ const MultiYearPlan: FunctionComponent = (): ReactElement => {
         )
         : (
           <>
-            <div>
+            <StyledInstructionalTextBox>
               <p>How to use this site:</p>
               <p>
                 This site provides a snapshot of the current and 4-year course
@@ -249,7 +250,7 @@ const MultiYearPlan: FunctionComponent = (): ReactElement => {
                 not planned to be offered.
               </p>
               <p>Direct questions to: seas-course-planner@g.harvard.edu</p>
-            </div>
+            </StyledInstructionalTextBox>
             <Table>
               <TableHead>
                 <TableRow isStriped>

--- a/src/client/components/pages/MultiYearPlan.tsx
+++ b/src/client/components/pages/MultiYearPlan.tsx
@@ -34,7 +34,7 @@ import { getSemestersFromYear, SemesterInfo } from 'common/utils/multiYearPlanHe
 import { getCatPrefixColor } from '../../../common/constants';
 import { listFilter } from './Filter';
 import { filterPlansByInstructors } from './utils/filterByInstructorValues';
-import StyledInstructionalTextBox from '../layout/InstructionalTextBox';
+import InstructionalTextBox from '../layout/InstructionalTextBox';
 import { WindowUtils } from './utils/getHostname';
 
 /**
@@ -227,7 +227,7 @@ const MultiYearPlan: FunctionComponent = (): ReactElement => {
           <>
             {WindowUtils.getHostname() === publicHostname
               && (
-                <StyledInstructionalTextBox>
+                <InstructionalTextBox>
                   <p>How to use this site:</p>
                   <p>
                     This site provides a snapshot of the current and 4-year
@@ -257,7 +257,7 @@ const MultiYearPlan: FunctionComponent = (): ReactElement => {
                     {' '}
                     <a href="mailto:seas-course-planner@g.harvard.edu">seas-course-planner@g.harvard.edu</a>
                   </p>
-                </StyledInstructionalTextBox>
+                </InstructionalTextBox>
               )}
             <Table>
               <TableHead>

--- a/src/client/components/pages/MultiYearPlan.tsx
+++ b/src/client/components/pages/MultiYearPlan.tsx
@@ -252,7 +252,11 @@ const MultiYearPlan: FunctionComponent = (): ReactElement => {
                     it means it does not have an assigned instructor yet
                     and/or it is planned to be offered.
                   </p>
-                  <p>Direct questions to: seas-course-planner@g.harvard.edu</p>
+                  <p>
+                    Direct questions to:
+                    {' '}
+                    <a href="mailto:seas-course-planner@g.harvard.edu">seas-course-planner@g.harvard.edu</a>
+                  </p>
                 </StyledInstructionalTextBox>
               )}
             <Table>

--- a/src/client/components/pages/MultiYearPlan.tsx
+++ b/src/client/components/pages/MultiYearPlan.tsx
@@ -35,6 +35,7 @@ import { getCatPrefixColor } from '../../../common/constants';
 import { listFilter } from './Filter';
 import { filterPlansByInstructors } from './utils/filterByInstructorValues';
 import StyledInstructionalTextBox from '../layout/InstructionalTextBox';
+import { WindowUtils } from './utils/getHostname';
 
 /**
  * The component represents the Multi Year Plan page, which will be rendered at
@@ -224,7 +225,7 @@ const MultiYearPlan: FunctionComponent = (): ReactElement => {
         )
         : (
           <>
-            {window.location.hostname === publicHostname
+            {WindowUtils.getHostname() === publicHostname
               && (
                 <StyledInstructionalTextBox>
                   <p>How to use this site:</p>

--- a/src/client/components/pages/MultiYearPlan.tsx
+++ b/src/client/components/pages/MultiYearPlan.tsx
@@ -240,9 +240,13 @@ const MultiYearPlan: FunctionComponent = (): ReactElement => {
                 </b>
               </p>
               <p>
-                Courses.my.harvard.edu is the official listing of courses.
-                If a course is blank it means it does not have an assigned
-                instructor yet and/or it is not planned to be offered.
+                <a href="https://courses.my.harvard.edu/" target="_blank" rel="noreferrer">
+                  Courses.my.harvard.edu
+                </a>
+                {' '}
+                is the official listing of courses. If a course is blank it
+                means it does not have an assigned instructor yet and/or it is
+                not planned to be offered.
               </p>
               <p>Direct questions to: seas-course-planner@g.harvard.edu</p>
             </div>

--- a/src/client/components/pages/MultiYearPlan.tsx
+++ b/src/client/components/pages/MultiYearPlan.tsx
@@ -321,7 +321,9 @@ const MultiYearPlan: FunctionComponent = (): ReactElement => {
                     <TableRow isStriped={courseIndex % 2 === 1} key={course.id}>
                       <TableCell
                         verticalAlignment={VALIGN.TOP}
-                        backgroundColor={getCatPrefixColor(course.catalogPrefix)}
+                        backgroundColor={
+                          getCatPrefixColor(course.catalogPrefix)
+                        }
                       >
                         {course.catalogPrefix}
                       </TableCell>

--- a/src/client/components/pages/__tests__/MultiYearPlan.test.tsx
+++ b/src/client/components/pages/__tests__/MultiYearPlan.test.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { strictEqual } from 'assert';
-import { fireEvent, wait, within } from '@testing-library/react';
+import {
+  BoundFunction,
+  FindByText,
+  fireEvent,
+  QueryByText,
+  wait,
+  within,
+} from '@testing-library/react';
 import {
   stub,
   SinonStub,
@@ -13,230 +20,263 @@ import { testFourYearPlan, error } from 'testData';
 import MultiYearPlan from '../MultiYearPlan';
 import * as filters from '../Filter';
 import * as instructorFilters from '../utils/filterByInstructorValues';
+import { WindowUtils } from '../utils/getHostname';
 
 describe('MultiYearPlan', function () {
   let getStub: SinonStub;
+  let windowStub: SinonStub;
   let dispatchMessage: SinonStub;
   let listFilterSpy: SinonSpy;
   let facultyFilterSpy: SinonSpy;
   const testData = testFourYearPlan;
-
-  beforeEach(function () {
-    getStub = stub(MultiYearPlanAPI, 'getMultiYearPlan');
-    dispatchMessage = stub();
-    getStub.resolves(testData);
-    listFilterSpy = spy(filters, 'listFilter');
-    facultyFilterSpy = spy(instructorFilters, 'filterPlansByInstructors');
-  });
-  describe('rendering', function () {
-    it('creates a table', async function () {
-      const { findByRole } = render(
-        <MultiYearPlan />
-      );
-      return findByRole('table');
+  const instructionalText = 'How to use this site:';
+  context('when visiting planning.seas', function () {
+    let queryByText: BoundFunction<QueryByText>;
+    beforeEach(function () {
+      getStub = stub(MultiYearPlanAPI, 'getMultiYearPlan');
+      windowStub = stub(WindowUtils, 'getHostname');
+      dispatchMessage = stub();
+      getStub.resolves(testData);
+      windowStub.returns(new URL(process.env.CLIENT_URL).hostname);
+      listFilterSpy = spy(filters, 'listFilter');
+      facultyFilterSpy = spy(instructorFilters, 'filterPlansByInstructors');
     });
-  });
-  describe('data fetching', function () {
-    context('when the request succeeds', function () {
-      context('with records', function () {
-        it('displays the MYP information', async function () {
-          const { findByText } = render(
-            <MultiYearPlan />
-          );
-          strictEqual(getStub.callCount, 1);
-          const { title } = testData[0];
-          return findByText(title);
-        });
-        it('displays the correct number of rows in the table', async function () {
-          const { getAllByRole } = render(
-            <MultiYearPlan />
-          );
-          await wait(() => getAllByRole('row').length > 1);
-          const rows = getAllByRole('row');
-          strictEqual(rows.length, testData.length + 2);
-        });
-        it('displays the correct content in the table cells', async function () {
-          const { getAllByRole } = render(
-            <MultiYearPlan />
-          );
-          await wait(() => getAllByRole('row').length > 1);
-          const rows = Array.from(getAllByRole('row')) as HTMLTableRowElement[];
-          const rowsContent = rows
-            .map(
-              (row) => (Array.from(row.cells).map((cell) => cell.textContent))
+    describe('rendering', function () {
+      it('creates a table', async function () {
+        const { findByRole } = render(
+          <MultiYearPlan />
+        );
+        return findByRole('table');
+      });
+      it('does not display instructional text', function () {
+        ({ queryByText } = render(
+          <MultiYearPlan />
+        ));
+        strictEqual(queryByText(instructionalText), null);
+      });
+    });
+    describe('data fetching', function () {
+      context('when the request succeeds', function () {
+        context('with records', function () {
+          it('displays the MYP information', async function () {
+            const { findByText } = render(
+              <MultiYearPlan />
             );
-          strictEqual(rowsContent[2][0], testData[0].catalogPrefix);
-          strictEqual(rowsContent[2][1], testData[0].catalogNumber);
-          strictEqual(rowsContent[2][2], testData[0].title);
-          const facultyNames1 = testData[0].semesters
-            .map((semester) => semester.instance.faculty.map((f) => f.displayName).join(''))
-            .join();
-          const facultyNames2 = rowsContent[2].slice(3).join();
-          strictEqual(facultyNames1, facultyNames2);
+            strictEqual(getStub.callCount, 1);
+            const { title } = testData[0];
+            return findByText(title);
+          });
+          it('displays the correct number of rows in the table', async function () {
+            const { getAllByRole } = render(
+              <MultiYearPlan />
+            );
+            await wait(() => getAllByRole('row').length > 1);
+            const rows = getAllByRole('row');
+            strictEqual(rows.length, testData.length + 2);
+          });
+          it('displays the correct content in the table cells', async function () {
+            const { getAllByRole } = render(
+              <MultiYearPlan />
+            );
+            await wait(() => getAllByRole('row').length > 1);
+            const rows = Array.from(getAllByRole('row')) as HTMLTableRowElement[];
+            const rowsContent = rows
+              .map(
+                (row) => (Array.from(row.cells).map((cell) => cell.textContent))
+              );
+            strictEqual(rowsContent[2][0], testData[0].catalogPrefix);
+            strictEqual(rowsContent[2][1], testData[0].catalogNumber);
+            strictEqual(rowsContent[2][2], testData[0].title);
+            const facultyNames1 = testData[0].semesters
+              .map((semester) => semester.instance.faculty.map((f) => f.displayName).join(''))
+              .join();
+            const facultyNames2 = rowsContent[2].slice(3).join();
+            strictEqual(facultyNames1, facultyNames2);
+          });
+        });
+        context('with no records', function () {
+          let emptyTestData: unknown[];
+          beforeEach(function () {
+            emptyTestData = [];
+            getStub.resolves(emptyTestData);
+          });
+          afterEach(function () {
+            getStub.restore();
+          });
+          it('only displays the header row', async function () {
+            const { getAllByRole } = render(
+              <MultiYearPlan />
+            );
+            await wait(() => getAllByRole('row').length === emptyTestData.length + 1);
+            const rows = getAllByRole('row');
+            strictEqual(rows.length, 2);
+          });
         });
       });
-      context('with no records', function () {
-        let emptyTestData: unknown[];
+      context('when the request fails', function () {
+        const emptyTestData = [];
         beforeEach(function () {
-          emptyTestData = [];
-          getStub.resolves(emptyTestData);
+          getStub.rejects(error);
         });
         afterEach(function () {
           getStub.restore();
         });
-        it('only displays the header row', async function () {
+        it('should throw an error', async function () {
           const { getAllByRole } = render(
-            <MultiYearPlan />
+            <MultiYearPlan />,
+            { dispatchMessage }
           );
           await wait(() => getAllByRole('row').length === emptyTestData.length + 1);
-          const rows = getAllByRole('row');
-          strictEqual(rows.length, 2);
+          strictEqual(dispatchMessage.callCount, 1);
         });
       });
     });
-    context('when the request fails', function () {
-      const emptyTestData = [];
-      beforeEach(function () {
-        getStub.rejects(error);
+    describe('data filtering', function () {
+      describe('Catalog Prefix', function () {
+        context('when "All" is selected', function () {
+          it('calls the listFilter once for each filter except the dropdown', async function () {
+            const { getAllByRole } = render(
+              <MultiYearPlan />
+            );
+            await wait(() => getAllByRole('row').length > 1);
+            const rows = getAllByRole('row');
+            const utils = within(rows[1]);
+            const catalogPrefixInput = utils.queryByLabelText('The table will be filtered as selected in the catalog prefix dropdown filter');
+            listFilterSpy.resetHistory();
+            fireEvent.change(catalogPrefixInput, { target: { value: 'All' } });
+            strictEqual(listFilterSpy.callCount, 2);
+          });
+        });
+        context('when any other value is selected', function () {
+          it('calls the listFilter function once for each filter', async function () {
+            const { getAllByRole } = render(
+              <MultiYearPlan />
+            );
+            await wait(() => getAllByRole('row').length > 1);
+            const rows = getAllByRole('row');
+            const utils = within(rows[1]);
+            const catalogPrefixInput = utils.queryByLabelText('The table will be filtered as selected in the catalog prefix dropdown filter');
+            listFilterSpy.resetHistory();
+            fireEvent.change(catalogPrefixInput, { target: { value: 'AnyValue' } });
+            strictEqual(listFilterSpy.callCount, 3);
+          });
+        });
       });
-      afterEach(function () {
-        getStub.restore();
+      describe('Catalog Number', function () {
+        context('when a value is entered', function () {
+          it('calls the listFilter function once for each filter except the dropdown', async function () {
+            const { getAllByRole } = render(
+              <MultiYearPlan />
+            );
+            await wait(() => getAllByRole('row').length > 1);
+            const rows = getAllByRole('row');
+            const utils = within(rows[1]);
+            const catalogNumber = utils.queryByLabelText('The table will be filtered as characters are typed in this catalog number filter field');
+            listFilterSpy.resetHistory();
+            fireEvent.change(catalogNumber, { target: { value: 'AnyValue' } });
+            strictEqual(listFilterSpy.callCount, 2);
+          });
+        });
+        context('when no value is entered', function () {
+          it('does not call the listFilter function', async function () {
+            const { getAllByRole } = render(
+              <MultiYearPlan />
+            );
+            await wait(() => getAllByRole('row').length > 1);
+            listFilterSpy.resetHistory();
+            strictEqual(listFilterSpy.callCount, 0);
+          });
+        });
       });
-      it('should throw an error', async function () {
-        const { getAllByRole } = render(
-          <MultiYearPlan />,
-          { dispatchMessage }
-        );
-        await wait(() => getAllByRole('row').length === emptyTestData.length + 1);
-        strictEqual(dispatchMessage.callCount, 1);
+      describe('Course Title', function () {
+        context('when a value is entered', function () {
+          it('calls the listFilter function once for each filter except the dropdown', async function () {
+            const { getAllByRole } = render(
+              <MultiYearPlan />
+            );
+            await wait(() => getAllByRole('row').length > 1);
+            const rows = getAllByRole('row');
+            const utils = within(rows[1]);
+            const courseTitle = utils.queryByLabelText('The table will be filtered as characters are typed in this course title filter field');
+            listFilterSpy.resetHistory();
+            fireEvent.change(courseTitle, { target: { value: 'AnyValue' } });
+            strictEqual(listFilterSpy.callCount, 2);
+          });
+        });
+        context('when no value is entered', function () {
+          it('does not call the listFilter function', async function () {
+            const { getAllByRole } = render(
+              <MultiYearPlan />
+            );
+            await wait(() => getAllByRole('row').length > 1);
+            listFilterSpy.resetHistory();
+            strictEqual(listFilterSpy.callCount, 0);
+          });
+        });
+      });
+      describe('Instructors', function () {
+        context('when a value is entered', function () {
+          context('for all instructor fields', function () {
+            it('calls the filterPlansByInstructors once per field', async function () {
+              const { getAllByRole } = render(
+                <MultiYearPlan />
+              );
+              await wait(() => getAllByRole('row').length > 1);
+              const rows = getAllByRole('row');
+              const utils = within(rows[1]);
+              const instructorFields = utils.queryAllByLabelText('The table will be filtered as characters are typed in this instructors filter field');
+              facultyFilterSpy.resetHistory();
+              instructorFields.forEach((instructorField) => {
+                fireEvent.change(instructorField, { target: { value: 'AnyValue' } });
+              });
+              strictEqual(facultyFilterSpy.callCount, instructorFields.length);
+            });
+          });
+          context('for one instructor field', function () {
+            it('calls the filterPlansByInstructors once', async function () {
+              const { getAllByRole } = render(
+                <MultiYearPlan />
+              );
+              await wait(() => getAllByRole('row').length > 1);
+              const rows = getAllByRole('row');
+              const utils = within(rows[1]);
+              const instructorFields = utils.queryAllByLabelText('The table will be filtered as characters are typed in this instructors filter field');
+              facultyFilterSpy.resetHistory();
+              fireEvent.change(instructorFields[0], { target: { value: 'AnyValue' } });
+              strictEqual(facultyFilterSpy.callCount, 1);
+            });
+          });
+        });
+        context('when no value is entered', function () {
+          it('does not call the filterPlansByInstructors function', async function () {
+            const { getAllByRole } = render(
+              <MultiYearPlan />
+            );
+            await wait(() => getAllByRole('row').length > 1);
+            facultyFilterSpy.resetHistory();
+            strictEqual(facultyFilterSpy.callCount, 0);
+          });
+        });
       });
     });
   });
-  describe('data filtering', function () {
-    describe('Catalog Prefix', function () {
-      context('when "All" is selected', function () {
-        it('calls the listFilter once for each filter except the dropdown', async function () {
-          const { getAllByRole } = render(
-            <MultiYearPlan />
-          );
-          await wait(() => getAllByRole('row').length > 1);
-          const rows = getAllByRole('row');
-          const utils = within(rows[1]);
-          const catalogPrefixInput = utils.queryByLabelText('The table will be filtered as selected in the catalog prefix dropdown filter');
-          listFilterSpy.resetHistory();
-          fireEvent.change(catalogPrefixInput, { target: { value: 'All' } });
-          strictEqual(listFilterSpy.callCount, 2);
-        });
-      });
-      context('when any other value is selected', function () {
-        it('calls the listFilter function once for each filter', async function () {
-          const { getAllByRole } = render(
-            <MultiYearPlan />
-          );
-          await wait(() => getAllByRole('row').length > 1);
-          const rows = getAllByRole('row');
-          const utils = within(rows[1]);
-          const catalogPrefixInput = utils.queryByLabelText('The table will be filtered as selected in the catalog prefix dropdown filter');
-          listFilterSpy.resetHistory();
-          fireEvent.change(catalogPrefixInput, { target: { value: 'AnyValue' } });
-          strictEqual(listFilterSpy.callCount, 3);
-        });
-      });
+  context('when visiting info.seas', function () {
+    let findByText: BoundFunction<FindByText>;
+    beforeEach(function () {
+      getStub = stub(MultiYearPlanAPI, 'getMultiYearPlan');
+      windowStub = stub(WindowUtils, 'getHostname');
+      dispatchMessage = stub();
+      getStub.resolves(testData);
+      windowStub.returns(new URL(process.env.PUBLIC_CLIENT_URL).hostname);
+      listFilterSpy = spy(filters, 'listFilter');
+      facultyFilterSpy = spy(instructorFilters, 'filterPlansByInstructors');
     });
-    describe('Catalog Number', function () {
-      context('when a value is entered', function () {
-        it('calls the listFilter function once for each filter except the dropdown', async function () {
-          const { getAllByRole } = render(
-            <MultiYearPlan />
-          );
-          await wait(() => getAllByRole('row').length > 1);
-          const rows = getAllByRole('row');
-          const utils = within(rows[1]);
-          const catalogNumber = utils.queryByLabelText('The table will be filtered as characters are typed in this catalog number filter field');
-          listFilterSpy.resetHistory();
-          fireEvent.change(catalogNumber, { target: { value: 'AnyValue' } });
-          strictEqual(listFilterSpy.callCount, 2);
-        });
-      });
-      context('when no value is entered', function () {
-        it('does not call the listFilter function', async function () {
-          const { getAllByRole } = render(
-            <MultiYearPlan />
-          );
-          await wait(() => getAllByRole('row').length > 1);
-          listFilterSpy.resetHistory();
-          strictEqual(listFilterSpy.callCount, 0);
-        });
-      });
-    });
-    describe('Course Title', function () {
-      context('when a value is entered', function () {
-        it('calls the listFilter function once for each filter except the dropdown', async function () {
-          const { getAllByRole } = render(
-            <MultiYearPlan />
-          );
-          await wait(() => getAllByRole('row').length > 1);
-          const rows = getAllByRole('row');
-          const utils = within(rows[1]);
-          const courseTitle = utils.queryByLabelText('The table will be filtered as characters are typed in this course title filter field');
-          listFilterSpy.resetHistory();
-          fireEvent.change(courseTitle, { target: { value: 'AnyValue' } });
-          strictEqual(listFilterSpy.callCount, 2);
-        });
-      });
-      context('when no value is entered', function () {
-        it('does not call the listFilter function', async function () {
-          const { getAllByRole } = render(
-            <MultiYearPlan />
-          );
-          await wait(() => getAllByRole('row').length > 1);
-          listFilterSpy.resetHistory();
-          strictEqual(listFilterSpy.callCount, 0);
-        });
-      });
-    });
-    describe('Instructors', function () {
-      context('when a value is entered', function () {
-        context('for all instructor fields', function () {
-          it('calls the filterPlansByInstructors once per field', async function () {
-            const { getAllByRole } = render(
-              <MultiYearPlan />
-            );
-            await wait(() => getAllByRole('row').length > 1);
-            const rows = getAllByRole('row');
-            const utils = within(rows[1]);
-            const instructorFields = utils.queryAllByLabelText('The table will be filtered as characters are typed in this instructors filter field');
-            facultyFilterSpy.resetHistory();
-            instructorFields.forEach((instructorField) => {
-              fireEvent.change(instructorField, { target: { value: 'AnyValue' } });
-            });
-            strictEqual(facultyFilterSpy.callCount, instructorFields.length);
-          });
-        });
-        context('for one instructor field', function () {
-          it('calls the filterPlansByInstructors once', async function () {
-            const { getAllByRole } = render(
-              <MultiYearPlan />
-            );
-            await wait(() => getAllByRole('row').length > 1);
-            const rows = getAllByRole('row');
-            const utils = within(rows[1]);
-            const instructorFields = utils.queryAllByLabelText('The table will be filtered as characters are typed in this instructors filter field');
-            facultyFilterSpy.resetHistory();
-            fireEvent.change(instructorFields[0], { target: { value: 'AnyValue' } });
-            strictEqual(facultyFilterSpy.callCount, 1);
-          });
-        });
-      });
-      context('when no value is entered', function () {
-        it('does not call the filterPlansByInstructors function', async function () {
-          const { getAllByRole } = render(
-            <MultiYearPlan />
-          );
-          await wait(() => getAllByRole('row').length > 1);
-          facultyFilterSpy.resetHistory();
-          strictEqual(facultyFilterSpy.callCount, 0);
-        });
+    describe('rendering', function () {
+      it('displays instructional text', async function () {
+        ({ findByText } = render(
+          <MultiYearPlan />
+        ));
+        await findByText(instructionalText, { exact: false });
       });
     });
   });

--- a/src/client/components/pages/utils/getHostname.ts
+++ b/src/client/components/pages/utils/getHostname.ts
@@ -1,0 +1,7 @@
+// Sinon does not allow stubbing of the window.location, so it is necessary to
+// access this value from here so that we can stub the window location in a test
+export const getHostname = (): string => window.location.hostname;
+
+export const WindowUtils = {
+  getHostname,
+};

--- a/src/client/components/pages/utils/getHostname.ts
+++ b/src/client/components/pages/utils/getHostname.ts
@@ -1,5 +1,8 @@
-// Sinon does not allow stubbing of the window.location, so it is necessary to
-// access this value from here so that we can stub the window location in a test
+/**
+ * Sinon does not allow stubbing of the window.location, so it is necessary to
+ * access this value from here so that we can stub the window location in
+ * a test.
+ */
 export const getHostname = (): string => window.location.hostname;
 
 export const WindowUtils = {


### PR DESCRIPTION
This PR adds instructional text from the current course planner to the multi year plan tab when the user is visiting from info.seas. The planning.seas page will continue not displaying this instructional text.

The description from PR #472 outlines how to see the public-facing (info.seas.harvard.edu) and private-facing (planning.seas.harvard.edu) versions of course planner to see this change. 

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #471 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
