### PR TITLE
Validate Meeting Times without Rooms

### DIFF
--- a/src/client/components/pages/Courses/MeetingModal.tsx
+++ b/src/client/components/pages/Courses/MeetingModal.tsx
@@ -472,7 +472,7 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
               nonOverlappingMeetings = false;
               // The trailing space is there in case of multiple time overlap
               // conflicts.
-              timeErrorMessage += `The meetings on ${dayEnumToString(room.day)} at ${PGTime.toDisplay(room.startTime)} - ${PGTime.toDisplay(room.endTime)} and ${PGTime.toDisplay(prevRoom.startTime)} - ${PGTime.toDisplay(prevRoom.endTime)} should not overlap. `;
+              timeErrorMessage += `The meetings on ${dayEnumToString(room.day)} at ${PGTime.toDisplay(room.startTime)}-${PGTime.toDisplay(room.endTime)} and ${PGTime.toDisplay(prevRoom.startTime)}-${PGTime.toDisplay(prevRoom.endTime)} should not overlap. `;
             }
           }
         });

--- a/tests/integration/e2e/CoursesPage.test.tsx
+++ b/tests/integration/e2e/CoursesPage.test.tsx
@@ -346,6 +346,53 @@ describe('End-to-end Course Instance updating', function () {
           });
         });
       });
+      context('Adding multiple meetings', function () {
+        context('with no rooms and overlapping times', function () {
+          const testDay = DAY.MON;
+          const testTime = '12:00 PM-1:00 PM';
+          beforeEach(async function () {
+            // click "Add new Time" to add the first meeting
+            const addButton = await renderResult.findByText('Add New Time');
+            fireEvent.click(addButton);
+            // Set day for the first meeting
+            let daySelector = await renderResult.findByLabelText('Meeting Day', { exact: false });
+            fireEvent.change(daySelector, { target: { value: testDay } });
+            // Set time for the first meeting
+            let timeDropdown = await renderResult.findByLabelText('Timeslot Button');
+            fireEvent.click(timeDropdown);
+            const firstTime = await renderResult.findByText(testTime);
+            fireEvent.click(firstTime);
+            // Adding a second meeting
+            fireEvent.click(addButton);
+            // Set day for the second meeting
+            daySelector = await renderResult.findByLabelText('Meeting Day', { exact: false });
+            fireEvent.change(daySelector, { target: { value: testDay } });
+            // Set time for the first meeting that overlaps the first time
+            timeDropdown = await renderResult.findByLabelText('Timeslot Button');
+            fireEvent.click(timeDropdown);
+            const secondTime = await renderResult.findByText(testTime);
+            fireEvent.click(secondTime);
+          });
+          context('when the modal save button is clicked', function () {
+            it('Should not close the modal', function () {
+              const saveButton = renderResult.getByText('Save');
+              fireEvent.click(saveButton);
+              const modal = renderResult.queryByRole('dialog');
+              notStrictEqual(modal, null);
+            });
+            it('Should show an error message', async function () {
+              const saveButton = renderResult.getByText('Save');
+              fireEvent.click(saveButton);
+              const modal = renderResult.getByRole('dialog');
+              const modalError = await within(modal).findByRole('alert');
+              strictEqual(
+                modalError.textContent,
+                `The meetings on ${dayEnumToString(testDay)} at ${testTime} and ${testTime} should not overlap. `
+              );
+            });
+          });
+        });
+      });
       context('Removing a meeting', function () {
         let testDeleteMeetingInfo: Meeting;
         beforeEach(async function () {


### PR DESCRIPTION
This PR adds client side validation that checks that meeting times without rooms for a course instance do not overlap. For instance, a user should not be able to save meetings (without rooms) that span from 12:00-1:00PM and 12:30-1:30PM. 

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #403

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
