### PR TITLE
Pins redis version to ^6.2.6, instead of ~6.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - ".:/node:rw"
     command: ["npm", "run", "start:client"]
   redis:
-    image: bitnami/redis:6.2
+    image: bitnami/redis:6.2.6
     environment:
       - REDIS_PASSWORD
     ports:


### PR DESCRIPTION
This PR pins `bitnami/redis:6.2`(note the lack of minor version) to `bitnami/redis:6.2.6` which is needed to address a breaking change between `bitnami/redis:6.2.6` and `bitnami/redis:6.2.7`. 

Work is likely needed to identify the breaking change, but until this happens it's probably best to pin to a working version to avoid breakages.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [ ] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [ ] Normal <!-- New piece of functionality -->
- [x] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Temporary workaround for #553 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
