### PR TITLE
Add version tag via hardcoded .env variable

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -112,3 +112,6 @@ REDIS_PORT=
 
 # A prefix used for namespacing redis keys to prevent collisions
 REDIS_PREFIX=
+
+# The current version of the app
+APP_VERSION=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
         OPEN_PORT: ${SERVER_PORT}
     environment:
       - APP_NAME
+      - APP_VERSION
       - CAS_URL
       - CLIENT_URL
       - PUBLIC_CLIENT_URL
@@ -61,6 +62,7 @@ services:
         OPEN_PORT: ${CLIENT_PORT}
     environment:
       - APP_NAME
+      - APP_VERSION
       - CLIENT_PORT
       - SERVER_URL
       - SERVER_PORT

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "lodash.merge": "^4.6.2",
         "lodash.set": "^4.3.2",
         "loglevel": "^1.6.8",
-        "mark-one": "^0.5.0",
+        "mark-one": "^0.5.2",
         "morgan": "^1.10.0",
         "nestjs-redis": "^1.3.3",
         "nestjs-session": "^1.0.0",
@@ -10398,9 +10398,9 @@
       }
     },
     "node_modules/mark-one": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.5.0.tgz",
-      "integrity": "sha512-YemkCoQ7dWOPn7r8uP1jGu+kFoLsXlCO6lMce4k/HeH3kmmQVfhyRDot84wM44LNN/VvDpGKBzBc27B0N8I7qw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.5.2.tgz",
+      "integrity": "sha512-e40DM8WBmHdR/6sm6rKjb4x9GX9SYamC36FglSpVncE9nuovxkgHS8mwN0oIv0ZsDpQq9En3t3TUpWXAutKrUw==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",
         "@openfonts/open-sans_all": "^1.43.0",
@@ -27296,9 +27296,9 @@
       }
     },
     "mark-one": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.5.0.tgz",
-      "integrity": "sha512-YemkCoQ7dWOPn7r8uP1jGu+kFoLsXlCO6lMce4k/HeH3kmmQVfhyRDot84wM44LNN/VvDpGKBzBc27B0N8I7qw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.5.2.tgz",
+      "integrity": "sha512-e40DM8WBmHdR/6sm6rKjb4x9GX9SYamC36FglSpVncE9nuovxkgHS8mwN0oIv0ZsDpQq9En3t3TUpWXAutKrUw==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",
         "@openfonts/open-sans_all": "^1.43.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.set": "^4.3.2",
     "loglevel": "^1.6.8",
-    "mark-one": "^0.5.0",
+    "mark-one": "^0.5.2",
     "morgan": "^1.10.0",
     "nestjs-redis": "^1.3.3",
     "nestjs-session": "^1.0.0",

--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -120,7 +120,7 @@ const App: FunctionComponent = (): ReactElement => {
           setDataFetching(false);
         });
     }
-  }, [dispatchMessageRef, setDataFetching, appVersion]);
+  }, [dispatchMessageRef, setDataFetching]);
 
   return (
     <div className="app-content">

--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -34,6 +34,8 @@ import {
   AppHeader,
 } from './layout';
 
+const appVersion = process.env.APP_VERSION;
+
 /**
  * The primary app component. Fetches the current user from the server when it
  * mounts, then saves it to the UserContext to pass down to other components
@@ -76,11 +78,6 @@ const App: FunctionComponent = (): ReactElement => {
   const [isDataFetching, setDataFetching] = useState(true);
 
   /**
-   * Tracks the current version of the application to be displayed in the footer
-   */
-  const [appVersion, setAppVersion] = useState('');
-
-  /**
    * Get the currently authenticated user from the server on launch.
    * If it fails, display a message for the user
    */
@@ -89,7 +86,6 @@ const App: FunctionComponent = (): ReactElement => {
     if (dispatchMessageRef.current) {
       const { current: dispatchMessage } = dispatchMessageRef;
       setDataFetching(true);
-      setAppVersion(process.env.APP_VERSION);
       getCurrentUser()
         .then((user: User): void => {
           setUser(user);

--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -18,7 +18,12 @@ import {
   MetadataContextValue,
   MessageReducerAction,
 } from 'client/context';
-import { MarkOneWrapper, PageBody, LoadSpinner } from 'mark-one';
+import {
+  MarkOneWrapper,
+  PageBody,
+  LoadSpinner,
+  Footer,
+} from 'mark-one';
 import { getCurrentUser } from 'client/api';
 import { getMetadata } from 'client/api/metadata';
 import { User } from 'common/classes';
@@ -71,6 +76,11 @@ const App: FunctionComponent = (): ReactElement => {
   const [isDataFetching, setDataFetching] = useState(true);
 
   /**
+   * Tracks the current version of the application to be displayed in the footer
+   */
+  const [appVersion, setAppVersion] = useState('');
+
+  /**
    * Get the currently authenticated user from the server on launch.
    * If it fails, display a message for the user
    */
@@ -79,6 +89,7 @@ const App: FunctionComponent = (): ReactElement => {
     if (dispatchMessageRef.current) {
       const { current: dispatchMessage } = dispatchMessageRef;
       setDataFetching(true);
+      setAppVersion(process.env.APP_VERSION);
       getCurrentUser()
         .then((user: User): void => {
           setUser(user);
@@ -109,7 +120,7 @@ const App: FunctionComponent = (): ReactElement => {
           setDataFetching(false);
         });
     }
-  }, [dispatchMessageRef, setDataFetching]);
+  }, [dispatchMessageRef, setDataFetching, appVersion]);
 
   return (
     <div className="app-content">
@@ -128,6 +139,11 @@ const App: FunctionComponent = (): ReactElement => {
                     <>
                       <AppHeader />
                       <AppRouter />
+                      <Footer
+                        justify="center"
+                      >
+                        {appVersion}
+                      </Footer>
                     </>
                   )}
                 <Message

--- a/webpackfile.client-dev.js
+++ b/webpackfile.client-dev.js
@@ -11,7 +11,8 @@ const {
   CLIENT_PORT,
   SERVER_URL,
   SERVER_PORT,
-  PUBLIC_CLIENT_URL
+  PUBLIC_CLIENT_URL,
+  APP_VERSION
 } = process.env;
 
 /**
@@ -103,6 +104,7 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env.SERVER_URL': JSON.stringify(SERVER_URL),
       'process.env.PUBLIC_CLIENT_URL': JSON.stringify(PUBLIC_CLIENT_URL),
+      'process.env.APP_VERSION': JSON.stringify(APP_VERSION),
     }),
   ],
 };

--- a/webpackfile.js
+++ b/webpackfile.js
@@ -9,6 +9,7 @@ const {
   APP_NAME,
   SERVER_URL,
   PUBLIC_CLIENT_URL,
+  APP_VERSION
 } = process.env;
 
 /**
@@ -102,6 +103,7 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env.SERVER_URL': JSON.stringify(SERVER_URL),
       'process.env.PUBLIC_CLIENT_URL': JSON.stringify(PUBLIC_CLIENT_URL),
+      'process.env.APP_VERSION': JSON.stringify(APP_VERSION),
     }),
     new HtmlWebpackRootPlugin(),
     new webpack.optimize.ModuleConcatenationPlugin(),


### PR DESCRIPTION
This PR adds a `Footer` that contains the app version number via a (currently) hardcoded .env value. The `.env-example` file was updated to include the `APP_VERSION` variable. In the future, the version number will come from Github Actions as opposed to a hardcoded value. 

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/29589689/214944417-90dd28fe-6179-4374-90e6-9c10a58c8487.png">


## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #618

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
