### PR TITLE
Fade course blocks that don't have popups

### DIFF
--- a/src/client/components/pages/Schedule/ScheduleView.tsx
+++ b/src/client/components/pages/Schedule/ScheduleView.tsx
@@ -112,8 +112,12 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
               const resolvedDuration = Math.round(
                 duration / minuteResolution
               );
+              const popoverInBlock = courses.some(({
+                instanceId,
+              }) => instanceId === currentPopover);
               return [...blocks, (
                 <SessionBlock
+                  isFaded={currentPopover && !popoverInBlock}
                   key={sessionId}
                   prefix={coursePrefix}
                   startRow={resolvedStartRow}
@@ -132,9 +136,12 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                     const displayEndTime = PGTime.toDisplay(
                       `${endHour}:${endMinute.toString().padStart(2, '0')}`
                     );
+                    const isSelected = currentPopover === instanceId;
                     return (
                       <CourseListing key={meetingId}>
                         <CourseListingButton
+                          isHighlighted={popoverInBlock && isSelected}
+                          isFaded={popoverInBlock && !isSelected}
                           aria-disabled
                           aria-labelledby={`${meetingId}-description`}
                           onClick={(event) => {
@@ -151,7 +158,7 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                           xOffset="0.5rem"
                           yOffset="1rem"
                           title={catalogNumber}
-                          isVisible={currentPopover === instanceId}
+                          isVisible={isSelected}
                         >
                           <p>{day}</p>
                           <p>{`${displayStartTime} - ${displayEndTime}`}</p>

--- a/src/client/components/pages/Schedule/blocks/CourseListingButton.tsx
+++ b/src/client/components/pages/Schedule/blocks/CourseListingButton.tsx
@@ -1,15 +1,31 @@
 import styled from 'styled-components';
 
+interface CourseListingButtonProps {
+  /**
+   * Whether this button should have a highlighted background
+   */
+  isHighlighted?: boolean;
+
+  /**
+   * Whether the text of the button should fade into the background, e.g. when
+   * one of the other courses in this block is highlighted
+   */
+  isFaded?: boolean;
+}
+
 /**
  * An essentially unstyled button used to trigger the Popover containing the
  * course details
  */
 const CourseListingButton = styled.button.attrs({
   type: 'button',
-})`
-  background: transparent;
+})<CourseListingButtonProps>`
+  background-color: ${({ isHighlighted }) => (
+    isHighlighted ? 'rgba(255, 255, 255, 0.5)' : 'transparent'
+  )};
   border: none;
   font-size: inherit;
+  opacity: ${({ isFaded }) => (isFaded ? '0.5' : '1')};
   padding: 0;
   margin: 0;
   width: 100%;

--- a/src/client/components/pages/Schedule/blocks/SessionBlock.tsx
+++ b/src/client/components/pages/Schedule/blocks/SessionBlock.tsx
@@ -29,6 +29,11 @@ interface SessionBlockProps {
    * computation
    */
   duration: number;
+  /**
+   * Whether the block should be faded out, as when a course in another block
+   * has been clicked
+   */
+  isFaded: boolean;
 }
 
 /**
@@ -36,7 +41,7 @@ interface SessionBlockProps {
  */
 type SessionBlockWrapperProps = Pick<
 SessionBlockProps,
-'prefix' | 'duration' | 'startRow'
+'prefix' | 'duration' | 'startRow' | 'isFaded'
 >;
 
 /**
@@ -63,6 +68,7 @@ const SessionBlockWrapper = styled.div<SessionBlockWrapperProps>`
   border-left: 1px solid #fff;
   border-right: 1px solid #fff;
   overflow-wrap: anywhere;
+  opacity: ${({ isFaded }) => (isFaded ? '0.6' : '1')};
 `;
 
 /**
@@ -95,11 +101,13 @@ const SessionBlock: FunctionComponent<SessionBlockProps> = ({
   startRow,
   duration,
   children,
+  isFaded,
 }) => (
   <SessionBlockWrapper
     prefix={prefix}
     startRow={startRow}
     duration={duration}
+    isFaded={isFaded}
   >
     <SessionBlockHeading>
       {prefix}


### PR DESCRIPTION
This adds `isFaded` and `isHighlighted` properties to the `SessionBlock` and `CourseListingButton` components that control the opacity setting of the element. When the user clicks on a single meeting, all other `SessionBlocks` that don't contain meetings in the same course will fade out. Within the blocks that do contain meetings in the same course, any other course numbers will be faded, while the chosen course will have a light highlight applied.

![2022-07-18_161844](https://user-images.githubusercontent.com/6124793/179761134-ea897ed8-e6c5-4586-b59f-74e4fee40db9.png)
 

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #505 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
