### PR TITLE
Update Placeholder Text for Courses Table

### DIFF
--- a/src/client/components/pages/Courses/tableFields.tsx
+++ b/src/client/components/pages/Courses/tableFields.tsx
@@ -36,6 +36,7 @@ import { dayEnumToString } from 'common/constants/day';
 import { offeredEnumToString } from 'common/constants/offered';
 import { TermKey } from 'common/constants/term';
 import styled from 'styled-components';
+import { camelCaseToTitleCase } from 'common/utils/util';
 import { PGTime } from '../../../../common/utils/PGTime';
 import { instructorDisplayNameToFirstLast } from '../utils/instructorDisplayNameToFirstLast';
 import { FilterOptions, FilterState } from './filters.d';
@@ -552,7 +553,9 @@ function generateTextField<
         id={subField ? `${field}${subField.toString()}` : `${field}`}
         name={field}
         value={filterValue as string}
-        placeholder={`Filter by ${field}`}
+        placeholder={subField
+          ? `Filter by ${camelCaseToTitleCase(field)} ${camelCaseToTitleCase(subField.toString())}`
+          : `Filter by ${camelCaseToTitleCase(field)}`}
         label={subField
           ? `The table will be filtered as characters are typed in this ${field} ${subField.toString()} filter field`
           : `The table will be filtered as characters are typed in this ${field} filter field`}


### PR DESCRIPTION
Originally, the placeholder text was created by using the `field` value, which tends to be in camel case. Instead, we would like the placeholder text to be in title case. Using the helper function, `camelCaseToTitleCase`, we can manipulate the `field` and `subfield`s to have the placeholder text show as expected. The reason why we are using the `subField` value is for properties nested under the `fall` and `spring` semesters. For now, we only have one text filter under the `fall` and `spring` semesters (`instructor` column), but we may want to add more text filters in the future. By incorporating the `subField` into the placeholder text, there is a differentiation between different properties nested under `fall` and `spring`.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #599

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
