### PR TITLE
Fix Course Ordering in Multi Year Plan and Course Admin tables

### DIFF
--- a/src/client/api/__tests__/courses.test.ts
+++ b/src/client/api/__tests__/courses.test.ts
@@ -116,8 +116,8 @@ describe('Course Admin API', function () {
     context('when successfully editing a course', function () {
       const newCourseTitle = 'Intro to Engineering';
       const editedCourse = {
-        ...dummy.computerScienceCourse,
-        area: dummy.computerScienceCourse.area.name,
+        ...dummy.cs50Course,
+        area: dummy.cs50Course.area.name,
         title: newCourseTitle,
       };
       const editedCourseResponse = {

--- a/src/client/components/pages/Courses/__tests__/CourseModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/CourseModal.test.tsx
@@ -18,7 +18,7 @@ import {
 } from 'sinon';
 import { render } from 'test-utils';
 import {
-  computerScienceCourse,
+  cs50Course,
   computerScienceCourseResponse,
   metadata,
   physicsCourse,
@@ -485,14 +485,14 @@ describe('Course Modal', function () {
           const existingAreaRadioButton = getByLabelText('Select an existing area', { exact: false }) as HTMLInputElement;
           const existingAreaSelect = document.getElementById('existingArea') as HTMLSelectElement;
           fireEvent.click(existingAreaRadioButton);
-          fireEvent.change(existingAreaSelect, { target: { value: `${computerScienceCourse.area.name}` } });
+          fireEvent.change(existingAreaSelect, { target: { value: `${cs50Course.area.name}` } });
           const submitButton = getByText('Submit');
           fireEvent.click(submitButton);
           await wait(() => !queryByText(/required field/));
           const existingAreas = Array.from(existingAreaSelect.options);
           let selectedAreaCount = 0;
           existingAreas.forEach((area) => {
-            if (area.value === computerScienceCourse.area.name) {
+            if (area.value === cs50Course.area.name) {
               selectedAreaCount += 1;
             }
           });

--- a/src/common/__tests__/data/courses.ts
+++ b/src/common/__tests__/data/courses.ts
@@ -13,7 +13,7 @@ export const emptyCourse = new Course();
 /**
  * An example [[Course]] representing CS 50.
  */
-export const computerScienceCourse = Object.assign(new Course(), {
+export const cs50Course = Object.assign(new Course(), {
   id: 'b8bc8456-51fd-48ef-b111-5a5990671cd1',
   area: {
     id: 'a49edd11-0f2d-4d8f-9096-a4062955a11a',
@@ -25,6 +25,24 @@ export const computerScienceCourse = Object.assign(new Course(), {
   number: '050',
   isSEAS: IS_SEAS.Y,
   termPattern: TERM_PATTERN.FALL,
+  isUndergraduate: true,
+});
+
+/**
+ * An example [[Course]] representing CS 200.
+ */
+export const cs200Course = Object.assign(new Course(), {
+  id: '295976e9-3c36-4785-843e-84906668a924',
+  area: {
+    id: '735fb5ae-8716-4c53-8e07-b0dc5a2db24b',
+    name: 'CS',
+  },
+  sameAs: null,
+  title: 'Introduction to Computer Science',
+  prefix: 'CS',
+  number: '200',
+  isSEAS: IS_SEAS.Y,
+  termPattern: TERM_PATTERN.SPRING,
   isUndergraduate: true,
 });
 
@@ -49,15 +67,15 @@ export const physicsCourse = Object.assign(new Course(), {
  * An example of [[CreateCourse]] representing CS 50
  */
 export const createCourseDtoExample: CreateCourse = {
-  area: computerScienceCourse.area.name,
-  title: computerScienceCourse.title,
-  isSEAS: computerScienceCourse.isSEAS,
-  isUndergraduate: computerScienceCourse.isUndergraduate,
-  prefix: computerScienceCourse.prefix,
-  number: computerScienceCourse.number,
-  termPattern: computerScienceCourse.termPattern,
-  sameAs: computerScienceCourse.sameAs,
-  private: computerScienceCourse.private,
+  area: cs50Course.area.name,
+  title: cs50Course.title,
+  isSEAS: cs50Course.isSEAS,
+  isUndergraduate: cs50Course.isUndergraduate,
+  prefix: cs50Course.prefix,
+  number: cs50Course.number,
+  termPattern: cs50Course.termPattern,
+  sameAs: cs50Course.sameAs,
+  private: cs50Course.private,
 };
 
 /**
@@ -160,16 +178,16 @@ export const newAreaCourseResponse: ManageCourseResponseDTO = {
  * An example [[UpdateCourseDTO]] response representing CS 50
  */
 export const updateCourseExample: UpdateCourseDTO = {
-  id: computerScienceCourse.id,
-  area: computerScienceCourse.area.name,
-  title: computerScienceCourse.title,
-  prefix: computerScienceCourse.prefix,
-  number: computerScienceCourse.number,
-  termPattern: computerScienceCourse.termPattern,
-  sameAs: computerScienceCourse.sameAs,
-  isUndergraduate: computerScienceCourse.isUndergraduate,
-  isSEAS: computerScienceCourse.isSEAS,
-  private: computerScienceCourse.private,
+  id: cs50Course.id,
+  area: cs50Course.area.name,
+  title: cs50Course.title,
+  prefix: cs50Course.prefix,
+  number: cs50Course.number,
+  termPattern: cs50Course.termPattern,
+  sameAs: cs50Course.sameAs,
+  isUndergraduate: cs50Course.isUndergraduate,
+  isSEAS: cs50Course.isSEAS,
+  private: cs50Course.private,
 };
 
 /**

--- a/src/server/course/__tests__/course.controller.test.ts
+++ b/src/server/course/__tests__/course.controller.test.ts
@@ -4,7 +4,7 @@ import { stub, SinonStub } from 'sinon';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import {
   emptyCourse,
-  computerScienceCourse,
+  cs50Course,
   createCourseDtoExample,
   computerScienceCourseResponse,
   updateCourseExample,
@@ -98,7 +98,7 @@ describe('Course controller', function () {
       });
       it('returns the newly created course', async function () {
         mockAreaRepository.findOne.resolves(createCourseDtoExample.area);
-        mockCourseService.save.resolves(computerScienceCourse);
+        mockCourseService.save.resolves(cs50Course);
 
         const createdCourse = await controller.create(
           createCourseDtoExample
@@ -126,12 +126,12 @@ describe('Course controller', function () {
   describe('update', function () {
     context('Without a sameAs course', function () {
       it('updates a course in the database', async function () {
-        mockAreaRepository.findOne.resolves(computerScienceCourse.area);
+        mockAreaRepository.findOne.resolves(cs50Course.area);
         mockCourseRepository.findOneOrFail.resolves();
-        mockCourseRepository.save.resolves(computerScienceCourse);
+        mockCourseRepository.save.resolves(cs50Course);
 
         await controller.update(
-          computerScienceCourse.id,
+          cs50Course.id,
           updateCourseExample
         );
 
@@ -139,18 +139,18 @@ describe('Course controller', function () {
         deepStrictEqual(
           mockCourseRepository.save.args[0][0],
           {
-            ...computerScienceCourse,
+            ...cs50Course,
             sameAs: undefined,
           }
         );
       });
       it('updates the course specified', async function () {
-        mockAreaRepository.findOne.resolves(computerScienceCourse.area);
+        mockAreaRepository.findOne.resolves(cs50Course.area);
         mockCourseRepository.findOneOrFail.resolves();
-        mockCourseRepository.save.resolves(computerScienceCourse);
+        mockCourseRepository.save.resolves(cs50Course);
 
         await controller.update(
-          computerScienceCourse.id,
+          cs50Course.id,
           updateCourseExample
         );
 
@@ -158,7 +158,7 @@ describe('Course controller', function () {
 
         deepStrictEqual(
           updatedCourse.id,
-          computerScienceCourse.id
+          cs50Course.id
         );
       });
       it('throws a NotFoundException if the course being udpated doesn\'t exist', async function () {
@@ -166,7 +166,7 @@ describe('Course controller', function () {
 
         await rejects(
           () => controller.update(
-            computerScienceCourse.id,
+            cs50Course.id,
             updateCourseExample
           ),
           NotFoundException
@@ -177,7 +177,7 @@ describe('Course controller', function () {
 
         await rejects(
           () => controller.update(
-            computerScienceCourse.id,
+            cs50Course.id,
             updateCourseExample
           ),
           Error
@@ -185,10 +185,10 @@ describe('Course controller', function () {
       });
       it('returns the updated course', async function () {
         mockCourseRepository.findOneOrFail.resolves();
-        mockCourseRepository.save.resolves(computerScienceCourse);
+        mockCourseRepository.save.resolves(cs50Course);
 
         const course = await controller.update(
-          computerScienceCourse.id,
+          cs50Course.id,
           updateCourseExample
         );
 

--- a/src/server/course/__tests__/course.service.test.ts
+++ b/src/server/course/__tests__/course.service.test.ts
@@ -14,7 +14,7 @@ import { Semester } from 'server/semester/semester.entity';
 import {
   spring,
   fall,
-  computerScienceCourse,
+  cs50Course,
   computerScienceCourseQueryResult,
   physicsCourseQueryResult,
   computerScienceCourseResponse,
@@ -89,11 +89,11 @@ describe('Course service', function () {
   describe('save', function () {
     beforeEach(function () {
       mockSemesterRepository.find.resolves([]);
-      mockAreaRepository.findOne.resolves(computerScienceCourse.area.name);
+      mockAreaRepository.findOne.resolves(cs50Course.area.name);
     });
 
     it('creates a new course in the database', async function () {
-      await courseService.save(computerScienceCourse);
+      await courseService.save(cs50Course);
 
       strictEqual(mockCourseRepository.save.callCount, 1);
     });
@@ -103,7 +103,7 @@ describe('Course service', function () {
 
       mockSemesterRepository.find.resolves(semesters);
 
-      await courseService.save(computerScienceCourse);
+      await courseService.save(cs50Course);
 
       const updatedCourse = mockCourseRepository.save.args[0][0] as Course;
 
@@ -114,11 +114,11 @@ describe('Course service', function () {
     });
 
     it('returns the newly created course', async function () {
-      mockCourseRepository.save.resolves(computerScienceCourse);
+      mockCourseRepository.save.resolves(cs50Course);
 
-      const createdCourse = await courseService.save(computerScienceCourse);
+      const createdCourse = await courseService.save(cs50Course);
 
-      deepStrictEqual(createdCourse, computerScienceCourse);
+      deepStrictEqual(createdCourse, cs50Course);
     });
   });
   describe('getCatalogPrefixList', function () {

--- a/src/server/course/course.service.ts
+++ b/src/server/course/course.service.ts
@@ -56,7 +56,8 @@ export class CourseService {
   /**
    * Retrieve all courses in the database and sort by:
    * - area ASC
-   * - catalogNumber ASC
+   * - numberInteger ASC
+   * - numberAlphabetical ASC
    */
   public async findCourses(): Promise<ManageCourseResponseDTO[]> {
     // Any changes to this query should be reflected in FindCoursesQueryResult.
@@ -75,10 +76,13 @@ export class CourseService {
       .addSelect('c."sameAsId"', 'sameAsId')
       .addSelect("CONCAT_WS(' ', p.prefix, p.number)", 'sameAs')
       .addSelect('c.private', 'private')
+      .addSelect('c."numberInteger"', 'numberInteger')
+      .addSelect('c."numberAlphabetical"', 'numberAlphabetical')
       .leftJoinAndSelect(Area, 'a', 'c."areaId" = a.id')
       .leftJoinAndSelect(Course, 'p', 'c."sameAsId" = p.id')
       .orderBy('a.name', 'ASC')
-      .addOrderBy('"catalogNumber"', 'ASC')
+      .addOrderBy('"numberInteger"', 'ASC')
+      .addOrderBy('"numberAlphabetical"', 'ASC')
       .getRawMany();
     return results.map((result) => ({
       id: result.id,

--- a/src/server/course/course.service.ts
+++ b/src/server/course/course.service.ts
@@ -81,6 +81,7 @@ export class CourseService {
       .leftJoinAndSelect(Area, 'a', 'c."areaId" = a.id')
       .leftJoinAndSelect(Course, 'p', 'c."sameAsId" = p.id')
       .orderBy('a.name', 'ASC')
+      .addOrderBy('prefix', 'ASC')
       .addOrderBy('"numberInteger"', 'ASC')
       .addOrderBy('"numberAlphabetical"', 'ASC')
       .getRawMany();

--- a/src/server/courseInstance/courseInstance.service.ts
+++ b/src/server/courseInstance/courseInstance.service.ts
@@ -172,12 +172,14 @@ export class CourseInstanceService {
         'instructors',
         'instructors."courseInstanceId" = ci.id'
       )
+      .leftJoin(Course, 'course', 'course.id=c.id')
       // Note that although the academic year in the semester entity is actually
       // the calendar year, academicYear is truly the academic year and has
       // been calculated by the SemesterView
       .where('s."academicYear" IN (:...academicYears)', { academicYears })
       .orderBy('"catalogPrefix"', 'ASC')
-      .addOrderBy('"catalogNumber"', 'ASC')
+      .addOrderBy('course."numberInteger"', 'ASC')
+      .addOrderBy('course."numberAlphabetical"', 'ASC')
       .addOrderBy('s."academicYear"', 'ASC')
       .addOrderBy('s."termOrder"', 'ASC')
       .addOrderBy('instructors."instructorOrder"', 'ASC')

--- a/tests/integration/server/course/course.controller.test.ts
+++ b/tests/integration/server/course/course.controller.test.ts
@@ -25,7 +25,7 @@ import {
   regularUser,
   string,
   adminUser,
-  computerScienceCourse,
+  cs50Course,
   createCourseDtoExample,
   computerScienceCourseResponse,
   updateCourseExample,
@@ -174,7 +174,7 @@ describe('Course API', function () {
           mockSemesterRepository.find.resolves([]);
           mockAreaRepository.findOne
             .resolves(computerScienceCourseResponse.area);
-          mockCourseRepository.save.resolves(computerScienceCourse);
+          mockCourseRepository.save.resolves(cs50Course);
 
           const response = await request(api)
             .post('/api/courses')
@@ -192,8 +192,8 @@ describe('Course API', function () {
         it('returns the newly created course', async function () {
           authStub.resolves(adminUser);
           mockSemesterRepository.find.resolves([]);
-          mockAreaRepository.findOne.resolves(computerScienceCourse.area.name);
-          mockCourseRepository.save.resolves(computerScienceCourse);
+          mockAreaRepository.findOne.resolves(cs50Course.area.name);
+          mockCourseRepository.save.resolves(cs50Course);
 
           const response = await request(api)
             .post('/api/courses')
@@ -212,7 +212,7 @@ describe('Course API', function () {
 
           const response = await request(api)
             .post('/api/courses')
-            .send({ title: computerScienceCourse.title });
+            .send({ title: cs50Course.title });
 
           const body = response.body as BadRequestInfo;
 
@@ -229,7 +229,7 @@ describe('Course API', function () {
 
           const response = await request(api)
             .post('/api/courses')
-            .send({ termPattern: computerScienceCourse.termPattern });
+            .send({ termPattern: cs50Course.termPattern });
 
           const body = response.body as BadRequestInfo;
 
@@ -246,7 +246,7 @@ describe('Course API', function () {
 
           const response = await request(api)
             .post('/api/courses')
-            .send({ title: computerScienceCourse.title });
+            .send({ title: cs50Course.title });
 
           const body = response.body as BadRequestInfo;
 
@@ -297,7 +297,7 @@ describe('Course API', function () {
           mockCourseRepository.findOneOrFail.rejects(new EntityNotFoundError(Course, ''));
 
           const response = await request(api)
-            .put(`/api/courses/${computerScienceCourse.id}`)
+            .put(`/api/courses/${cs50Course.id}`)
             .send(updateCourseExample);
 
           strictEqual(response.ok, false);
@@ -306,14 +306,14 @@ describe('Course API', function () {
         });
         it('updates the specified course', async function () {
           const newCourseInfo = {
-            id: computerScienceCourse.id,
-            area: computerScienceCourse.area.name,
-            title: computerScienceCourse.title,
-            prefix: computerScienceCourse.prefix,
-            number: computerScienceCourse.number,
-            termPattern: computerScienceCourse.termPattern,
-            isUndergraduate: computerScienceCourse.isUndergraduate,
-            isSEAS: computerScienceCourse.isSEAS,
+            id: cs50Course.id,
+            area: cs50Course.area.name,
+            title: cs50Course.title,
+            prefix: cs50Course.prefix,
+            number: cs50Course.number,
+            termPattern: cs50Course.termPattern,
+            isUndergraduate: cs50Course.isUndergraduate,
+            isSEAS: cs50Course.isSEAS,
           };
           mockCourseRepository.findOneOrFail.resolves(newCourseInfo);
           mockAreaRepository.findOne.resolves(newCourseInfo.area);
@@ -330,8 +330,8 @@ describe('Course API', function () {
           authStub.resolves(adminUser);
 
           const response = await request(api)
-            .put(`/api/courses/${computerScienceCourse.id}`)
-            .send({ title: computerScienceCourse.title });
+            .put(`/api/courses/${cs50Course.id}`)
+            .send({ title: cs50Course.title });
 
           const body = response.body as BadRequestInfo;
 
@@ -347,8 +347,8 @@ describe('Course API', function () {
           authStub.resolves(adminUser);
 
           const response = await request(api)
-            .put(`/api/courses/${computerScienceCourse.id}`)
-            .send({ termPattern: computerScienceCourse.termPattern });
+            .put(`/api/courses/${cs50Course.id}`)
+            .send({ termPattern: cs50Course.termPattern });
 
           const body = response.body as BadRequestInfo;
 
@@ -364,8 +364,8 @@ describe('Course API', function () {
           authStub.resolves(adminUser);
 
           const response = await request(api)
-            .put(`/api/courses/${computerScienceCourse.id}`)
-            .send({ title: computerScienceCourse.title });
+            .put(`/api/courses/${cs50Course.id}`)
+            .send({ title: cs50Course.title });
 
           const body = response.body as BadRequestInfo;
 
@@ -383,7 +383,7 @@ describe('Course API', function () {
           authStub.rejects(new UnauthorizedException());
 
           const response = await request(api)
-            .put(`/api/courses/${computerScienceCourse.id}`);
+            .put(`/api/courses/${cs50Course.id}`);
 
           strictEqual(response.ok, false);
           strictEqual(response.status, HttpStatus.UNAUTHORIZED);

--- a/tests/integration/server/course/course.service.test.ts
+++ b/tests/integration/server/course/course.service.test.ts
@@ -11,6 +11,7 @@ import { AUTH_MODE } from 'common/constants';
 import { deepStrictEqual, strictEqual } from 'assert';
 import { CourseModule } from 'server/course/course.module';
 import {
+  cs200Course,
   cs50Course,
   physicsCourse,
 } from 'testData';
@@ -108,29 +109,23 @@ describe('Course service', function () {
       ]
     );
   });
-  it('sorts the courses by catalogNumber in ascending order', async function () {
+  it('sorts the courses by the integer followed by the alphabetical portion of the course in ascending order', async function () {
     await courseRepository.query(`TRUNCATE ${Course.name} CASCADE`);
-    const [physicsCourseArea] = await areaRepository.save([
-      {
-        name: physicsCourse.area.name,
-      },
-    ]);
-    // Save two courses in the database with their catalog numbers
-    // deliberately not in ascending alphabetical order and
-    // assign the physics course area to both as a control
+    // CS 050 should appear before CS 200
     const [
-      compSciCourse,
-      physCourse,
+      cs50,
+      cs200,
     ] = await courseRepository.save([
+      // Save the courses in the opposite expected order so that we can check
+      // that the courses will be ordered correctly by the integer portion
+      // followed by the alphabetical portion of the course.
       {
-        ...computerScienceCourse,
-        catalogNumber: 'CS 050',
-        area: physicsCourseArea,
+        ...cs200Course,
+        catalogNumber: 'CS 200',
       },
       {
-        ...physicsCourse,
-        catalogNumber: 'AP 295a',
-        area: physicsCourseArea,
+        ...cs50Course,
+        catalogNumber: 'CS 050',
       },
     ]);
 
@@ -140,8 +135,8 @@ describe('Course service', function () {
     ];
 
     deepStrictEqual(actualCatalogNumbers, [
-      physCourse.catalogNumber,
-      compSciCourse.catalogNumber,
+      cs50.catalogNumber,
+      cs200.catalogNumber,
     ]);
   });
 });

--- a/tests/integration/server/course/course.service.test.ts
+++ b/tests/integration/server/course/course.service.test.ts
@@ -11,7 +11,7 @@ import { AUTH_MODE } from 'common/constants';
 import { deepStrictEqual, strictEqual } from 'assert';
 import { CourseModule } from 'server/course/course.module';
 import {
-  computerScienceCourse,
+  cs50Course,
   physicsCourse,
 } from 'testData';
 import { PopulationModule } from '../../../mocks/database/population/population.module';
@@ -81,7 +81,7 @@ describe('Course service', function () {
         name: physicsCourse.area.name,
       },
       {
-        name: computerScienceCourse.area.name,
+        name: cs50Course.area.name,
       },
     ]);
 
@@ -90,7 +90,7 @@ describe('Course service', function () {
     // courses get sorted by area in ascending alphabetical order
     await courseRepository.save([
       {
-        ...computerScienceCourse,
+        ...cs50Course,
         area: computerScienceCourseArea,
       },
       {

--- a/tests/integration/server/courseInstance/courseInstance.service.test.ts
+++ b/tests/integration/server/courseInstance/courseInstance.service.test.ts
@@ -381,18 +381,41 @@ describe('Course Instance Service', function () {
           deepStrictEqual(faculty, sorted);
         });
     });
-    it('should return the courses ordered by catalog prefix and catalog number', function () {
+    it('should return the courses ordered by catalog prefix and course integer followed by the alphabetical portion of the course', function () {
+      const parseCourseNumber = (course: MultiYearPlanResponseDTO) => {
+        const courseInfo = {
+          numberInteger: null,
+          numberAlphabetical: null,
+        };
+        const numberMatch = /(?<int>\d+)?(?<alpha>[a-zA-Z\s]+)?/.exec(course.catalogNumber);
+        if (numberMatch && 'groups' in numberMatch) {
+          const { alpha, int } = numberMatch.groups;
+          courseInfo.numberInteger = int
+            ? parseInt(int, 10)
+            : null;
+          courseInfo.numberAlphabetical = alpha || null;
+        }
+        return courseInfo;
+      };
       const sorted = result.slice().sort((course1, course2): number => {
+        const course1Info = parseCourseNumber(course1);
+        const course2Info = parseCourseNumber(course2);
         if (course1.catalogPrefix < course2.catalogPrefix) {
           return -1;
         }
         if (course1.catalogPrefix > course2.catalogPrefix) {
           return 1;
         }
-        if (course1.catalogNumber < course2.catalogNumber) {
+        if (course1Info.numberInteger < course2Info.numberInteger) {
           return -1;
         }
-        if (course1.catalogNumber > course2.catalogNumber) {
+        if (course1Info.numberInteger > course2Info.numberInteger) {
+          return 1;
+        }
+        if (course1Info.numberAlphabetical < course2Info.numberAlphabetical) {
+          return -1;
+        }
+        if (course1Info.numberAlphabetical > course2Info.numberAlphabetical) {
           return 1;
         }
         return 0;


### PR DESCRIPTION
This PR updates the ordering of courses so that instead of ordering by `catalogNumber`, we are ordering by the integer portion of the course number and the alpha part of the course number so that CS 50 appears before CS 100, for instance. 

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #616

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
