### PR TITLE
Update import and export statements for the Location API

### DIFF
--- a/src/client/api/index.ts
+++ b/src/client/api/index.ts
@@ -6,3 +6,4 @@ export * from './nonClassMeeting';
 export * from './meetings';
 export * from './reports';
 export * from './httpStatus';
+export * from './rooms';

--- a/src/client/components/pages/RoomSchedule/RoomSchedule.tsx
+++ b/src/client/components/pages/RoomSchedule/RoomSchedule.tsx
@@ -1,4 +1,4 @@
-import { LocationAPI } from 'client/api/rooms';
+import { LocationAPI } from 'client/api';
 import { AppMessage, MESSAGE_TYPE, MESSAGE_ACTION } from 'client/classes';
 import { MenuFlex } from 'client/components/general';
 import { VerticalSpace } from 'client/components/layout';


### PR DESCRIPTION
This is a continuation of PR https://github.com/seas-computing/course-planner/pull/557.

This was in response to the type error: `Unsafe call of an any typed value from @typescript-eslint/no-unsafe-call`. By exporting the rooms file from `index.ts`, we can import from `client/api` as opposed to `client/api/rooms`.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [ ] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #550

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
