### PR TITLE
Add an empty passphrase file

### DIFF
--- a/init-redis-ssl.sh
+++ b/init-redis-ssl.sh
@@ -6,12 +6,14 @@ export REDIS_TLS_ENABLED=yes
 export REDIS_TLS_PORT=6379
 export REDIS_TLS_CERT_FILE=$CERT_DIR/redis.crt
 export REDIS_TLS_KEY_FILE=$CERT_DIR/redis.key
+export REDIS_TLS_KEY_FILE_PASS=$CERT_DIR/redis.pass
 export REDIS_TLS_CA_FILE=/usr/share/ca-certificates/mozilla/VeriSign_Universal_Root_Certification_Authority.crt
 export REDIS_TLS_AUTH_CLIENTS=no
 (
   echo "Generating ssl key and certificate"
   umask 077
   mkdir -p $CERT_DIR
+  touch $REDIS_TLS_KEY_FILE_PASS
   openssl req -x509\
     -newkey rsa:4096\
     -days 3650\


### PR DESCRIPTION
As of `bitnami/redis:6.2.7-debian-11-r18`, the startup script for redis
requires a file containing a passphrase to be provided via the
`REDIS_TLS_KEY_FILE_PASS` environment variable if Redis is running with
TLS enabled. Since we're only using this container in local development
and not in production, we can override by creating an empty file when we
initialize the SSL certificate so that it passes the "Does the file
exist?" check that the redis script is running.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [ ] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [ ] Normal <!-- New piece of functionality -->
- [x] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #553 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
