### PR TITLE
Remove authentication from metadata endpoint

### DIFF
--- a/src/server/metadata/metadata.controller.ts
+++ b/src/server/metadata/metadata.controller.ts
@@ -1,16 +1,13 @@
 import {
   Controller,
   Get,
-  UseGuards,
   Inject,
 } from '@nestjs/common';
 import {
   ApiOperation,
   ApiOkResponse,
   ApiTags,
-  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { Authentication } from 'server/auth/authentication.guard';
 import { SemesterService } from 'server/semester/semester.service';
 import { MetadataResponse } from 'common/dto/metadata/MetadataResponse.dto';
 import { AreaService } from 'server/area/area.service';
@@ -19,9 +16,7 @@ import { CourseService } from 'server/course/course.service';
 import { LocationService } from 'server/location/location.service';
 
 @ApiTags('Metadata')
-@UseGuards(Authentication)
 @Controller('api/metadata')
-@ApiUnauthorizedResponse({ description: 'Thrown if the user is not authenticated' })
 export class MetadataController {
   @Inject(ConfigService)
   private readonly configService: ConfigService;


### PR DESCRIPTION
The `/metadata` endpoint does not return any sensitive data and is required for the world-readable pages on the info.seas site. So we do not need to block anonymous users.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [ ] Normal <!-- New piece of functionality -->
- [x] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #608 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
