### PR TITLE
Add Room Combobox to Initial Room Schedule page

### DIFF
--- a/src/client/api/rooms.ts
+++ b/src/client/api/rooms.ts
@@ -2,6 +2,11 @@ import RoomRequest from 'common/dto/room/RoomRequest.dto';
 import RoomResponse from 'common/dto/room/RoomResponse.dto';
 import request from './request';
 
+export const getRooms = async ():Promise<RoomResponse[]> => {
+  const response = await request.get('/api/rooms/');
+  return response.data as RoomResponse[];
+};
+
 /**
  * Retrieves all rooms and the meetings, if any, that are occurring during the
  * requested time period
@@ -10,7 +15,7 @@ export const getRoomAvailability = async (roomInfo: RoomRequest):
 Promise<RoomResponse[]> => {
   const response = await request
     .get(
-      '/api/rooms',
+      '/api/rooms/availability',
       {
         params: roomInfo,
       }
@@ -20,4 +25,5 @@ Promise<RoomResponse[]> => {
 
 export const LocationAPI = {
   getRoomAvailability,
+  getRooms,
 };

--- a/src/client/components/layout/AppHeader.tsx
+++ b/src/client/components/layout/AppHeader.tsx
@@ -40,6 +40,7 @@ const AppHeader:FunctionComponent = () => {
     { link: '/faculty', text: 'Faculty', isVisible: isReadOnly },
     { link: '/four-year-plan', text: '4 Year Plan', isVisible: true },
     { link: '/schedule', text: 'Schedule', isVisible: true },
+    { link: '/room-schedule', text: 'Room Schedule', isVisible: true },
     { link: '/course-admin', text: 'Course Admin', isVisible: isAdmin },
     { link: '/faculty-admin', text: 'Faculty Admin', isVisible: isAdmin },
   ];

--- a/src/client/components/layout/AppRouter.tsx
+++ b/src/client/components/layout/AppRouter.tsx
@@ -13,6 +13,7 @@ import {
   MultiYearPlan,
   Schedule,
   NonClassMeetings,
+  RoomSchedule,
 } from '../pages';
 import { useGroupGuard } from '../../hooks/useGroupGuard';
 import ForbiddenPage from '../pages/ForbiddenPage';
@@ -46,6 +47,7 @@ const AppRouter: FunctionComponent = (): ReactElement => {
         <Redirect exact from="/" to="/four-year-plan" />
         <Route exact path="/four-year-plan" component={MultiYearPlan} />
         <Route exact path="/schedule" component={Schedule} />
+        <Route exact path="/room-schedule" component={RoomSchedule} />
         <Route
           exact
           path={[
@@ -87,6 +89,7 @@ const AppRouter: FunctionComponent = (): ReactElement => {
         />
         <Route exact path="/four-year-plan" component={MultiYearPlan} />
         <Route exact path="/schedule" component={Schedule} />
+        <Route exact path="/room-schedule" component={RoomSchedule} />
         <Route
           exact
           path="/course-admin"
@@ -117,6 +120,7 @@ const AppRouter: FunctionComponent = (): ReactElement => {
           '/faculty',
           '/four-year-plan',
           '/schedule',
+          '/room-schedule',
           '/course-admin',
           '/faculty-admin',
         ]}

--- a/src/client/components/layout/__tests__/AppHeader.test.tsx
+++ b/src/client/components/layout/__tests__/AppHeader.test.tsx
@@ -49,6 +49,10 @@ describe('AppHeader', function () {
         const link = queryByText('Schedule');
         assert(link);
       });
+      it('should display the "Room Schedule" link', function () {
+        const link = queryByText('Room Schedule');
+        assert(link);
+      });
       it('should display the "4 Year Plan" link', function () {
         const link = queryByText('4 Year Plan');
         assert(link);
@@ -91,6 +95,10 @@ describe('AppHeader', function () {
       });
       it('should display the "Schedule" link', function () {
         const link = queryByText('Schedule');
+        assert(link);
+      });
+      it('should display the "Room Schedule" link', function () {
+        const link = queryByText('Room Schedule');
         assert(link);
       });
       it('should display the "4 Year Plan" link', function () {
@@ -145,6 +153,10 @@ describe('AppHeader', function () {
     });
     it('should display the "Schedule" link', function () {
       const link = queryByText('Schedule');
+      assert(link);
+    });
+    it('should display the "Room Schedule" link', function () {
+      const link = queryByText('Room Schedule');
       assert(link);
     });
     it('should display the "4 Year Plan" link', function () {

--- a/src/client/components/pages/RoomSchedule/RoomSchedule.tsx
+++ b/src/client/components/pages/RoomSchedule/RoomSchedule.tsx
@@ -1,0 +1,108 @@
+import { LocationAPI } from 'client/api/rooms';
+import { AppMessage, MESSAGE_TYPE, MESSAGE_ACTION } from 'client/classes';
+import { MenuFlex } from 'client/components/general';
+import { VerticalSpace } from 'client/components/layout';
+import { MessageContext } from 'client/context';
+import { TERM } from 'common/constants';
+import RoomResponse from 'common/dto/room/RoomResponse.dto';
+import { Combobox, NoteText } from 'mark-one';
+import React, {
+  FunctionComponent, useCallback, useContext, useEffect, useState,
+} from 'react';
+
+/**
+ * Displays the course schedule for a particular room and semester
+ */
+const RoomSchedule: FunctionComponent = () => {
+  const currentTerm = TERM.FALL;
+  const currentAcademicYear = 2020;
+  /**
+   * Saves a complete list of rooms in local state
+   */
+  const [
+    fullRoomList,
+    setFullRoomList,
+  ] = useState<RoomResponse[]>([]);
+
+  /**
+   * Keeps track of the currently selected room
+   */
+  const [
+    currentRoom,
+    setCurrentRoom,
+  ] = useState<{id: string, displayName: string}>({
+    id: '',
+    displayName: '',
+  });
+
+  /**
+   * The current value for the message context
+   */
+  const dispatchMessage = useContext(MessageContext);
+
+  const loadRooms = useCallback(async (): Promise<void> => {
+    try {
+      const roomList = await LocationAPI.getRooms();
+      setFullRoomList(roomList);
+    } catch (e) {
+      dispatchMessage({
+        message: new AppMessage(
+          'Unable to get room data from server. If the problem persists, contact SEAS Computing',
+          MESSAGE_TYPE.ERROR
+        ),
+        type: MESSAGE_ACTION.PUSH,
+      });
+    }
+  }, [dispatchMessage]);
+
+  /**
+   * Gets the rooms data from the server
+   * If it fails, display a message for the user
+   */
+  useEffect((): void => {
+    void loadRooms();
+  }, [loadRooms]);
+
+  return (
+    <div className="roomSchedule">
+      <VerticalSpace>
+        <MenuFlex>
+          <NoteText>
+            {`Current Semester: ${currentTerm} ${currentAcademicYear}`}
+          </NoteText>
+          <NoteText>
+            {currentRoom.displayName
+              ? `Current Room: ${currentRoom.displayName}`
+              : 'Current Room: None Selected'}
+          </NoteText>
+          <Combobox
+            options={fullRoomList
+              .map((room):
+              {value: string; label: string} => ({
+                label: room.name,
+                value: room.id,
+              }))}
+            currentValue={null}
+            label="Select a room"
+            isLabelVisible={false}
+            placeholder="Select a room"
+            onOptionSelected={({
+              selectedItem: {
+                value: id,
+                label: displayName,
+              },
+            }) => {
+              setCurrentRoom({ id, displayName });
+            }}
+            filterFunction={(option, inputValue) => {
+              const re = new RegExp(inputValue, 'i');
+              return re.test(option.label);
+            }}
+          />
+        </MenuFlex>
+      </VerticalSpace>
+    </div>
+  );
+};
+
+export default RoomSchedule;

--- a/src/client/components/pages/index.ts
+++ b/src/client/components/pages/index.ts
@@ -7,3 +7,4 @@ export { default as MultiYearPlan } from './MultiYearPlan';
 export { default as Schedule } from './Schedule/SchedulePage';
 export { default as NoMatch } from './NoMatch';
 export { default as listFilter } from './Filter';
+export { default as RoomSchedule } from './RoomSchedule/RoomSchedule';

--- a/src/server/location/location.controller.ts
+++ b/src/server/location/location.controller.ts
@@ -29,6 +29,17 @@ export class LocationController {
   private readonly locationService: LocationService;
 
   @Get('/')
+  @ApiOperation({ summary: 'Retrieve Room Data' })
+  @ApiOkResponse({
+    type: RoomResponse,
+    description: 'An array of the existing rooms along with their building and campus information',
+    isArray: true,
+  })
+  public async getRooms(): Promise<RoomResponse[]> {
+    return this.locationService.getRoomList();
+  }
+
+  @Get('/availability')
   @ApiOperation({ summary: 'Retrieve all rooms from the database along with the meetings that take place in them' })
   @ApiOkResponse({
     type: RoomResponse,

--- a/src/server/location/location.service.ts
+++ b/src/server/location/location.service.ts
@@ -32,6 +32,16 @@ export class LocationService {
   @InjectRepository(RoomBookingInfoView)
   private readonly roomBookingRepository: Repository<RoomBookingInfoView>;
 
+  public async getRoomList(): Promise<RoomResponse[]> {
+    return this.roomListingViewRepository
+      .createQueryBuilder()
+      .select('id')
+      .addSelect('name')
+      .addSelect('campus')
+      .addSelect('capacity')
+      .getRawMany();
+  }
+
   /**
    * Queries the view of room booking info in our database for any existing
    * bookings that might overlap with the meeting represented by the data in

--- a/tests/integration/e2e/AppRouter.test.tsx
+++ b/tests/integration/e2e/AppRouter.test.tsx
@@ -167,6 +167,16 @@ describe('Application Routing and Authorization', function () {
           return findByText('Select Semester');
         });
       });
+      context('/room-schedule', function () {
+        it('renders the Room Schedule component', function () {
+          const { findByText } = render(
+            <MemoryRouter initialEntries={['/room-schedule']}>
+              <App />
+            </MemoryRouter>
+          );
+          return findByText('Select a room');
+        });
+      });
       context('Undefined routes', function () {
         it('renders the NoMatch component', function () {
           const { findByText } = render(
@@ -250,6 +260,16 @@ describe('Application Routing and Authorization', function () {
             </MemoryRouter>
           );
           return findByText('Select Semester');
+        });
+      });
+      context('/room-schedule', function () {
+        it('renders the Room Schedule component', function () {
+          const { findByText } = render(
+            <MemoryRouter initialEntries={['/room-schedule']}>
+              <App />
+            </MemoryRouter>
+          );
+          return findByText('Select a room');
         });
       });
       context('Undefined routes', function () {
@@ -343,6 +363,16 @@ describe('Application Routing and Authorization', function () {
           return findByText(/401/);
         });
       });
+      context('/room-schedule', function () {
+        it('renders the UnauthorizedPage component', function () {
+          const { findByText } = render(
+            <MemoryRouter initialEntries={['/room-schedule']}>
+              <App />
+            </MemoryRouter>
+          );
+          return findByText(/401/);
+        });
+      });
       context('Undefined routes', function () {
         it('renders the NoMatch component', function () {
           const { findByText } = render(
@@ -427,6 +457,16 @@ describe('Application Routing and Authorization', function () {
             </MemoryRouter>
           );
           return findByText('Select Semester');
+        });
+      });
+      context('/room-schedule', function () {
+        it('renders the Room Schedule component', function () {
+          const { findByText } = render(
+            <MemoryRouter initialEntries={['/room-schedule']}>
+              <App />
+            </MemoryRouter>
+          );
+          return findByText('Select a room');
         });
       });
       context('Undefined routes', function () {

--- a/tests/integration/server/auth/auth.test.ts
+++ b/tests/integration/server/auth/auth.test.ts
@@ -163,6 +163,12 @@ const endpointTests: Endpoint[] = [
     expectAllowedGroup: GROUP.ADMIN,
   },
   {
+    path: '/api/rooms/availability',
+    method: 'get',
+    expectAnonymousAccess: false,
+    expectAllowedGroup: GROUP.ADMIN,
+  },
+  {
     path: `/api/meetings/${dummy.uuid}`,
     method: 'put',
     expectAnonymousAccess: false,

--- a/tests/integration/server/location/location.controller.test.ts
+++ b/tests/integration/server/location/location.controller.test.ts
@@ -97,7 +97,7 @@ describe('Location API', function () {
     await testModule.close();
   });
 
-  describe('GET /rooms', function () {
+  describe('GET /rooms/availability', function () {
     const testParams: RoomRequest = {
       calendarYear: '2020',
       term: TERM.FALL,
@@ -114,7 +114,7 @@ describe('Location API', function () {
         authStub.rejects(new ForbiddenException());
 
         response = await request(api)
-          .get('/api/rooms')
+          .get('/api/rooms/availability')
           .query(testParams);
 
         strictEqual(response.ok, false);
@@ -130,7 +130,7 @@ describe('Location API', function () {
             authStub.resolves(adminUser);
             const invalidYear = '1902';
             response = await request(api)
-              .get('/api/rooms')
+              .get('/api/rooms/availability')
               .query({ ...testParams, calendarYear: invalidYear });
             result = response.body;
           });
@@ -150,7 +150,7 @@ describe('Location API', function () {
             authStub.resolves(adminUser);
             const invalidTerm = 'fakeTerm' as TERM;
             response = await request(api)
-              .get('/api/rooms')
+              .get('/api/rooms/availability')
               .query({ ...testParams, term: invalidTerm });
           });
           it('should return a 400 status', function () {
@@ -162,7 +162,7 @@ describe('Location API', function () {
             authStub.resolves(adminUser);
             const invalidDay = 'fakeDay' as DAY;
             response = await request(api)
-              .get('/api/rooms')
+              .get('/api/rooms/availability')
               .query({ ...testParams, day: invalidDay });
           });
           it('should return a 400 status', function () {
@@ -174,7 +174,7 @@ describe('Location API', function () {
             authStub.resolves(adminUser);
             const invalidStartTime = '10:00AM';
             response = await request(api)
-              .get('/api/rooms')
+              .get('/api/rooms/availability')
               .query({ ...testParams, startTime: invalidStartTime });
           });
           it('should return a 400 status', function () {
@@ -186,7 +186,7 @@ describe('Location API', function () {
             authStub.resolves(adminUser);
             const invalidEndTime = '26:00:00';
             response = await request(api)
-              .get('/api/rooms')
+              .get('/api/rooms/availability')
               .query({ ...testParams, endTime: invalidEndTime });
           });
           it('should return a 400 status', function () {
@@ -198,7 +198,7 @@ describe('Location API', function () {
             authStub.resolves(adminUser);
             const invalidExcludeParent = 'notUUID';
             response = await request(api)
-              .get('/api/rooms')
+              .get('/api/rooms/availability')
               .query({ ...testParams, excludeParent: invalidExcludeParent });
           });
           it('should return a 400 status', function () {
@@ -211,7 +211,7 @@ describe('Location API', function () {
             beforeEach(async function () {
               authStub.resolves(adminUser);
               response = await request(api)
-                .get('/api/rooms')
+                .get('/api/rooms/availability')
                 .query(testParams);
               result = response.body;
             });
@@ -276,7 +276,7 @@ describe('Location API', function () {
               testInstance = await testInstanceQuery
                 .getRawOne();
               response = await request(api)
-                .get('/api/rooms')
+                .get('/api/rooms/availability')
                 .query({
                   ...testParams,
                   excludeParent: testInstance.ci_id,
@@ -337,7 +337,7 @@ describe('Location API', function () {
         beforeEach(async function () {
           authStub.resolves(regularUser);
           response = await request(api)
-            .get('/api/rooms')
+            .get('/api/rooms/availability')
             .query(testParams);
         });
         it('is inaccessible to unauthenticated users', function () {


### PR DESCRIPTION
This PR adds the initial Room Schedule tab/page, which includes a combobox that contains all of the rooms in the database. The previously existing location controller method `getRoomAvailability` was using the `/` route, and I updated the new controller method `getRooms` to use this route instead. This was because `getRooms` is more general and does not take parameters in order to find the room availability for a specific time (term/calendar year/day, etc).


## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [ ] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #550

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
