### PR TITLE
Move loading spinner to modal body

### DIFF
--- a/src/client/components/pages/Courses/MeetingModal.tsx
+++ b/src/client/components/pages/Courses/MeetingModal.tsx
@@ -529,37 +529,43 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
         {`Meetings for ${instanceIdentifier}`}
       </ModalHeader>
       <ModalBody>
-        <MeetingModalBodyGrid>
-          <MeetingScheduler>
-            <MeetingSchedulerHeader>{`Meeting times for ${instanceIdentifier}`}</MeetingSchedulerHeader>
-            <MeetingSchedulerBody>
-              <MeetingTimesList
-                allMeetings={allMeetings}
-                currentEditMeeting={currentEditMeeting}
-                meetingTimeError={meetingTimeError}
-                updateCurrentEditMeeting={updateCurrentEditMeeting}
-                toggleCurrentEditMeeting={toggleCurrentEditMeeting}
-                showRoomsHandler={searchForRooms}
-                newMeetingIdNumber={newMeetingIdNumber.toString()}
-                updateNewMeetingIdNumber={updateNewMeetingIdNumber}
-                removeMeeting={removeMeeting}
-              />
-            </MeetingSchedulerBody>
-          </MeetingScheduler>
-          <NotesSection>
-            {getNotes()}
-          </NotesSection>
-          <RoomAvailability>
-            <RoomAvailabilityHeader>Room Availability</RoomAvailabilityHeader>
-            <RoomAvailabilityBody>
-              <RoomSelection
-                roomRequestData={showRoomsData}
-                roomHandler={(room) => { updateCurrentEditMeeting({ room }); }}
-                currentRoomId={currentEditMeeting?.room?.id}
-              />
-            </RoomAvailabilityBody>
-          </RoomAvailability>
-        </MeetingModalBodyGrid>
+        {(saving) ? (
+          <LoadSpinner>Saving Meetings</LoadSpinner>
+        ) : (
+          <MeetingModalBodyGrid>
+            <MeetingScheduler>
+              <MeetingSchedulerHeader>{`Meeting times for ${instanceIdentifier}`}</MeetingSchedulerHeader>
+              <MeetingSchedulerBody>
+                <MeetingTimesList
+                  allMeetings={allMeetings}
+                  currentEditMeeting={currentEditMeeting}
+                  meetingTimeError={meetingTimeError}
+                  updateCurrentEditMeeting={updateCurrentEditMeeting}
+                  toggleCurrentEditMeeting={toggleCurrentEditMeeting}
+                  showRoomsHandler={searchForRooms}
+                  newMeetingIdNumber={newMeetingIdNumber.toString()}
+                  updateNewMeetingIdNumber={updateNewMeetingIdNumber}
+                  removeMeeting={removeMeeting}
+                />
+              </MeetingSchedulerBody>
+            </MeetingScheduler>
+            <NotesSection>
+              {getNotes()}
+            </NotesSection>
+            <RoomAvailability>
+              <RoomAvailabilityHeader>Room Availability</RoomAvailabilityHeader>
+              <RoomAvailabilityBody>
+                <RoomSelection
+                  roomRequestData={showRoomsData}
+                  roomHandler={(room) => {
+                    updateCurrentEditMeeting({ room });
+                  }}
+                  currentRoomId={currentEditMeeting?.room?.id}
+                />
+              </RoomAvailabilityBody>
+            </RoomAvailability>
+          </MeetingModalBodyGrid>
+        )}
       </ModalBody>
       <ModalFooter>
         <Button
@@ -569,7 +575,6 @@ const MeetingModal: FunctionComponent<MeetingModalProps> = function ({
         >
           Save
         </Button>
-        {saving && <LoadSpinner>Saving Meetings</LoadSpinner>}
         {!!saveError && (
           <ModalMessage
             variant={VARIANT.NEGATIVE}


### PR DESCRIPTION
This PR moves the loading spinner from the modal footer...

![image](https://user-images.githubusercontent.com/50675045/211392849-58241e2c-3b30-4e9d-b4bf-c0905ee999c6.png)

.... and into the modal body
![image](https://user-images.githubusercontent.com/50675045/211392736-99d45322-5aad-4d88-a99d-97518b7f04a6.png)

this fixes a UI bug where saving meetings causes the modal footer (and buttons) to stretch vertically. It also hides the modal content when saving, which is how other modals behave, so it also provides some consistency.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #595

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
