### PR TITLE
Fix Schedule Display - Extend end time to 10pm

### DIFF
--- a/src/client/components/pages/Schedule/SchedulePage.tsx
+++ b/src/client/components/pages/Schedule/SchedulePage.tsx
@@ -21,7 +21,7 @@ import { useStoredState } from '../../../hooks/useStoredState';
  */
 
 const FIRST_HOUR = 8;
-const LAST_HOUR = 20;
+const LAST_HOUR = 22;
 
 /** Describes the currently selected semester */
 interface SemesterSelection {


### PR DESCRIPTION
This PR updates the schedule such that the end time is extended from 8pm to 10pm. According to our users, the latest end time for a course is 9:30pm. For now, we will hardcode the end time value as 10pm, but we may dynamically update the end time in the future.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #535

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
