### PR TITLE
Fix Modal Header Displays: Terms & Calendar Years not displaying correctly

### DIFF
--- a/src/client/components/pages/Courses/CoursesPage.tsx
+++ b/src/client/components/pages/Courses/CoursesPage.tsx
@@ -748,7 +748,7 @@ const CoursesPage: FunctionComponent = (): ReactElement => {
         isVisible={instructorModalData.visible}
         currentSemester={{
           term: instructorModalData.term,
-          calendarYear: selectedAcademicYear.toString(),
+          academicYear: selectedAcademicYear.toString(),
         }}
         currentCourse={instructorModalData.course}
         closeModal={closeInstructorModal}

--- a/src/client/components/pages/Courses/CoursesPage.tsx
+++ b/src/client/components/pages/Courses/CoursesPage.tsx
@@ -806,7 +806,7 @@ const CoursesPage: FunctionComponent = (): ReactElement => {
         course={enrollmentModalData.course}
         currentSemester={{
           term: enrollmentModalData.term,
-          calendarYear: selectedAcademicYear.toString(),
+          academicYear: selectedAcademicYear.toString(),
         }}
         onSave={(data) => {
           const semKey = enrollmentModalData.term.toLowerCase() as TermKey;

--- a/src/client/components/pages/Courses/CoursesPage.tsx
+++ b/src/client/components/pages/Courses/CoursesPage.tsx
@@ -707,7 +707,9 @@ const CoursesPage: FunctionComponent = (): ReactElement => {
         isVisible={meetingModalData.visible}
         currentSemester={{
           term: meetingModalData.term,
-          calendarYear: selectedAcademicYear.toString(),
+          calendarYear: meetingModalData.term === TERM.SPRING
+            ? selectedAcademicYear.toString()
+            : (selectedAcademicYear - 1).toString(),
         }}
         currentCourse={meetingModalData.visible
           ? meetingModalData.course

--- a/src/client/components/pages/Courses/CoursesPage.tsx
+++ b/src/client/components/pages/Courses/CoursesPage.tsx
@@ -769,7 +769,7 @@ const CoursesPage: FunctionComponent = (): ReactElement => {
         isVisible={offeredModalData.visible}
         currentSemester={{
           term: offeredModalData.term,
-          calendarYear: selectedAcademicYear.toString(),
+          academicYear: selectedAcademicYear.toString(),
         }}
         currentCourseInstance={offeredModalData.course}
         onClose={closeOfferedModal}

--- a/src/client/components/pages/Courses/EnrollmentModal.tsx
+++ b/src/client/components/pages/Courses/EnrollmentModal.tsx
@@ -28,6 +28,7 @@ import CourseInstanceUpdateDTO from 'common/dto/courses/CourseInstanceUpdate.dto
 import { AxiosError } from 'axios';
 import { EnrollmentField } from './tableFields';
 import { BadRequestInfo } from './CourseModal';
+import { getInstanceIdentifier } from '../utils/getInstanceIdentifier';
 
 interface EnrollmentModalProps {
   /**
@@ -56,7 +57,7 @@ interface EnrollmentModalProps {
    */
   currentSemester: {
     term: TERM,
-    calendarYear: string
+    academicYear: string
   };
 }
 
@@ -331,7 +332,7 @@ const EnrollmentModal: FunctionComponent<EnrollmentModalProps> = ({
         tabIndex={0}
       >
         <span id="enrollment-modal-header">
-          {`Enrollment for ${course?.catalogNumber}, ${currentSemester?.term} ${currentSemester.calendarYear}`}
+          {`Enrollment for ${getInstanceIdentifier(course, currentSemester)}`}
         </span>
       </ModalHeader>
       <ModalBody>

--- a/src/client/components/pages/Courses/InstructorModal.tsx
+++ b/src/client/components/pages/Courses/InstructorModal.tsx
@@ -30,6 +30,7 @@ import { InstructorResponseDTO } from '../../../../common/dto/courses/Instructor
 import { getAllInstructors } from '../../../api/faculty';
 import { ManageFacultyResponseDTO } from '../../../../common/dto/faculty/ManageFacultyResponse.dto';
 import { updateInstructorList } from '../../../api';
+import { getInstanceIdentifier } from '../utils/getInstanceIdentifier';
 
 /**
 * Implement flexbox inside our ListItem to handle row spacing for handling
@@ -55,7 +56,7 @@ interface InstructorModalProps {
    */
   currentSemester: {
     term: TERM,
-    calendarYear: string,
+    academicYear: string,
   };
   /**
    * Full details of the course/instances whose instructors are being edited
@@ -265,16 +266,11 @@ const InstructorModal: FunctionComponent<InstructorModalProps> = ({
       setSaving(false);
     }
   };
-
-  const instanceIdentifier = currentCourse && currentSemester
-    ? `${
-      currentCourse.catalogNumber
-    }, ${
-      currentSemester.term
-    } ${
-      currentSemester.calendarYear
-    }`
-    : '';
+  // Generate and store the instance identifier so that it can be used
+  // in the modal header and as alternative text
+  const instanceIdentifier = getInstanceIdentifier(
+    currentCourse, currentSemester
+  );
   return (
     <Modal
       ariaLabelledBy="edit-instructors-header"

--- a/src/client/components/pages/Courses/MeetingModal.tsx
+++ b/src/client/components/pages/Courses/MeetingModal.tsx
@@ -21,6 +21,7 @@ import React, {
 } from 'react';
 import styled from 'styled-components';
 import axios from 'axios';
+import { toTitleCase } from 'common/utils/util';
 import { MeetingTimesList } from './MeetingTimesList';
 import RoomSelection from './RoomSelection';
 import RoomRequest from '../../../../common/dto/room/RoomRequest.dto';
@@ -480,7 +481,7 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
     ? `${
       currentCourse.catalogNumber
     }, ${
-      currentSemester.term
+      toTitleCase(currentSemester.term)
     } ${
       currentSemester.calendarYear
     }`

--- a/src/client/components/pages/Courses/OfferedModal.tsx
+++ b/src/client/components/pages/Courses/OfferedModal.tsx
@@ -25,6 +25,7 @@ import React, {
   useState,
 } from 'react';
 import { updateCourseInstance } from '../../../api';
+import { getInstanceIdentifier } from '../utils/getInstanceIdentifier';
 
 interface OfferedModalProps {
   /**
@@ -37,7 +38,7 @@ interface OfferedModalProps {
    */
   currentSemester: {
     term: TERM,
-    calendarYear: string,
+    academicYear: string,
   };
   /**
    * Full details of the instance for which the offered value is being edited
@@ -129,16 +130,6 @@ const OfferedModal: FunctionComponent<OfferedModalProps> = ({
     });
   };
 
-  const instanceIdentifier = currentCourseInstance && currentSemester
-    ? `${
-      currentCourseInstance.catalogNumber
-    }, ${
-      currentSemester.term
-    } ${
-      currentSemester.calendarYear
-    }`
-    : '';
-
   useEffect(() => {
     if (currentSemester && currentCourseInstance) {
       const currentTermKey = currentSemester.term.toLowerCase() as TermKey;
@@ -217,7 +208,7 @@ const OfferedModal: FunctionComponent<OfferedModalProps> = ({
         tabIndex={0}
       >
         <span id="edit-offered-header">
-          {`Edit Offered Value for ${instanceIdentifier}`}
+          {`Edit Offered Value for ${getInstanceIdentifier(currentCourseInstance, currentSemester)}`}
         </span>
       </ModalHeader>
       <ModalBody>

--- a/src/client/components/pages/Courses/__tests__/EnrollmentModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/EnrollmentModal.test.tsx
@@ -31,7 +31,7 @@ describe('Enrollment Modal', function () {
         <EnrollmentModal
           course={testData}
           currentSemester={{
-            calendarYear: testData.spring.calendarYear,
+            academicYear: testData.spring.calendarYear,
             term: TERM.SPRING,
           }}
           onClose={closeStub}

--- a/src/client/components/pages/Courses/__tests__/InstructorModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/InstructorModal.test.tsx
@@ -8,6 +8,7 @@ import * as dummy from 'testData';
 import CourseInstanceResponseDTO from 'common/dto/courses/CourseInstanceResponse';
 import { stub, SinonStub } from 'sinon';
 import { strictEqual, deepStrictEqual, notStrictEqual } from 'assert';
+import { TermKey } from 'common/constants/term';
 import * as facultyAPI from '../../../../api/faculty';
 import * as courseAPI from '../../../../api/courses';
 import InstructorModal from '../InstructorModal';
@@ -17,8 +18,13 @@ describe('InstructorModal', function () {
   let testCourse: CourseInstanceResponseDTO;
   let instructorNames: string[];
   let instructorFetchStub: SinonStub;
-  const term = TERM.FALL;
-  const { calendarYear } = dummy.cs50CourseInstance.fall;
+  const testTerm = TERM.FALL;
+  const semKey = testTerm.toLowerCase() as TermKey;
+  const testAcademicYear = testTerm === TERM.FALL
+    ? (parseInt(
+      dummy.cs50CourseInstance[semKey].calendarYear, 10
+    ) + 1).toString()
+    : dummy.cs50CourseInstance[semKey].calendarYear;
   let onCloseStub: SinonStub;
   let onSaveStub: SinonStub;
   beforeEach(function () {
@@ -43,7 +49,10 @@ describe('InstructorModal', function () {
           <InstructorModal
             isVisible
             currentCourse={testCourse}
-            currentSemester={{ term, calendarYear }}
+            currentSemester={{
+              term: testTerm,
+              academicYear: testAcademicYear,
+            }}
             closeModal={onCloseStub}
             onSave={onSaveStub}
           />
@@ -72,7 +81,10 @@ describe('InstructorModal', function () {
           <InstructorModal
             isVisible
             currentCourse={testCourse}
-            currentSemester={{ term, calendarYear }}
+            currentSemester={{
+              term: testTerm,
+              academicYear: testAcademicYear,
+            }}
             closeModal={onCloseStub}
             onSave={onSaveStub}
           />
@@ -120,7 +132,10 @@ describe('InstructorModal', function () {
           <InstructorModal
             isVisible
             currentCourse={testCourse}
-            currentSemester={{ term, calendarYear }}
+            currentSemester={{
+              term: testTerm,
+              academicYear: testAcademicYear,
+            }}
             closeModal={onCloseStub}
             onSave={onSaveStub}
           />
@@ -188,7 +203,10 @@ describe('InstructorModal', function () {
           <InstructorModal
             isVisible
             currentCourse={testCourse}
-            currentSemester={{ term, calendarYear }}
+            currentSemester={{
+              term: testTerm,
+              academicYear: testAcademicYear,
+            }}
             closeModal={onCloseStub}
             onSave={onSaveStub}
           />
@@ -265,7 +283,10 @@ describe('InstructorModal', function () {
         <InstructorModal
           isVisible
           currentCourse={testCourse}
-          currentSemester={{ term, calendarYear }}
+          currentSemester={{
+            term: testTerm,
+            academicYear: testAcademicYear,
+          }}
           closeModal={onCloseStub}
           onSave={onSaveStub}
         />
@@ -325,7 +346,10 @@ describe('InstructorModal', function () {
         <InstructorModal
           isVisible
           currentCourse={testCourse}
-          currentSemester={{ term, calendarYear }}
+          currentSemester={{
+            term: testTerm,
+            academicYear: testAcademicYear,
+          }}
           closeModal={onCloseStub}
           onSave={onSaveStub}
         />
@@ -370,7 +394,10 @@ describe('InstructorModal', function () {
         <InstructorModal
           isVisible
           currentCourse={testCourse}
-          currentSemester={{ term, calendarYear }}
+          currentSemester={{
+            term: testTerm,
+            academicYear: testAcademicYear,
+          }}
           closeModal={onCloseStub}
           onSave={onSaveStub}
         />
@@ -407,7 +434,10 @@ describe('InstructorModal', function () {
         <InstructorModal
           isVisible
           currentCourse={testCourse}
-          currentSemester={{ term, calendarYear }}
+          currentSemester={{
+            term: testTerm,
+            academicYear: testAcademicYear,
+          }}
           closeModal={onCloseStub}
           onSave={onSaveStub}
         />

--- a/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/MeetingModal.test.tsx
@@ -33,6 +33,7 @@ import * as roomAPI from 'client/api/rooms';
 import * as meetingAPI from 'client/api/meetings';
 import { Button, VARIANT } from 'mark-one';
 import axios from 'axios';
+import { toTitleCase } from 'common/utils/util';
 import MeetingModal from '../MeetingModal';
 import { PGTime } from '../../../../../common/utils/PGTime';
 import * as filters from '../../Filter';
@@ -88,7 +89,7 @@ describe('Meeting Modal', function () {
     describe('On Open Behavior', function () {
       it('populates the heading with the correct course instance information', function () {
         return waitForElement(
-          () => getByText(`Meetings for ${cs50CourseInstance.catalogNumber}, ${meetingTerm} ${cs50CourseInstance[semKey].calendarYear}`)
+          () => getByText(`Meetings for ${cs50CourseInstance.catalogNumber}, ${toTitleCase(meetingTerm)} ${cs50CourseInstance[semKey].calendarYear}`)
         );
       });
       describe('Meeting Times', function () {

--- a/src/client/components/pages/Courses/__tests__/OfferedModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/OfferedModal.test.tsx
@@ -21,6 +21,7 @@ import { TERM } from 'common/constants';
 import { TermKey } from 'common/constants/term';
 import { cs50CourseInstance, cs50FallInstanceUpdate } from 'testData';
 import axios from 'axios';
+import { toTitleCase } from 'common/utils/util';
 import OfferedModal from '../OfferedModal';
 
 describe('Offered Modal', function () {
@@ -61,7 +62,7 @@ describe('Offered Modal', function () {
     describe('On Open Behavior', function () {
       it('populates the heading with the correct course instance information', function () {
         return waitForElement(
-          () => getByText(`Edit Offered Value for ${cs50CourseInstance.catalogNumber}, ${meetingTerm} ${cs50CourseInstance[semKey].calendarYear}`)
+          () => getByText(`Edit Offered Value for ${cs50CourseInstance.catalogNumber}, ${toTitleCase(meetingTerm)} ${cs50CourseInstance[semKey].calendarYear}`)
         );
       });
       it('populates the offered dropdown with the expected current instance offered value', function () {

--- a/src/client/components/pages/Courses/__tests__/OfferedModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/OfferedModal.test.tsx
@@ -32,7 +32,7 @@ describe('Offered Modal', function () {
   let onCloseStub: SinonStub;
   let onSaveStub: SinonStub;
   let putStub: SinonStub;
-  const meetingTerm = TERM.FALL;
+  const meetingTerm = TERM.SPRING;
   const semKey = meetingTerm.toLowerCase() as TermKey;
   const testCourseInstance = cs50CourseInstance;
   describe('rendering', function () {
@@ -44,7 +44,7 @@ describe('Offered Modal', function () {
           isVisible
           currentCourseInstance={testCourseInstance}
           currentSemester={{
-            calendarYear: testCourseInstance[semKey].calendarYear,
+            academicYear: testCourseInstance[semKey].calendarYear,
             term: meetingTerm,
           }}
           onClose={onCloseStub}

--- a/src/client/components/pages/utils/__tests__/getInstanceIdentifier.test.tsx
+++ b/src/client/components/pages/utils/__tests__/getInstanceIdentifier.test.tsx
@@ -1,0 +1,33 @@
+import { strictEqual } from 'assert';
+import { TERM } from 'common/constants';
+import { am105CourseInstance } from 'testData';
+import { getInstanceIdentifier } from '../getInstanceIdentifier';
+
+describe('getInstanceIdentifier function', function () {
+  const testAcademicYear = '2023';
+  context('when the semester term is TERM.FALL', function () {
+    const testSemester = {
+      term: TERM.FALL,
+      academicYear: testAcademicYear,
+    };
+    it('should return the identifier with the calendar year', function () {
+      const identifier = getInstanceIdentifier(
+        am105CourseInstance, testSemester
+      );
+      const calendarYear = parseInt(testSemester.academicYear, 10) - 1;
+      strictEqual(identifier.includes(calendarYear.toString()), true);
+    });
+  });
+  context('when the semester term is TERM.SPRING', function () {
+    const testSemester = {
+      term: TERM.SPRING,
+      academicYear: testAcademicYear,
+    };
+    it('should return the identifier with the academic year', function () {
+      const identifier = getInstanceIdentifier(
+        am105CourseInstance, testSemester
+      );
+      strictEqual(identifier.includes(testAcademicYear), true);
+    });
+  });
+});

--- a/src/client/components/pages/utils/getInstanceIdentifier.ts
+++ b/src/client/components/pages/utils/getInstanceIdentifier.ts
@@ -1,0 +1,36 @@
+import { TERM } from 'common/constants';
+import CourseInstanceResponseDTO from 'common/dto/courses/CourseInstanceResponse';
+
+interface semester {
+  term: TERM,
+  academicYear: string,
+}
+
+/**
+ * Generates the text to identify the course and term/year information for a
+ * specific course instance and semester. This is frequently used as the
+ * text in modal headers.
+ */
+export const getInstanceIdentifier = (
+  courseInstance: CourseInstanceResponseDTO,
+  semester: semester
+): string => {
+  if (courseInstance && semester) {
+    return semester.term === TERM.FALL
+      ? `${
+        courseInstance.catalogNumber
+      }, ${
+        semester.term
+      } ${
+        parseInt(semester.academicYear, 10) - 1
+      }`
+      : `${
+        courseInstance.catalogNumber
+      }, ${
+        semester.term
+      } ${
+        semester.academicYear
+      }`;
+  }
+  return '';
+};

--- a/src/client/components/pages/utils/getInstanceIdentifier.ts
+++ b/src/client/components/pages/utils/getInstanceIdentifier.ts
@@ -1,5 +1,6 @@
 import { TERM } from 'common/constants';
 import CourseInstanceResponseDTO from 'common/dto/courses/CourseInstanceResponse';
+import { toTitleCase } from 'common/utils/util';
 
 interface semester {
   term: TERM,
@@ -16,18 +17,18 @@ export const getInstanceIdentifier = (
   semester: semester
 ): string => {
   if (courseInstance && semester) {
-    return semester.term === TERM.FALL
+    return semester.term.toUpperCase() === TERM.FALL
       ? `${
         courseInstance.catalogNumber
       }, ${
-        semester.term
+        toTitleCase(semester.term)
       } ${
         parseInt(semester.academicYear, 10) - 1
       }`
       : `${
         courseInstance.catalogNumber
       }, ${
-        semester.term
+        toTitleCase(semester.term)
       } ${
         semester.academicYear
       }`;


### PR DESCRIPTION
This PR fixes the modal headers so that the Fall term modals display the calendar year as opposed to the calendar year. The displayed terms in the modal header were also updated so that they are in title case. The `getInstanceIdentifier` util function was updated so that it accounts for any casing of the term passed in to the function.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #563

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
