### PR TITLE
Update logic determining the cursor style in the schedule

### DIFF
--- a/src/client/components/pages/Schedule/ScheduleView.tsx
+++ b/src/client/components/pages/Schedule/ScheduleView.tsx
@@ -194,6 +194,7 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                           disabled={
                             !isSelectedDegreeProgram
                             || (popoverInBlock && !isSelected)
+                            || !isPrefixActive(coursePrefix)
                           }
                           aria-disabled
                           aria-labelledby={`${meetingId}-description`}


### PR DESCRIPTION
When the prefix is not active, the cursor should be a regular arrow to show that the course cannot be clicked to reveal a popover with more info on the course.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #601

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
