### PR TITLE
Add Campus Information to Metadata

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -59,6 +59,7 @@ const App: FunctionComponent = (): ReactElement => {
     areas: [],
     semesters: [],
     catalogPrefixes: [],
+    campuses: [],
   });
 
   const metadataContext = new MetadataContextValue(currentMetadata,

--- a/src/client/components/__tests__/App.test.tsx
+++ b/src/client/components/__tests__/App.test.tsx
@@ -43,6 +43,7 @@ describe('App', function () {
           areas: [],
           semesters: [],
           catalogPrefixes: [],
+          campuses: [],
         }
       )
       .returns(
@@ -52,6 +53,7 @@ describe('App', function () {
             areas: [],
             semesters: [],
             catalogPrefixes: [],
+            campuses: [],
           },
           setMetaStateStub,
         ]

--- a/src/common/__tests__/data/metadata.ts
+++ b/src/common/__tests__/data/metadata.ts
@@ -1,5 +1,6 @@
 import { TERM } from 'common/constants';
 import { MetadataResponse } from 'common/dto/metadata/MetadataResponse.dto';
+import { CampusResponse } from 'common/dto/room/CampusResponse.dto';
 
 /**
  * Example of an academic year
@@ -27,6 +28,83 @@ const semesters = [
 const catalogPrefixes = ['AC', 'AM', 'AP', 'BE', 'CS', 'ES', 'ESE', 'GENED', 'SEMINAR'];
 
 /**
+ * Example of campuses along with their building and room information
+ */
+const campuses: CampusResponse[] = [
+  {
+    id: '0badd038-a4d1-4e29-8a60-e2092f110e33',
+    name: 'Allston',
+    buildings: [
+      {
+        id: 'def023e0-d47a-4346-bdfb-bf7daed9e18d',
+        name: 'SEC',
+        rooms: [
+          {
+            id: '18e44241-ecb5-4fa7-b857-60d4cc76bb83',
+            name: '211',
+            capacity: 75,
+          },
+          {
+            id: 'bf1f7364-b53a-49f6-a8e5-393b770d1ede',
+            name: '150',
+            capacity: 40,
+          },
+        ],
+      },
+      {
+        id: '2de0aaac-dc6e-4871-acc5-7569d2a72548',
+        name: '114 Western Ave',
+        rooms: [
+          {
+            id: 'a6040e74-ddfe-4995-a66c-9586fb12e2e9',
+            name: '101B',
+            capacity: 100,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '4d8f7196-1d46-4e2d-9461-fd1c618aba3b',
+    name: 'Cambridge',
+    buildings: [
+      {
+        id: '40853f0e-1185-4871-9b8b-f4b73750a9ad',
+        name: 'Maxwell Dworkin',
+        rooms: [
+          {
+            id: 'ec635477-d92f-4ebd-a3a1-322c899488e3',
+            name: '201A',
+            capacity: 75,
+          },
+          {
+            id: 'bf1f7364-b53a-49f6-a8e5-393b770d1ede',
+            name: '202A',
+            capacity: 150,
+          },
+        ],
+      },
+      {
+        id: '2d545f2e-ebc7-48d2-a7e3-59bb120233a2',
+        name: 'Pierce Hall',
+        rooms: [
+          {
+            id: 'f9e810d1-a825-452c-9a58-8d9ce15b778f',
+            name: '108B',
+            capacity: 35,
+          },
+          {
+            id: 'c67e066f-b0c5-4997-987d-9b66ef68f384',
+            name: '101C',
+            capacity: 50,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+/**
  * Example of the data returned from the /api/metadata endpoint, used for
  * populating certain fields throughout the app.
  */
@@ -35,4 +113,5 @@ export const metadata: MetadataResponse = {
   areas,
   semesters,
   catalogPrefixes,
+  campuses,
 };

--- a/src/common/dto/metadata/MetadataResponse.dto.ts
+++ b/src/common/dto/metadata/MetadataResponse.dto.ts
@@ -6,6 +6,7 @@
  */
 
 import { ApiProperty } from '@nestjs/swagger';
+import { CampusResponse } from '../room/CampusResponse.dto';
 
 export abstract class MetadataResponse {
   @ApiProperty({
@@ -34,4 +35,10 @@ export abstract class MetadataResponse {
     isArray: true,
   })
   public catalogPrefixes: string[];
+
+  @ApiProperty({
+    type: CampusResponse,
+    isArray: true,
+  })
+  public campuses: CampusResponse[];
 }

--- a/src/common/dto/room/CampusResponse.dto.ts
+++ b/src/common/dto/room/CampusResponse.dto.ts
@@ -1,0 +1,93 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsUUID,
+} from 'class-validator';
+
+abstract class RoomInfo {
+  /**
+   * The uuid of the room
+   */
+  @ApiProperty({
+    example: 'acda43fe-db55-4a68-87db-b10dd9bf4a84',
+  })
+  @IsUUID()
+  @IsNotEmpty()
+  id: string;
+
+  /**
+   * The name of the room
+   */
+  @ApiProperty({
+    example: '101a',
+  })
+  @IsNotEmpty()
+  name: string;
+
+  /**
+   * The maximum number of people that can occupy the room at a time
+   */
+  @ApiProperty({
+    type: 'number',
+    example: 200,
+  })
+  public capacity: number;
+}
+
+abstract class BuildingInfo {
+  /**
+   * The uuid of the building
+   */
+  @ApiProperty({
+    example: '6ed133e9-7917-4fe7-b57f-3d1c353ec320',
+  })
+  @IsUUID()
+  @IsNotEmpty()
+  id: string;
+
+  /**
+   * The name of the building
+   */
+  @ApiProperty({
+    example: 'SEC',
+  })
+  @IsNotEmpty()
+  name: string;
+
+  /**
+   * The rooms associated with this campus
+   */
+  @ApiProperty({
+    type: RoomInfo,
+  })
+  rooms: RoomInfo[];
+}
+
+export abstract class CampusResponse {
+  /**
+   * The uuid of the campus
+   */
+  @ApiProperty({
+    example: 'b7d903ba-e298-42fb-ba97-c06c1e278cea',
+  })
+  @IsUUID()
+  @IsNotEmpty()
+  id: string;
+
+  /**
+   * The name of the campus
+   */
+  @ApiProperty({
+    example: 'Cambridge',
+  })
+  @IsNotEmpty()
+  name: string;
+
+  /**
+   * The buildings associated with this campus
+   */
+  @ApiProperty({
+    type: BuildingInfo,
+  })
+  buildings: BuildingInfo[];
+}

--- a/src/server/location/__tests__/location.service.test.ts
+++ b/src/server/location/__tests__/location.service.test.ts
@@ -7,7 +7,6 @@ import {
 } from 'sinon';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import {
-  strictEqual,
   deepStrictEqual,
 } from 'assert';
 import { SelectQueryBuilder } from 'typeorm';

--- a/src/server/location/__tests__/location.service.test.ts
+++ b/src/server/location/__tests__/location.service.test.ts
@@ -1,0 +1,138 @@
+import { TestingModule, Test } from '@nestjs/testing';
+import {
+  stub,
+  SinonStub,
+  createStubInstance,
+  SinonStubbedInstance,
+} from 'sinon';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  strictEqual,
+  deepStrictEqual,
+} from 'assert';
+import { SelectQueryBuilder } from 'typeorm';
+import { CampusResponse } from 'common/dto/room/CampusResponse.dto';
+import flatMap from 'lodash.flatmap';
+import { LocationService } from '../location.service';
+import { metadata } from '../../../common/__tests__/data/metadata';
+import { Campus } from '../campus.entity';
+import { Room } from '../room.entity';
+import { RoomBookingInfoView } from '../RoomBookingInfoView.entity';
+import { RoomListingView } from '../RoomListingView.entity';
+
+describe('Location service', function () {
+  let locationService: LocationService;
+  let mockLocationQueryBuilder
+  : SinonStubbedInstance<SelectQueryBuilder<CampusResponse>>;
+  let mockRoomListingViewRepository: Record<string, SinonStub>;
+  let mockRoomBookingRepository: Record<string, SinonStub>;
+  let mockRoomRepository: Record<string, SinonStub>;
+  let mockCampusRepository: Record<string, SinonStub>;
+
+  beforeEach(async function () {
+    mockLocationQueryBuilder = createStubInstance(SelectQueryBuilder);
+    mockLocationQueryBuilder.leftJoinAndSelect.returnsThis();
+    mockLocationQueryBuilder.orderBy.returnsThis();
+    mockLocationQueryBuilder.addOrderBy.returnsThis();
+    mockLocationQueryBuilder.getMany.resolves(metadata.campuses);
+
+    mockRoomListingViewRepository = {
+      find: stub(),
+      createQueryBuilder: stub().returns(mockLocationQueryBuilder),
+    };
+
+    mockRoomBookingRepository = {
+      createQueryBuilder: stub().returns(mockLocationQueryBuilder),
+    };
+
+    mockRoomRepository = {
+      find: stub(),
+      save: stub(),
+      createQueryBuilder: stub().returns(mockLocationQueryBuilder),
+    };
+
+    mockCampusRepository = {
+      createQueryBuilder: stub().returns(mockLocationQueryBuilder),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LocationService,
+        {
+          provide: getRepositoryToken(RoomListingView),
+          useValue: mockRoomListingViewRepository,
+        },
+        {
+          provide: getRepositoryToken(RoomBookingInfoView),
+          useValue: mockRoomBookingRepository,
+        },
+        {
+          provide: getRepositoryToken(Room),
+          useValue: mockRoomRepository,
+        },
+        {
+          provide: getRepositoryToken(Campus),
+          useValue: mockCampusRepository,
+        },
+      ],
+      controllers: [],
+    }).compile();
+
+    locationService = module.get<LocationService>(LocationService);
+  });
+  describe('getCampusMetadata', function () {
+    context('When there are records in the database', function () {
+      beforeEach(function () {
+        mockLocationQueryBuilder.leftJoinAndSelect.returnsThis();
+        mockLocationQueryBuilder.orderBy.returnsThis();
+        mockLocationQueryBuilder.addOrderBy.returnsThis();
+        mockLocationQueryBuilder.getMany.resolves(metadata.campuses);
+      });
+      it('should return all campuses', async function () {
+        const result = await locationService.getCampusMetadata();
+        const actualCampuses = result.map((campus) => campus.name);
+        const expectedCampuses = metadata.campuses
+          .map((campus) => campus.name).sort();
+        deepStrictEqual(actualCampuses, expectedCampuses);
+      });
+      it('should return all buildings', async function () {
+        const result = await locationService.getCampusMetadata();
+        const actualBuildings = flatMap(result
+          .map((campus) => campus.buildings)
+          .map((buildings) => buildings
+            .map((building) => building.name))).sort();
+        const expectedBuildings = flatMap(metadata.campuses
+          .map((campus) => campus.buildings)
+          .map((buildings) => buildings
+            .map((building) => building.name))).sort();
+        deepStrictEqual(actualBuildings, expectedBuildings);
+      });
+      it('should return all rooms', async function () {
+        const result = await locationService.getCampusMetadata();
+        const actualRooms = flatMap(result
+          .map((campus) => campus.buildings)
+          .map((buildings) => buildings
+            .map((building) => building.rooms
+              .map((room) => room.name)))).sort();
+        const expectedRooms = flatMap(metadata.campuses
+          .map((campus) => campus.buildings)
+          .map((buildings) => buildings
+            .map((building) => building.rooms
+              .map((room) => room.name)))).sort();
+        deepStrictEqual(actualRooms, expectedRooms);
+      });
+    });
+    context('When there are no records in the database', function () {
+      beforeEach(function () {
+        mockLocationQueryBuilder.leftJoinAndSelect.returnsThis();
+        mockLocationQueryBuilder.orderBy.returnsThis();
+        mockLocationQueryBuilder.addOrderBy.returnsThis();
+        mockLocationQueryBuilder.getMany.resolves([]);
+      });
+      it('should return an empty array', async function () {
+        const result = await locationService.getCampusMetadata();
+        deepStrictEqual(result, []);
+      });
+    });
+  });
+});

--- a/src/server/location/location.module.ts
+++ b/src/server/location/location.module.ts
@@ -5,6 +5,8 @@ import { RoomListingView } from 'server/location/RoomListingView.entity';
 import { LocationController } from './location.controller';
 import { LocationService } from './location.service';
 import { Room } from './room.entity';
+import { Campus } from './campus.entity';
+import { Building } from './building.entity';
 
 @Module({
   imports: [
@@ -12,6 +14,8 @@ import { Room } from './room.entity';
       RoomListingView,
       RoomBookingInfoView,
       Room,
+      Campus,
+      Building,
     ]),
   ],
   controllers: [LocationController],

--- a/src/server/location/location.service.ts
+++ b/src/server/location/location.service.ts
@@ -6,8 +6,10 @@ import RoomResponse from 'common/dto/room/RoomResponse.dto';
 import RoomRequest from 'common/dto/room/RoomRequest.dto';
 import RoomMeetingResponse from 'common/dto/room/RoomMeetingResponse.dto';
 import RoomAdminResponse from 'common/dto/room/RoomAdminResponse.dto';
+import { CampusResponse } from 'common/dto/room/CampusResponse.dto';
 import { RoomBookingInfoView } from './RoomBookingInfoView.entity';
 import { Room } from './room.entity';
+import { Campus } from './campus.entity';
 
 /**
  * A service for managing room, building, and campus entities in the database.
@@ -37,6 +39,9 @@ export class LocationService {
 
   @InjectRepository(Room)
   private roomRepository: Repository<Room>;
+
+  @InjectRepository(Campus)
+  private campusRepository: Repository<Campus>;
 
   /**
    * Retrieves all rooms in the database along with their campus and capacity
@@ -165,5 +170,25 @@ export class LocationService {
       .addOrderBy('building.name', 'ASC')
       .addOrderBy('r.name', 'ASC')
       .getMany() as Promise<RoomAdminResponse[]>;
+  }
+
+  /**
+   * Returns a list of campuses along with their building and room information.
+   */
+  public async getCampusMetadata(): Promise<CampusResponse[]> {
+    return await this.campusRepository
+      .createQueryBuilder('c')
+      .leftJoinAndSelect(
+        'c.buildings',
+        'b'
+      )
+      .leftJoinAndSelect(
+        'b.rooms',
+        'r'
+      )
+      .orderBy('c.name', 'ASC')
+      .addOrderBy('b.name', 'ASC')
+      .addOrderBy('r.name', 'ASC')
+      .getMany() as CampusResponse[];
   }
 }

--- a/src/server/metadata/__tests__/metadata.controller.test.ts
+++ b/src/server/metadata/__tests__/metadata.controller.test.ts
@@ -5,13 +5,23 @@ import { AreaService } from 'server/area/area.service';
 import { ConfigService } from 'server/config/config.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Authentication } from 'server/auth/authentication.guard';
-import { rawAreaList, rawCatalogPrefixList, rawSemesterList } from 'testData';
+import {
+  metadata,
+  rawAreaList,
+  rawCatalogPrefixList,
+  rawSemesterList,
+} from 'testData';
 import { strictEqual } from 'assert';
 import { Area } from 'server/area/area.entity';
 import { Semester } from 'server/semester/semester.entity';
 import { MetadataResponse } from 'common/dto/metadata/MetadataResponse.dto';
 import { CourseService } from 'server/course/course.service';
 import { Course } from 'server/course/course.entity';
+import { LocationService } from 'server/location/location.service';
+import { RoomListingView } from 'server/location/RoomListingView.entity';
+import { RoomBookingInfoView } from 'server/location/RoomBookingInfoView.entity';
+import { Room } from 'server/location/room.entity';
+import { Campus } from 'server/location/campus.entity';
 import { MetadataController } from '../metadata.controller';
 
 describe('Metadata Controller', function () {
@@ -20,11 +30,13 @@ describe('Metadata Controller', function () {
   let getSemesterListStub: SinonStub;
   let findAreaStub: SinonStub;
   let getCatalogPrefixListStub: SinonStub;
+  let getCampusMetadataStub: SinonStub;
   const mockRepository: Record<string, SinonStub> = {};
   beforeEach(async function () {
     getSemesterListStub = stub();
     findAreaStub = stub();
     getCatalogPrefixListStub = stub();
+    getCampusMetadataStub = stub();
     const testModule = await Test.createTestingModule({
       controllers: [MetadataController],
       providers: [
@@ -47,6 +59,12 @@ describe('Metadata Controller', function () {
           },
         },
         {
+          provide: LocationService,
+          useValue: {
+            getCampusMetadata: getCampusMetadataStub,
+          },
+        },
+        {
           provide: getRepositoryToken(Area),
           useValue: mockRepository,
         },
@@ -56,6 +74,22 @@ describe('Metadata Controller', function () {
         },
         {
           provide: getRepositoryToken(Course),
+          useValue: mockRepository,
+        },
+        {
+          provide: getRepositoryToken(RoomListingView),
+          useValue: mockRepository,
+        },
+        {
+          provide: getRepositoryToken(RoomBookingInfoView),
+          useValue: mockRepository,
+        },
+        {
+          provide: getRepositoryToken(Room),
+          useValue: mockRepository,
+        },
+        {
+          provide: getRepositoryToken(Campus),
           useValue: mockRepository,
         },
         ConfigService,
@@ -72,7 +106,7 @@ describe('Metadata Controller', function () {
   });
   describe('/api/metadata/', function () {
     describe('Get all metadata', function () {
-      let metadata: MetadataResponse;
+      let metadataResponse: MetadataResponse;
       const expectedAcademicYear = 2021;
       const expectedAreas = rawAreaList.map((area) => area.name);
       const expectedSemesters = rawSemesterList
@@ -85,22 +119,27 @@ describe('Metadata Controller', function () {
         findAreaStub.resolves(expectedAreas);
         getSemesterListStub.resolves(expectedSemesters);
         getCatalogPrefixListStub.resolves(expectedCatalogPrefixes);
-        metadata = await mdController.getMetadata();
+        getCampusMetadataStub.resolves(metadata.campuses);
+        metadataResponse = await mdController.getMetadata();
       });
       it('should return the correct academic year', function () {
-        strictEqual(metadata.currentAcademicYear, expectedAcademicYear);
+        strictEqual(metadataResponse.currentAcademicYear, expectedAcademicYear);
       });
       it('should return the correct areas', function () {
         strictEqual(findAreaStub.callCount, 1);
-        strictEqual(metadata.areas, expectedAreas);
+        strictEqual(metadataResponse.areas, expectedAreas);
       });
       it('should return the correct semesters', function () {
         strictEqual(getSemesterListStub.callCount, 1);
-        strictEqual(metadata.semesters, expectedSemesters);
+        strictEqual(metadataResponse.semesters, expectedSemesters);
       });
       it('should return the correct catalog prefixes', function () {
         strictEqual(getCatalogPrefixListStub.callCount, 1);
-        strictEqual(metadata.catalogPrefixes, expectedCatalogPrefixes);
+        strictEqual(metadataResponse.catalogPrefixes, expectedCatalogPrefixes);
+      });
+      it('should return the correct campuses', function () {
+        strictEqual(getCampusMetadataStub.callCount, 1);
+        strictEqual(metadataResponse.campuses, metadata.campuses);
       });
     });
   });

--- a/src/server/metadata/metadata.controller.ts
+++ b/src/server/metadata/metadata.controller.ts
@@ -16,6 +16,7 @@ import { MetadataResponse } from 'common/dto/metadata/MetadataResponse.dto';
 import { AreaService } from 'server/area/area.service';
 import { ConfigService } from 'server/config/config.service';
 import { CourseService } from 'server/course/course.service';
+import { LocationService } from 'server/location/location.service';
 
 @ApiTags('Metadata')
 @UseGuards(Authentication)
@@ -34,6 +35,9 @@ export class MetadataController {
   @Inject(CourseService)
   private readonly courseService: CourseService;
 
+  @Inject(LocationService)
+  private readonly locationService: LocationService;
+
   /**
    * Responds with an object containing data about the current academic year,
    * currently existing areas, semesters, and catalog prefixes that exist in
@@ -51,6 +55,7 @@ export class MetadataController {
       areas: await this.areaService.getAreaList(),
       semesters: await this.semesterService.getSemesterList(),
       catalogPrefixes: await this.courseService.getCatalogPrefixList(),
+      campuses: await this.locationService.getCampusMetadata(),
     };
   }
 }

--- a/src/server/metadata/metadata.module.ts
+++ b/src/server/metadata/metadata.module.ts
@@ -7,6 +7,7 @@ import { Area } from 'server/area/area.entity';
 import { CourseService } from 'server/course/course.service';
 import { Course } from 'server/course/course.entity';
 import { SemesterModule } from 'server/semester/semester.module';
+import { LocationModule } from 'server/location/location.module';
 import { MetadataController } from './metadata.controller';
 
 @Module({
@@ -17,6 +18,7 @@ import { MetadataController } from './metadata.controller';
       Course,
     ]),
     SemesterModule,
+    LocationModule,
   ],
   controllers: [MetadataController],
   providers: [


### PR DESCRIPTION
This PR updates the metadata to include campus information. The campus information outlines the buildings and rooms that are in that campus. This will be used to populate the campus and building dropdowns in the Create Room modal and can be used to check that users are not creating existing campuses, buildings, and rooms.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #572

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
