### PR TITLE
Set the app version using the version listed in Github Actions

### DIFF
--- a/.github/workflows/05-publish.yml
+++ b/.github/workflows/05-publish.yml
@@ -106,6 +106,7 @@ jobs:
         run: |
           rm -rf build
           git checkout ${{ env.VERSION_TAG }}
+          export APP_VERSION="${{ env.VERSION_TAG }}"
           npm run build:client
           export QA_BUNDLE_NAME="${{ env.PACKAGE_NAME }}_${{ env.VERSION_TAG }}_QA.tar.gz"
           tar -czvf $QA_BUNDLE_NAME -C build client
@@ -118,6 +119,7 @@ jobs:
         run: |
           rm -rf build
           git checkout ${{ env.VERSION_TAG }}
+          export APP_VERSION="${{ env.VERSION_TAG }}"
           npm run build:client
           export PROD_BUNDLE_NAME="${{ env.PACKAGE_NAME }}_${{ env.VERSION_TAG }}_PROD.tar.gz"
           tar -czvf $PROD_BUNDLE_NAME -C build client


### PR DESCRIPTION
In order to get the version that is on Github Actions, we are updating the "publish" workflow to set the value of the APP_VERSION variable to be equal to the value of the Github Actions VERSION_TAG.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #618

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
