### PR TITLE
Add Initial Room Admin Page & Table

### DIFF
--- a/src/client/api/__tests__/location.test.ts
+++ b/src/client/api/__tests__/location.test.ts
@@ -1,0 +1,52 @@
+import { deepStrictEqual, fail, strictEqual } from 'assert';
+import RoomAdminResponse from 'common/dto/room/RoomAdminResponse.dto';
+import { SinonStub, stub } from 'sinon';
+import { adminRoomsResponse, error } from 'testData';
+import request from '../request';
+import { LocationAPI } from '../rooms';
+
+describe('Location API', function () {
+  let getAdminRoomsResponse: RoomAdminResponse[];
+  let getStub: SinonStub;
+  describe('GET /rooms/admin', function () {
+    beforeEach(function () {
+      getStub = stub(request, 'get');
+    });
+    afterEach(function () {
+      getStub.restore();
+    });
+    describe('gets all room information', function () {
+      context('when data fetch succeeds', function () {
+        beforeEach(async function () {
+          getStub.resolves({
+            data: adminRoomsResponse,
+          });
+          getAdminRoomsResponse = await LocationAPI.getAdminRooms();
+        });
+        it('should call getAdminRooms', function () {
+          strictEqual(getStub.callCount, 1);
+        });
+        it('should request /api/rooms/admin', function () {
+          const [[path]] = getStub.args;
+          strictEqual(path, '/api/rooms/admin');
+        });
+        it('should return the rooms information', function () {
+          deepStrictEqual(getAdminRoomsResponse, adminRoomsResponse);
+        });
+      });
+      context('when data fetch fails', function () {
+        beforeEach(function () {
+          getStub.rejects();
+        });
+        it('should throw an error', async function () {
+          try {
+            await LocationAPI.getAdminRooms();
+            fail('Did not throw an error');
+          } catch (err) {
+            deepStrictEqual(err, error);
+          }
+        });
+      });
+    });
+  });
+});

--- a/src/client/api/rooms.ts
+++ b/src/client/api/rooms.ts
@@ -1,3 +1,4 @@
+import RoomAdminResponse from 'common/dto/room/RoomAdminResponse.dto';
 import RoomMeetingResponse from 'common/dto/room/RoomMeetingResponse.dto';
 import RoomRequest from 'common/dto/room/RoomRequest.dto';
 import RoomResponse from 'common/dto/room/RoomResponse.dto';
@@ -27,7 +28,16 @@ Promise<RoomMeetingResponse[]> => {
   return response.data as RoomMeetingResponse[];
 };
 
+/**
+ * Retrieves all room numbers along with their building and campus info
+ */
+export const getAdminRooms = async ():Promise<RoomAdminResponse[]> => {
+  const response = await request.get('/api/rooms/admin');
+  return response.data as RoomAdminResponse[];
+};
+
 export const LocationAPI = {
   getRoomAvailability,
   getRooms,
+  getAdminRooms,
 };

--- a/src/client/components/layout/AppHeader.tsx
+++ b/src/client/components/layout/AppHeader.tsx
@@ -43,6 +43,7 @@ const AppHeader:FunctionComponent = () => {
     { link: '/room-schedule', text: 'Room Schedule', isVisible: true },
     { link: '/course-admin', text: 'Course Admin', isVisible: isAdmin },
     { link: '/faculty-admin', text: 'Faculty Admin', isVisible: isAdmin },
+    { link: '/room-admin', text: 'Room Admin', isVisible: isAdmin },
   ];
 
   /**

--- a/src/client/components/layout/AppRouter.tsx
+++ b/src/client/components/layout/AppRouter.tsx
@@ -18,6 +18,7 @@ import {
 import { useGroupGuard } from '../../hooks/useGroupGuard';
 import ForbiddenPage from '../pages/ForbiddenPage';
 import UnauthorizedPage from '../pages/UnauthorizedPage';
+import RoomAdmin from '../pages/RoomAdmin/RoomAdmin';
 
 /**
  * Selects which body component to render based on the current URL path. The
@@ -56,6 +57,7 @@ const AppRouter: FunctionComponent = (): ReactElement => {
             '/faculty',
             '/course-admin',
             '/faculty-admin',
+            '/room-admin',
           ]}
           component={UnauthorizedPage}
         />
@@ -100,6 +102,11 @@ const AppRouter: FunctionComponent = (): ReactElement => {
           path="/faculty-admin"
           component={isAdmin ? FacultyAdmin : ForbiddenPage}
         />
+        <Route
+          exact
+          path="/room-admin"
+          component={isAdmin ? RoomAdmin : ForbiddenPage}
+        />
         <Route component={NoMatch} />
       </Switch>
     );
@@ -123,6 +130,7 @@ const AppRouter: FunctionComponent = (): ReactElement => {
           '/room-schedule',
           '/course-admin',
           '/faculty-admin',
+          '/room-admin',
         ]}
         component={UnauthorizedPage}
       />

--- a/src/client/components/layout/__tests__/AppHeader.test.tsx
+++ b/src/client/components/layout/__tests__/AppHeader.test.tsx
@@ -78,6 +78,10 @@ describe('AppHeader', function () {
         const link = queryByText('Faculty Admin');
         assert(link);
       });
+      it('should display the "Room Admin" link', function () {
+        const link = queryByText('Room Admin');
+        assert(link);
+      });
       it('Should display a log out link', function () {
         const link = queryByText('Log Out');
         assert(link);
@@ -124,6 +128,10 @@ describe('AppHeader', function () {
       });
       it('should NOT display the "Faculty Admin" link', function () {
         const link = queryByText('Faculty Admin');
+        assert.strictEqual(link, null);
+      });
+      it('should NOT display the "Room Admin" link', function () {
+        const link = queryByText('Room Admin');
         assert.strictEqual(link, null);
       });
       it('Should display a log out link', function () {
@@ -181,6 +189,10 @@ describe('AppHeader', function () {
     });
     it('should NOT display the "Faculty Admin" link', function () {
       const link = queryByText('Faculty Admin');
+      assert.strictEqual(link, null);
+    });
+    it('should NOT display the "Room Admin" link', function () {
+      const link = queryByText('Room Admin');
       assert.strictEqual(link, null);
     });
     it('Should not display a log out link', function () {

--- a/src/client/components/pages/RoomAdmin/RoomAdmin.tsx
+++ b/src/client/components/pages/RoomAdmin/RoomAdmin.tsx
@@ -1,23 +1,95 @@
+import { faEdit } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { LocationAPI } from 'client/api';
+import { AppMessage, MESSAGE_ACTION, MESSAGE_TYPE } from 'client/classes';
+import { MessageContext } from 'client/context';
+import RoomAdminResponse from 'common/dto/room/RoomAdminResponse.dto';
 import {
+  ALIGN,
+  BorderlessButton,
   Table,
+  TableBody,
+  TableCell,
   TableHead,
   TableHeadingCell,
   TableRow,
+  VARIANT,
 } from 'mark-one';
-import React, { FunctionComponent } from 'react';
+import { TableRowProps } from 'mark-one/lib/Tables/TableRow';
+import React, {
+  FunctionComponent, ReactElement, useCallback, useContext, useEffect, useState,
+} from 'react';
 
-const RoomAdmin: FunctionComponent = () => (
-  <div className="room-admin-table">
-    <Table>
-      <TableHead>
-        <TableRow isStriped>
-          <TableHeadingCell scope="col">Campus</TableHeadingCell>
-          <TableHeadingCell scope="col">Building</TableHeadingCell>
-          <TableHeadingCell scope="col">Room Name</TableHeadingCell>
-        </TableRow>
-      </TableHead>
-    </Table>
-  </div>
-);
+const RoomAdmin: FunctionComponent = () => {
+  /**
+   * Saves a complete list of rooms in local state
+   */
+  const [
+    fullRoomList,
+    setFullRoomList,
+  ] = useState<RoomAdminResponse[]>([]);
+
+  /**
+   * The current value for the message context
+   */
+  const dispatchMessage = useContext(MessageContext);
+
+  const loadRooms = useCallback(async (): Promise<void> => {
+    try {
+      const rooms = await LocationAPI.getAdminRooms();
+      setFullRoomList(rooms);
+    } catch (e) {
+      dispatchMessage({
+        message: new AppMessage(
+          'Unable to get room data from server. If the problem persists, contact SEAS Computing',
+          MESSAGE_TYPE.ERROR
+        ),
+        type: MESSAGE_ACTION.PUSH,
+      });
+    }
+  }, [dispatchMessage]);
+
+  /**
+   * Gets the rooms data from the server.
+   * If it fails, display a message for the user.
+   */
+  useEffect((): void => {
+    void loadRooms();
+  }, [loadRooms]);
+
+  return (
+    <div className="room-admin-table">
+      <Table>
+        <TableHead>
+          <TableRow isStriped>
+            <TableHeadingCell scope="col">Campus</TableHeadingCell>
+            <TableHeadingCell scope="col">Building</TableHeadingCell>
+            <TableHeadingCell scope="col">Room Name</TableHeadingCell>
+            <TableHeadingCell scope="col">Edit</TableHeadingCell>
+          </TableRow>
+        </TableHead>
+        <TableBody isScrollable>
+          {fullRoomList.map((room, i): ReactElement<TableRowProps> => (
+            <TableRow isStriped={i % 2 === 1} key={room.id}>
+              <TableCell>{room.building.campus.name}</TableCell>
+              <TableCell>{room.building.name}</TableCell>
+              <TableCell>{room.name}</TableCell>
+              <TableCell alignment={ALIGN.CENTER}>
+                <BorderlessButton
+                  id={`edit-${room.id}`}
+                  alt={`Edit room information for ${room.building.name} ${room.name}`}
+                  variant={VARIANT.INFO}
+                  onClick={(): void => {}}
+                >
+                  <FontAwesomeIcon icon={faEdit} />
+                </BorderlessButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
 
 export default RoomAdmin;

--- a/src/client/components/pages/RoomAdmin/RoomAdmin.tsx
+++ b/src/client/components/pages/RoomAdmin/RoomAdmin.tsx
@@ -1,0 +1,23 @@
+import {
+  Table,
+  TableHead,
+  TableHeadingCell,
+  TableRow,
+} from 'mark-one';
+import React, { FunctionComponent } from 'react';
+
+const RoomAdmin: FunctionComponent = () => (
+  <div className="room-admin-table">
+    <Table>
+      <TableHead>
+        <TableRow isStriped>
+          <TableHeadingCell scope="col">Campus</TableHeadingCell>
+          <TableHeadingCell scope="col">Building</TableHeadingCell>
+          <TableHeadingCell scope="col">Room Name</TableHeadingCell>
+        </TableRow>
+      </TableHead>
+    </Table>
+  </div>
+);
+
+export default RoomAdmin;

--- a/src/client/components/pages/RoomAdmin/RoomAdmin.tsx
+++ b/src/client/components/pages/RoomAdmin/RoomAdmin.tsx
@@ -65,6 +65,7 @@ const RoomAdmin: FunctionComponent = () => {
             <TableHeadingCell scope="col">Campus</TableHeadingCell>
             <TableHeadingCell scope="col">Building</TableHeadingCell>
             <TableHeadingCell scope="col">Room Name</TableHeadingCell>
+            <TableHeadingCell scope="col">Capacity</TableHeadingCell>
             <TableHeadingCell scope="col">Edit</TableHeadingCell>
           </TableRow>
         </TableHead>
@@ -74,6 +75,7 @@ const RoomAdmin: FunctionComponent = () => {
               <TableCell>{room.building.campus.name}</TableCell>
               <TableCell>{room.building.name}</TableCell>
               <TableCell>{room.name}</TableCell>
+              <TableCell>{room.capacity}</TableCell>
               <TableCell alignment={ALIGN.CENTER}>
                 <BorderlessButton
                   id={`edit-${room.id}`}

--- a/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
+++ b/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
@@ -4,6 +4,7 @@ import {
 } from 'assert';
 import {
   wait,
+  within,
 } from '@testing-library/react';
 import {
   stub,
@@ -43,38 +44,35 @@ describe('Room Admin Table', function () {
             <RoomAdmin />
           );
           await wait(() => getAllByRole('row').length > 1);
-          const rows = Array.from(getAllByRole('row')) as HTMLTableRowElement[];
-          const rowsContent = rows
-            .map(
-              (row) => (Array.from(row.cells).map((cell) => cell.textContent))
-            );
-          // An amalgamation of all room information
-          const roomInfo = [
-            secRoomResponse.name,
-            secRoomResponse.building.name,
-            secRoomResponse.building.campus.name,
-            secRoomResponse.capacity.toString(),
-            oxfordRoomResponse.name,
-            oxfordRoomResponse.building.name,
-            oxfordRoomResponse.building.campus.name,
-            oxfordRoomResponse.capacity.toString(),
-            bauerRoomResponse.name,
-            bauerRoomResponse.building.name,
-            bauerRoomResponse.building.campus.name,
-            bauerRoomResponse.capacity.toString(),
-          ];
-
-          for (let i = 1; i < rows.length; i++) {
-            rowsContent[i] = rowsContent[i].slice(0, -1);
-            rowsContent[i].forEach((data) => {
-              // Remove the Edit column, which contains no table data.
+          const rows = getAllByRole('row').slice(1) as HTMLTableRowElement[];
+          [
+            [
+              secRoomResponse.name,
+              secRoomResponse.building.name,
+              secRoomResponse.building.campus.name,
+              secRoomResponse.capacity.toString(),
+            ],
+            [
+              oxfordRoomResponse.name,
+              oxfordRoomResponse.building.name,
+              oxfordRoomResponse.building.campus.name,
+              oxfordRoomResponse.capacity.toString(),
+            ],
+            [
+              bauerRoomResponse.name,
+              bauerRoomResponse.building.name,
+              bauerRoomResponse.building.campus.name,
+              bauerRoomResponse.capacity.toString(),
+            ],
+          ].forEach((roomData, index) => {
+            roomData.forEach((data) => {
               strictEqual(
-                roomInfo.includes(data),
+                within(rows[index]).queryByText(data) !== null,
                 true,
                 `${data} is not in the table as expected`
               );
             });
-          }
+          });
         });
       });
       context('when there are no room records', function () {

--- a/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
+++ b/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
@@ -23,14 +23,6 @@ import RoomAdmin from '../RoomAdmin';
 
 describe('Room Admin Table', function () {
   let getStub: SinonStub;
-  describe('rendering', function () {
-    it('creates a table', async function () {
-      const { container } = render(
-        <RoomAdmin />
-      );
-      return waitForElement(() => container.querySelector('.room-admin-table'));
-    });
-  });
   describe('data fetching', function () {
     context('when room data fetch succeeds', function () {
       beforeEach(function () {

--- a/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
+++ b/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
@@ -3,7 +3,6 @@ import {
   strictEqual,
 } from 'assert';
 import {
-  waitForElement,
   wait,
 } from '@testing-library/react';
 import {

--- a/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
+++ b/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import {
+  strictEqual,
+} from 'assert';
+import {
+  waitForElement,
+  wait,
+} from '@testing-library/react';
+import {
+  stub,
+  SinonStub,
+} from 'sinon';
+import { render } from 'test-utils';
+import { LocationAPI } from 'client/api';
+import {
+  adminRoomsResponse,
+  bauerRoomResponse,
+  error,
+  oxfordRoomResponse,
+  secRoomResponse,
+} from 'testData';
+import RoomAdmin from '../RoomAdmin';
+
+describe('Room Admin Table', function () {
+  let getStub: SinonStub;
+  describe('rendering', function () {
+    it('creates a table', async function () {
+      const { container } = render(
+        <RoomAdmin />
+      );
+      return waitForElement(() => container.querySelector('.room-admin-table'));
+    });
+  });
+  describe('data fetching', function () {
+    context('when room data fetch succeeds', function () {
+      beforeEach(function () {
+        getStub = stub(LocationAPI, 'getAdminRooms');
+        getStub.resolves(adminRoomsResponse);
+      });
+      context('when there are room records', function () {
+        it('displays the correct number of rows in the table', async function () {
+          const { getAllByRole } = render(
+            <RoomAdmin />
+          );
+          await wait(() => getAllByRole('row').length > 1);
+          const rows = getAllByRole('row');
+          // The "+1" takes the table headers into account for the number of rows
+          strictEqual(rows.length, adminRoomsResponse.length + 1);
+        });
+        it('displays the correct content in the table cells', async function () {
+          const { getAllByRole } = render(
+            <RoomAdmin />
+          );
+          await wait(() => getAllByRole('row').length > 1);
+          const rows = Array.from(getAllByRole('row')) as HTMLTableRowElement[];
+          const rowsContent = rows
+            .map(
+              (row) => (Array.from(row.cells).map((cell) => cell.textContent))
+            );
+          const secRoomCampus = rowsContent[1][0];
+          const secRoomBuilding = rowsContent[1][1];
+          const secRoomName = rowsContent[1][2];
+          const secRoomCapacity = rowsContent[1][3];
+          const oxfordRoomCampus = rowsContent[2][0];
+          const oxfordRoomBuilding = rowsContent[2][1];
+          const oxfordRoomName = rowsContent[2][2];
+          const oxfordRoomCapacity = rowsContent[2][3];
+          const bauerRoomCampus = rowsContent[3][0];
+          const bauerRoomBuilding = rowsContent[3][1];
+          const bauerRoomName = rowsContent[3][2];
+          const bauerRoomCapacity = rowsContent[3][3];
+          strictEqual(
+            secRoomCampus,
+            secRoomResponse.building.campus.name,
+            'The SEC campus is not being displayed as expected.'
+          );
+          strictEqual(
+            secRoomBuilding,
+            secRoomResponse.building.name,
+            'The SEC building is not being displayed as expected.'
+          );
+          strictEqual(
+            secRoomName,
+            secRoomResponse.name,
+            'The SEC room name is not being displayed as expected.'
+          );
+          strictEqual(
+            secRoomCapacity,
+            secRoomResponse.capacity.toString(),
+            'The SEC room capacity is not being displayed as expected.'
+          );
+          strictEqual(
+            oxfordRoomCampus,
+            oxfordRoomResponse.building.campus.name,
+            'The 60 Oxford Street campus is not being displayed as expected.'
+          );
+          strictEqual(
+            oxfordRoomBuilding,
+            oxfordRoomResponse.building.name,
+            'The 60 Oxford Street building is not being displayed as expected.'
+          );
+          strictEqual(
+            oxfordRoomName,
+            oxfordRoomResponse.name,
+            'The 60 Oxford Street room name is not being displayed as expected.'
+          );
+          strictEqual(
+            oxfordRoomCapacity,
+            oxfordRoomResponse.capacity.toString(),
+            'The 60 Oxford Street room capacity is not being displayed as expected.'
+          );
+          strictEqual(
+            bauerRoomCampus,
+            bauerRoomResponse.building.campus.name,
+            'The Bauer room campus is not being displayed as expected.'
+          );
+          strictEqual(
+            bauerRoomBuilding,
+            bauerRoomResponse.building.name,
+            'The Bauer room building is not being displayed as expected.'
+          );
+          strictEqual(
+            bauerRoomName,
+            bauerRoomResponse.name,
+            'The Bauer room name is not being displayed as expected.'
+          );
+          strictEqual(
+            bauerRoomCapacity,
+            bauerRoomResponse.capacity.toString(),
+            'The Bauer room capacity is not being displayed as expected.'
+          );
+        });
+      });
+      context('when there are no room records', function () {
+        const emptyTestData = [];
+        beforeEach(function () {
+          getStub.resolves(emptyTestData);
+        });
+        it('displays the correct number of rows in the table (only the header row)', async function () {
+          const { getAllByRole } = render(
+            <RoomAdmin />
+          );
+          await wait(() => getAllByRole('row').length === emptyTestData.length + 1);
+          const rows = getAllByRole('row');
+          // With the filter, there are two table header rows
+          strictEqual(rows.length, emptyTestData.length + 1);
+        });
+      });
+    });
+    context('when room data fetch fails', function () {
+      const emptyTestData = [];
+      let dispatchMessage: SinonStub;
+      beforeEach(function () {
+        dispatchMessage = stub();
+        getStub = stub(LocationAPI, 'getAdminRooms');
+        getStub.rejects(error);
+      });
+      afterEach(function () {
+        getStub.restore();
+      });
+      it('should throw an error', async function () {
+        const { getAllByRole } = render(
+          <RoomAdmin />,
+          { dispatchMessage }
+        );
+        await wait(() => getAllByRole('row').length === emptyTestData.length + 1);
+        strictEqual(dispatchMessage.callCount, 1);
+      });
+    });
+  });
+});

--- a/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
+++ b/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
@@ -30,7 +30,7 @@ describe('Room Admin Table', function () {
         getStub.resolves(adminRoomsResponse);
       });
       context('when there are room records', function () {
-        it('displays the correct number of rows in the table', async function () {
+        it('displays one table row per room', async function () {
           const { getAllByRole } = render(
             <RoomAdmin />
           );

--- a/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
+++ b/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
@@ -128,7 +128,7 @@ describe('Room Admin Table', function () {
         beforeEach(function () {
           getStub.resolves(emptyTestData);
         });
-        it('displays the correct number of rows in the table (only the header row)', async function () {
+        it('displays only the header row', async function () {
           const { getAllByRole } = render(
             <RoomAdmin />
           );

--- a/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
+++ b/src/client/components/pages/RoomAdmin/__tests__/RoomAdminTable.test.tsx
@@ -48,78 +48,33 @@ describe('Room Admin Table', function () {
             .map(
               (row) => (Array.from(row.cells).map((cell) => cell.textContent))
             );
-          const secRoomCampus = rowsContent[1][0];
-          const secRoomBuilding = rowsContent[1][1];
-          const secRoomName = rowsContent[1][2];
-          const secRoomCapacity = rowsContent[1][3];
-          const oxfordRoomCampus = rowsContent[2][0];
-          const oxfordRoomBuilding = rowsContent[2][1];
-          const oxfordRoomName = rowsContent[2][2];
-          const oxfordRoomCapacity = rowsContent[2][3];
-          const bauerRoomCampus = rowsContent[3][0];
-          const bauerRoomBuilding = rowsContent[3][1];
-          const bauerRoomName = rowsContent[3][2];
-          const bauerRoomCapacity = rowsContent[3][3];
-          strictEqual(
-            secRoomCampus,
-            secRoomResponse.building.campus.name,
-            'The SEC campus is not being displayed as expected.'
-          );
-          strictEqual(
-            secRoomBuilding,
-            secRoomResponse.building.name,
-            'The SEC building is not being displayed as expected.'
-          );
-          strictEqual(
-            secRoomName,
+          // An amalgamation of all room information
+          const roomInfo = [
             secRoomResponse.name,
-            'The SEC room name is not being displayed as expected.'
-          );
-          strictEqual(
-            secRoomCapacity,
+            secRoomResponse.building.name,
+            secRoomResponse.building.campus.name,
             secRoomResponse.capacity.toString(),
-            'The SEC room capacity is not being displayed as expected.'
-          );
-          strictEqual(
-            oxfordRoomCampus,
-            oxfordRoomResponse.building.campus.name,
-            'The 60 Oxford Street campus is not being displayed as expected.'
-          );
-          strictEqual(
-            oxfordRoomBuilding,
-            oxfordRoomResponse.building.name,
-            'The 60 Oxford Street building is not being displayed as expected.'
-          );
-          strictEqual(
-            oxfordRoomName,
             oxfordRoomResponse.name,
-            'The 60 Oxford Street room name is not being displayed as expected.'
-          );
-          strictEqual(
-            oxfordRoomCapacity,
+            oxfordRoomResponse.building.name,
+            oxfordRoomResponse.building.campus.name,
             oxfordRoomResponse.capacity.toString(),
-            'The 60 Oxford Street room capacity is not being displayed as expected.'
-          );
-          strictEqual(
-            bauerRoomCampus,
-            bauerRoomResponse.building.campus.name,
-            'The Bauer room campus is not being displayed as expected.'
-          );
-          strictEqual(
-            bauerRoomBuilding,
-            bauerRoomResponse.building.name,
-            'The Bauer room building is not being displayed as expected.'
-          );
-          strictEqual(
-            bauerRoomName,
             bauerRoomResponse.name,
-            'The Bauer room name is not being displayed as expected.'
-          );
-          strictEqual(
-            bauerRoomCapacity,
+            bauerRoomResponse.building.name,
+            bauerRoomResponse.building.campus.name,
             bauerRoomResponse.capacity.toString(),
-            'The Bauer room capacity is not being displayed as expected.'
-          );
+          ];
+
+          for (let i = 1; i < rows.length; i++) {
+            rowsContent[i] = rowsContent[i].slice(0, -1);
+            rowsContent[i].forEach((data) => {
+              // Remove the Edit column, which contains no table data.
+              strictEqual(
+                roomInfo.includes(data),
+                true,
+                `${data} is not in the table as expected`
+              );
+            });
+          }
         });
       });
       context('when there are no room records', function () {

--- a/src/client/components/pages/index.ts
+++ b/src/client/components/pages/index.ts
@@ -8,3 +8,4 @@ export { default as Schedule } from './Schedule/SchedulePage';
 export { default as NoMatch } from './NoMatch';
 export { default as listFilter } from './Filter';
 export { default as RoomSchedule } from './RoomSchedule/RoomSchedule';
+export { default as RoomAdmin } from './RoomAdmin/RoomAdmin';

--- a/src/common/__tests__/data/locations.ts
+++ b/src/common/__tests__/data/locations.ts
@@ -72,44 +72,62 @@ export const roomRequest: RoomRequest = {
   calendarYear: '2020',
 };
 
+/**
+ * A room response object, for use in testing the room admin table
+ */
+export const secRoomResponse: RoomAdminResponse = {
+  id: '36f876da-f152-4b62-b254-55cee104ceb4',
+  name: '101A',
+  capacity: 20,
+  building: {
+    id: '9b22ae2d-20a8-4e3d-a6ed-7096ee50cd19',
+    name: 'SEC',
+    campus: {
+      id: '73016f1f-11d3-4a60-95a4-34f2864c9408',
+      name: 'Allston',
+    },
+  },
+};
+
+/**
+ * A room response object, for use in testing the room admin table
+ */
+export const oxfordRoomResponse: RoomAdminResponse = {
+  id: '2d545f2e-ebc7-48d2-a7e3-59bb120233a2',
+  name: '330',
+  capacity: 60,
+  building: {
+    id: 'ec635477-d92f-4ebd-a3a1-322c899488e3',
+    name: '60 Oxford Street',
+    campus: {
+      id: 'def023e0-d47a-4346-bdfb-bf7daed9e18d',
+      name: 'Cambridge',
+    },
+  },
+};
+
+/**
+ * A room response object, for use in testing the room admin table
+ */
+export const bauerRoomResponse: RoomAdminResponse = {
+  id: '7298b3fb-ad0a-42aa-ba1e-62052984e1e0',
+  name: 'Bauer G18 Naito Lobby',
+  capacity: 100,
+  building: {
+    id: 'd0dbf5ae-ed8f-4b39-bcab-dd644aff4c4f',
+    name: 'Bauer Laboratory',
+    campus: {
+      id: 'aa6099b1-8d07-478d-94ba-abd2a97c1920',
+      name: 'Cambridge',
+    },
+  },
+};
+
+/**
+ * An array of room responses, for use in testing the room admin table
+ */
 export const adminRoomsResponse: RoomAdminResponse[] = [
-  {
-    id: '36f876da-f152-4b62-b254-55cee104ceb4',
-    name: '101A',
-    capacity: 20,
-    building: {
-      id: '9b22ae2d-20a8-4e3d-a6ed-7096ee50cd19',
-      name: 'SEC',
-      campus: {
-        id: '73016f1f-11d3-4a60-95a4-34f2864c9408',
-        name: 'Allston',
-      },
-    },
-  },
-  {
-    id: '2d545f2e-ebc7-48d2-a7e3-59bb120233a2',
-    name: '330',
-    capacity: 60,
-    building: {
-      id: 'ec635477-d92f-4ebd-a3a1-322c899488e3',
-      name: '60 Oxford Street',
-      campus: {
-        id: 'def023e0-d47a-4346-bdfb-bf7daed9e18d',
-        name: 'Cambridge',
-      },
-    },
-  },
-  {
-    id: '7298b3fb-ad0a-42aa-ba1e-62052984e1e0',
-    name: 'Bauer G18 Naito Lobby',
-    capacity: 100,
-    building: {
-      id: 'd0dbf5ae-ed8f-4b39-bcab-dd644aff4c4f',
-      name: 'Bauer Laboratory',
-      campus: {
-        id: 'aa6099b1-8d07-478d-94ba-abd2a97c1920',
-        name: 'Cambridge',
-      },
-    },
-  },
+  secRoomResponse,
+  oxfordRoomResponse,
+  bauerRoomResponse,
 ];

--- a/src/common/__tests__/data/locations.ts
+++ b/src/common/__tests__/data/locations.ts
@@ -1,3 +1,4 @@
+import RoomAdminResponse from 'common/dto/room/RoomAdminResponse.dto';
 import RoomMeetingResponse from 'common/dto/room/RoomMeetingResponse.dto';
 import { DAY, TERM } from '../../constants';
 import RoomRequest from '../../dto/room/RoomRequest.dto';
@@ -70,3 +71,45 @@ export const roomRequest: RoomRequest = {
   term: TERM.FALL,
   calendarYear: '2020',
 };
+
+export const adminRoomsResponse: RoomAdminResponse[] = [
+  {
+    id: '36f876da-f152-4b62-b254-55cee104ceb4',
+    name: '101A',
+    capacity: 20,
+    building: {
+      id: '9b22ae2d-20a8-4e3d-a6ed-7096ee50cd19',
+      name: 'SEC',
+      campus: {
+        id: '73016f1f-11d3-4a60-95a4-34f2864c9408',
+        name: 'Allston',
+      },
+    },
+  },
+  {
+    id: '2d545f2e-ebc7-48d2-a7e3-59bb120233a2',
+    name: '330',
+    capacity: 60,
+    building: {
+      id: 'ec635477-d92f-4ebd-a3a1-322c899488e3',
+      name: '60 Oxford Street',
+      campus: {
+        id: 'def023e0-d47a-4346-bdfb-bf7daed9e18d',
+        name: 'Cambridge',
+      },
+    },
+  },
+  {
+    id: '7298b3fb-ad0a-42aa-ba1e-62052984e1e0',
+    name: 'Bauer G18 Naito Lobby',
+    capacity: 100,
+    building: {
+      id: 'd0dbf5ae-ed8f-4b39-bcab-dd644aff4c4f',
+      name: 'Bauer Laboratory',
+      campus: {
+        id: 'aa6099b1-8d07-478d-94ba-abd2a97c1920',
+        name: 'Cambridge',
+      },
+    },
+  },
+];

--- a/src/common/dto/room/RoomAdminResponse.dto.ts
+++ b/src/common/dto/room/RoomAdminResponse.dto.ts
@@ -1,12 +1,48 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-interface BuildingInfo {
-  id: string;
-  name: string;
-  campus: {
-    id: string;
-    name: string;
-  }
+export abstract class CampusInfo {
+  /**
+   * The database uuid of the campus
+   */
+  @ApiProperty({
+    type: 'string',
+    example: 'a1f2651d-db94-4565-8816-b8ce9d3533ab',
+  })
+  public id: string;
+
+  /**
+   * The campus name
+   */
+  @ApiProperty({
+    type: 'string',
+    example: 'Allston',
+  })
+  public name: string;
+}
+
+export abstract class BuildingInfo {
+  /**
+   * The database uuid of the building
+   */
+  @ApiProperty({
+    type: 'string',
+    example: 'bf1f7364-b53a-49f6-a8e5-393b770d1ede',
+  })
+  public id: string;
+
+  /**
+   * The building name
+   */
+  @ApiProperty({
+    type: 'string',
+    example: 'SEC',
+  })
+  public name: string;
+
+  @ApiProperty({
+    type: CampusInfo,
+  })
+  public campus: CampusInfo;
 }
 
 export default abstract class RoomAdminResponse {
@@ -37,19 +73,8 @@ export default abstract class RoomAdminResponse {
   })
   public capacity: number;
 
-  /**
-   * The building and campus name information of the room
-   */
   @ApiProperty({
-    example: {
-      id: 'b5478231-478e-464d-b29c-45c98fa472b3',
-      name: 'Maxwell Dworkin',
-      campus: {
-        id: '4193a3e5-5987-4083-97cf-a949c146260f',
-        name: 'Cambridge',
-      },
-    },
-    isArray: false,
+    type: BuildingInfo,
   })
   public building: BuildingInfo;
 }

--- a/src/common/dto/room/RoomAdminResponse.dto.ts
+++ b/src/common/dto/room/RoomAdminResponse.dto.ts
@@ -1,0 +1,55 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+interface BuildingInfo {
+  id: string;
+  name: string;
+  campus: {
+    id: string;
+    name: string;
+  }
+}
+
+export default abstract class RoomAdminResponse {
+  /**
+   * The database uuid of the room
+   */
+  @ApiProperty({
+    type: 'string',
+    example: '861f3bca-e318-4c02-976c-53d60a2c09bc',
+  })
+  public id: string;
+
+  /**
+   * The room number
+   */
+  @ApiProperty({
+    type: 'string',
+    example: '125',
+  })
+  public name: string;
+
+  /**
+   * The maximum number of people that can occupy the room at a time
+   */
+  @ApiProperty({
+    type: 'number',
+    example: 200,
+  })
+  public capacity: number;
+
+  /**
+   * The building and campus name information of the room
+   */
+  @ApiProperty({
+    example: {
+      id: 'b5478231-478e-464d-b29c-45c98fa472b3',
+      name: 'Maxwell Dworkin',
+      campus: {
+        id: '4193a3e5-5987-4083-97cf-a949c146260f',
+        name: 'Cambridge',
+      },
+    },
+    isArray: false,
+  })
+  public building: BuildingInfo;
+}

--- a/src/server/location/location.controller.ts
+++ b/src/server/location/location.controller.ts
@@ -14,6 +14,7 @@ import { Authentication } from 'server/auth/authentication.guard';
 import RoomResponse from 'common/dto/room/RoomResponse.dto';
 import RoomRequest from 'common/dto/room/RoomRequest.dto';
 import RoomMeetingResponse from 'common/dto/room/RoomMeetingResponse.dto';
+import RoomAdminResponse from 'common/dto/room/RoomAdminResponse.dto';
 import { LocationService } from './location.service';
 
 @ApiTags('Rooms')
@@ -50,5 +51,16 @@ export class LocationController {
   public async getRoomAvailability(@Query() roomInfo: RoomRequest)
     : Promise<RoomMeetingResponse[]> {
     return this.locationService.getRooms(roomInfo);
+  }
+
+  @Get('/admin')
+  @ApiOperation({ summary: 'Retrieve all room names and corresponding building and campus data' })
+  @ApiOkResponse({
+    type: RoomAdminResponse,
+    description: 'An array of all room names and corresponding building and campus data',
+    isArray: true,
+  })
+  public async getAdminRooms(): Promise<RoomAdminResponse[]> {
+    return this.locationService.getAdminRooms();
   }
 }

--- a/src/server/location/location.controller.ts
+++ b/src/server/location/location.controller.ts
@@ -60,7 +60,7 @@ export class LocationController {
     description: 'An array of all room names and corresponding building and campus data',
     isArray: true,
   })
-  public async getAdminRooms(): Promise<RoomAdminResponse[]> {
+  public async getFullRoomList(): Promise<RoomAdminResponse[]> {
     return this.locationService.getFullRoomList();
   }
 }

--- a/src/server/location/location.controller.ts
+++ b/src/server/location/location.controller.ts
@@ -50,7 +50,7 @@ export class LocationController {
   })
   public async getRoomAvailability(@Query() roomInfo: RoomRequest)
     : Promise<RoomMeetingResponse[]> {
-    return this.locationService.getRooms(roomInfo);
+    return this.locationService.getRoomAvailability(roomInfo);
   }
 
   @Get('/admin')
@@ -61,6 +61,6 @@ export class LocationController {
     isArray: true,
   })
   public async getAdminRooms(): Promise<RoomAdminResponse[]> {
-    return this.locationService.getAdminRooms();
+    return this.locationService.getFullRoomList();
   }
 }

--- a/src/server/location/location.module.ts
+++ b/src/server/location/location.module.ts
@@ -4,12 +4,14 @@ import { RoomBookingInfoView } from 'server/location/RoomBookingInfoView.entity'
 import { RoomListingView } from 'server/location/RoomListingView.entity';
 import { LocationController } from './location.controller';
 import { LocationService } from './location.service';
+import { Room } from './room.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
       RoomListingView,
       RoomBookingInfoView,
+      Room,
     ]),
   ],
   controllers: [LocationController],

--- a/src/server/location/location.service.ts
+++ b/src/server/location/location.service.ts
@@ -5,7 +5,9 @@ import { RoomListingView } from 'server/location/RoomListingView.entity';
 import RoomResponse from 'common/dto/room/RoomResponse.dto';
 import RoomRequest from 'common/dto/room/RoomRequest.dto';
 import RoomMeetingResponse from 'common/dto/room/RoomMeetingResponse.dto';
+import RoomAdminResponse from 'common/dto/room/RoomAdminResponse.dto';
 import { RoomBookingInfoView } from './RoomBookingInfoView.entity';
+import { Room } from './room.entity';
 
 /**
  * A service for managing room, building, and campus entities in the database.
@@ -32,6 +34,9 @@ export class LocationService {
 
   @InjectRepository(RoomBookingInfoView)
   private readonly roomBookingRepository: Repository<RoomBookingInfoView>;
+
+  @InjectRepository(Room)
+  private roomRepository: Repository<Room>;
 
   /**
    * Retrieves all rooms in the database along with their campus and capacity
@@ -139,5 +144,26 @@ export class LocationService {
       meetingTitles: meetings
         .filter((title) => !!title),
     }));
+  }
+
+  /**
+   * Resolves with a list of rooms along with their associated campus and
+   * building information. This is used to populate the Room Admin table.
+   */
+  public async getAdminRooms(): Promise<RoomAdminResponse[]> {
+    return this.roomRepository
+      .createQueryBuilder('r')
+      .leftJoinAndSelect(
+        'r.building',
+        'building'
+      )
+      .leftJoinAndSelect(
+        'building.campus',
+        'campus'
+      )
+      .orderBy('campus.name', 'ASC')
+      .addOrderBy('building.name', 'ASC')
+      .addOrderBy('r.name', 'ASC')
+      .getMany() as Promise<RoomAdminResponse[]>;
   }
 }

--- a/src/server/location/location.service.ts
+++ b/src/server/location/location.service.ts
@@ -148,7 +148,7 @@ export class LocationService {
 
   /**
    * Resolves with a list of rooms along with their associated campus and
-   * building information. This is used to populate the Room Admin table.
+   * building information.
    */
   public async getAdminRooms(): Promise<RoomAdminResponse[]> {
     return this.roomRepository

--- a/src/server/location/location.service.ts
+++ b/src/server/location/location.service.ts
@@ -104,7 +104,7 @@ export class LocationService {
    * the server so that we can strictly compare by UUID, not by the
    * (potentially not unique) meeting title string.
    */
-  public async getRooms(
+  public async getRoomAvailability(
     {
       excludeParent,
       ...roomInfo
@@ -150,7 +150,7 @@ export class LocationService {
    * Resolves with a list of rooms along with their associated campus and
    * building information.
    */
-  public async getAdminRooms(): Promise<RoomAdminResponse[]> {
+  public async getFullRoomList(): Promise<RoomAdminResponse[]> {
     return this.roomRepository
       .createQueryBuilder('r')
       .leftJoinAndSelect(

--- a/tests/integration/e2e/AppRouter.test.tsx
+++ b/tests/integration/e2e/AppRouter.test.tsx
@@ -127,6 +127,16 @@ describe('Application Routing and Authorization', function () {
           return findAllByText(/HUID/);
         });
       });
+      context('/room-admin', function () {
+        it('renders the RoomAdmin component', function () {
+          const { findAllByText } = render(
+            <MemoryRouter initialEntries={['/room-admin']}>
+              <App />
+            </MemoryRouter>
+          );
+          return findAllByText(/Building/);
+        });
+      });
       context('/faculty', function () {
         it('renders the Faculty component', function () {
           const { findAllByText } = render(
@@ -216,6 +226,16 @@ describe('Application Routing and Authorization', function () {
         it('renders the NoMatch component', function () {
           const { findByText } = render(
             <MemoryRouter initialEntries={['/faculty-admin']}>
+              <App />
+            </MemoryRouter>
+          );
+          return findByText(/403/);
+        });
+      });
+      context('/room-admin', function () {
+        it('renders the NoMatch component', function () {
+          const { findByText } = render(
+            <MemoryRouter initialEntries={['/room-admin']}>
               <App />
             </MemoryRouter>
           );
@@ -323,6 +343,16 @@ describe('Application Routing and Authorization', function () {
           return findByText(/401/);
         });
       });
+      context('/room-admin', function () {
+        it('renders the UnauthorizedPage component', function () {
+          const { findByText } = render(
+            <MemoryRouter initialEntries={['/room-admin']}>
+              <App />
+            </MemoryRouter>
+          );
+          return findByText(/401/);
+        });
+      });
       context('/faculty', function () {
         it('renders the UnauthorizedPage component', function () {
           const { findByText } = render(
@@ -413,6 +443,16 @@ describe('Application Routing and Authorization', function () {
         it('renders the UnauthorizedPage component', function () {
           const { findByText } = render(
             <MemoryRouter initialEntries={['/faculty-admin']}>
+              <App />
+            </MemoryRouter>
+          );
+          return findByText(/401/);
+        });
+      });
+      context('/room-admin', function () {
+        it('renders the UnauthorizedPage component', function () {
+          const { findByText } = render(
+            <MemoryRouter initialEntries={['/room-admin']}>
               <App />
             </MemoryRouter>
           );

--- a/tests/integration/server/location/location.controller.test.ts
+++ b/tests/integration/server/location/location.controller.test.ts
@@ -427,7 +427,7 @@ describe('Location API', function () {
         result = response.body;
       });
       it('returns all rooms in the database', async function () {
-        let expectedRooms: RoomAdminResponse[] = await locationRepo.createQueryBuilder('r')
+        const expectedRooms: RoomAdminResponse[] = await locationRepo.createQueryBuilder('r')
           .leftJoinAndSelect(
             'r.building',
             'building'
@@ -440,20 +440,9 @@ describe('Location API', function () {
           .addOrderBy('building.name', 'ASC')
           .addOrderBy('r.name', 'ASC')
           .getMany();
-        expectedRooms = expectedRooms.map((room) => ({
-          id: room.id,
-          name: room.name,
-          capacity: room.capacity,
-          building: {
-            id: room.building.id,
-            name: room.building.name,
-            campus: {
-              id: room.building.campus.id,
-              name: room.building.campus.name,
-            },
-          },
-        }));
-        deepStrictEqual(result, expectedRooms);
+        const expectedRoomIds = expectedRooms.map((room) => room.id).sort();
+        const resultIds = result.map((room) => room.id).sort();
+        deepStrictEqual(expectedRoomIds, resultIds);
       });
     });
     context('As a non-admin user', function () {

--- a/tests/integration/server/location/location.controller.test.ts
+++ b/tests/integration/server/location/location.controller.test.ts
@@ -408,7 +408,7 @@ describe('Location API', function () {
       beforeEach(function () {
         authStub.resolves(null);
       });
-      it('should return a 400 status', async function () {
+      it('returns a forbidden error', async function () {
         authStub.rejects(new ForbiddenException());
 
         response = await request(api)

--- a/tests/integration/server/location/location.controller.test.ts
+++ b/tests/integration/server/location/location.controller.test.ts
@@ -426,13 +426,6 @@ describe('Location API', function () {
           .get('/api/rooms/admin');
         result = response.body;
       });
-      it('should return a 200 status', function () {
-        strictEqual(response.status, HttpStatus.OK);
-      });
-      it('should return a nonempty array of data', function () {
-        strictEqual(Array.isArray(result), true);
-        notStrictEqual(result.length, 0);
-      });
       it('returns all rooms in the database', async function () {
         let expectedRooms: RoomAdminResponse[] = await locationRepo.createQueryBuilder('r')
           .leftJoinAndSelect(


### PR DESCRIPTION
This PR adds the initial Room Admin page, which includes the room admin table with campus, building, name, and capacity information. The functionality of the edit buttons will be implemented in a future ticket. 

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #566

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
