### PR TITLE
Improve scrolling for Popover elements in Schedule

### DIFF
--- a/src/client/components/pages/Schedule/ScheduleView.tsx
+++ b/src/client/components/pages/Schedule/ScheduleView.tsx
@@ -118,6 +118,7 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
               return [...blocks, (
                 <SessionBlock
                   isFaded={currentPopover && !popoverInBlock}
+                  isPopoverVisible={!!currentPopover}
                   key={sessionId}
                   prefix={coursePrefix}
                   startRow={resolvedStartRow}

--- a/src/client/components/pages/Schedule/blocks/SessionBlock.tsx
+++ b/src/client/components/pages/Schedule/blocks/SessionBlock.tsx
@@ -57,6 +57,10 @@ interface SessionBlockProps {
    * to break out of the overflow defined within the body wrapper
    */
   popovers: JSX.Element[];
+  /**
+   * Whether a popover is currently visible
+   */
+  isPopoverVisible: boolean;
 }
 
 /**
@@ -87,6 +91,12 @@ type SessionBlockHeadingProps = {
  * Takes the children from the SessionBlock
  */
 type SessionBlockBodyProps = Pick<SessionBlockProps, 'children'>;
+
+/**
+ * Takes the isPopoverVisible prop from the SessionBlock
+ */
+ type SessionBlockBodyWrapperProps = Pick<
+ SessionBlockProps, 'isPopoverVisible' | 'isFaded'>;
 
 /**
  * The top level of the SessionBlock, which handles setting the placement
@@ -145,8 +155,12 @@ const SessionBlockHeading = styled.h4<SessionBlockHeadingProps>`
 /**
  * A wrapper around the table to handle scrolling within the list only.
  */
-const SessionBlockBodyWrapper = styled.div`
-  overflow-y: scroll;
+const SessionBlockBodyWrapper = styled.div<SessionBlockBodyWrapperProps>`
+  overflow-y: ${({ isPopoverVisible, isFaded }): string => (
+    isPopoverVisible && !isFaded
+      ? 'hidden'
+      : 'scroll'
+  )};
   position: absolute;
   width: 100%;
   top: 2em;
@@ -176,6 +190,7 @@ const SessionBlock: FunctionComponent<SessionBlockProps> = ({
   duration,
   children,
   isFaded,
+  isPopoverVisible,
   popovers,
 }) => {
   /**
@@ -238,6 +253,8 @@ const SessionBlock: FunctionComponent<SessionBlockProps> = ({
         {prefix.substr(0, 3)}
       </SessionBlockHeading>
       <SessionBlockBodyWrapper
+        isPopoverVisible={isPopoverVisible}
+        isFaded={isFaded}
         ref={bodyWrapperRef}
       >
         <SessionBlockBody>


### PR DESCRIPTION
This PR added an `isPopoverVisible` prop as an indication of whether a popover is currently showing. If the popover is showing, the scroll for that popover should be hidden. However, if a popover is showing, the faded blocks can still be scrolled. When no popover is showing, the schedule blocks should be scrollable like usual.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #549

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
