### PR TITLE
Bugfix: Fix tests checking retired functionality

### DIFF
--- a/tests/integration/server/courseInstance/courseInstance.controller.test.ts
+++ b/tests/integration/server/courseInstance/courseInstance.controller.test.ts
@@ -53,6 +53,7 @@ describe('CourseInstance API', function () {
   let ciRepository: Repository<CourseInstance>;
   let api: HttpServer;
   let authStub: SinonStub;
+  let configService: ConfigService;
 
   beforeEach(async function () {
     authStub = stub(TestingStrategy.prototype, 'login');
@@ -94,6 +95,7 @@ describe('CourseInstance API', function () {
     meetingRepository = testModule.get(getRepositoryToken(Meeting));
     fciRepository = testModule.get(getRepositoryToken(FacultyCourseInstance));
     ciRepository = testModule.get(getRepositoryToken(CourseInstance));
+    configService = testModule.get<ConfigService>(ConfigService);
     const nestApp = await testModule
       .createNestApplication()
       .useGlobalPipes(new BadRequestExceptionPipe())
@@ -1046,6 +1048,7 @@ describe('CourseInstance API', function () {
     let newOfferedValue: OFFERED;
     let response: Response;
     let testCourseInstance: CourseInstance;
+    const currentAcademicYear = 2022;
     const testRequest: CourseInstanceUpdateDTO = {
       offered: OFFERED.N,
       preEnrollment: 0,
@@ -1053,11 +1056,12 @@ describe('CourseInstance API', function () {
       actualEnrollment: 0,
     };
     beforeEach(async function () {
+      stub(configService, 'academicYear').get(() => currentAcademicYear);
       testCourseInstance = await ciRepository.findOne(
         {
           where: {
             semester: {
-              academicYear: 2022,
+              academicYear: currentAcademicYear,
             },
           },
           relations: [


### PR DESCRIPTION
These tests were previously failing, because the tests were calculating the current academic year as 2023, while these tests are trying to retire course instances from 2022. Since we're not allowed to retire instances of the past, the current academic year has been stubbed to 2022 so that the tests no longer fail as the real academic year changes.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [ ] Normal <!-- New piece of functionality -->
- [x] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #530

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
