### PR TITLE
Roll over no longer active status into new academic year

### DIFF
--- a/src/server/semester/semester.service.ts
+++ b/src/server/semester/semester.service.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityNotFoundError, Repository } from 'typeorm';
-import { OFFERED, TERM } from 'common/constants';
+import { ABSENCE_TYPE, OFFERED, TERM } from 'common/constants';
 import { CourseInstance } from 'server/courseInstance/courseinstance.entity';
 import { NonClassEvent } from 'server/nonClassEvent/nonclassevent.entity';
 import { Absence } from 'server/absence/absence.entity';
@@ -216,9 +216,12 @@ export class SemesterService implements OnApplicationBootstrap {
       this.logService.verbose('Creating the fall absences.');
 
       fallSemester.absences = existingSpringAbsences
-        .map((absence) => ({
-          ...new Absence(),
+        .map((absence) => this.absenceRepository.create({
+          ...absence,
           faculty: absence.faculty,
+          type: (absence.type === ABSENCE_TYPE.NO_LONGER_ACTIVE)
+            ? ABSENCE_TYPE.NO_LONGER_ACTIVE
+            : ABSENCE_TYPE.PRESENT,
         }));
 
       this.logService.verbose(`Created ${fallSemester.absences.length} fall absences.`);

--- a/src/server/semester/semester.service.ts
+++ b/src/server/semester/semester.service.ts
@@ -217,7 +217,6 @@ export class SemesterService implements OnApplicationBootstrap {
 
       fallSemester.absences = existingSpringAbsences
         .map((absence) => this.absenceRepository.create({
-          ...absence,
           faculty: absence.faculty,
           type: (absence.type === ABSENCE_TYPE.NO_LONGER_ACTIVE)
             ? ABSENCE_TYPE.NO_LONGER_ACTIVE

--- a/src/server/semester/semester.service.ts
+++ b/src/server/semester/semester.service.ts
@@ -276,7 +276,7 @@ export class SemesterService implements OnApplicationBootstrap {
         this.logService.error(e);
       }
     }
-    if (this.config.isProduction && today.getMonth() === MONTH.JUN) {
+    if (this.config.isProduction && today.getMonth() >= MONTH.JUN) {
       const yearToAdd = today.getFullYear() + 4;
       try {
         return await this.addAcademicYear(yearToAdd);

--- a/src/server/semester/semester.service.ts
+++ b/src/server/semester/semester.service.ts
@@ -266,6 +266,16 @@ export class SemesterService implements OnApplicationBootstrap {
 
   public async onApplicationBootstrap(): Promise<void> {
     const today = new Date();
+    // One-time fix to add the 2026 academic year to the system
+    // This can be deleted after running once, but could safely be left here as
+    // it won't run more than once
+    if (this.config.isProduction && today.getFullYear() === 2023) {
+      try {
+        return await this.addAcademicYear(2026);
+      } catch (e) {
+        this.logService.error(e);
+      }
+    }
     if (this.config.isProduction && today.getMonth() === MONTH.JUN) {
       const yearToAdd = today.getFullYear() + 4;
       try {

--- a/tests/integration/server/semester/semester.service.test.ts
+++ b/tests/integration/server/semester/semester.service.test.ts
@@ -19,6 +19,8 @@ import { Semester } from 'server/semester/semester.entity';
 import FakeTimers from '@sinonjs/fake-timers';
 import { MONTH } from 'common/constants/month';
 import { stub } from 'sinon';
+import { Faculty } from 'server/faculty/faculty.entity';
+import { Absence } from 'server/absence/absence.entity';
 import { PopulationModule } from '../../../mocks/database/population/population.module';
 import { TestingStrategy } from '../../../mocks/authentication/testing.strategy';
 import { semesters } from '../../../mocks/database/population/data/semesters';
@@ -26,6 +28,8 @@ import { semesters } from '../../../mocks/database/population/data/semesters';
 describe('Semester Service', function () {
   let testModule: TestingModule;
   let semesterService: SemesterService;
+  let absenceRepository: Repository<Absence>;
+  let facultyRepository: Repository<Faculty>;
   let semesterRepository: Repository<Semester>;
   let fakeConfig: ConfigService;
 
@@ -61,6 +65,8 @@ describe('Semester Service', function () {
 
     semesterService = testModule.get(SemesterService);
     semesterRepository = testModule.get(getRepositoryToken(Semester));
+    absenceRepository = testModule.get(getRepositoryToken(Absence));
+    facultyRepository = testModule.get(getRepositoryToken(Faculty));
     await testModule.createNestApplication()
       .useGlobalPipes(new BadRequestExceptionPipe())
       .init();
@@ -375,6 +381,62 @@ describe('Semester Service', function () {
           strictEqual(err instanceof Error, true);
           strictEqual(error.toString().includes('Cannot create requested academic year until preceding academic year is created.'), true);
         }
+      });
+    });
+    describe('faculty', function () {
+      const [lastSpringSemester] = semesters.slice(-1);
+      const testAcademicYear = lastSpringSemester.academicYear + 1;
+      describe(`is ${ABSENCE_TYPE.NO_LONGER_ACTIVE}`, function () {
+        it('carries over from previous available academic year', async function () {
+          const { id } = await facultyRepository
+            .createQueryBuilder('f')
+            .leftJoinAndSelect('f.absences', 'absence')
+            .getOne();
+
+          await absenceRepository.createQueryBuilder()
+            .update(Absence)
+            .set({ type: ABSENCE_TYPE.NO_LONGER_ACTIVE })
+            .where('facultyId = :id', { id })
+            .execute();
+
+          await semesterService.addAcademicYear(testAcademicYear);
+
+          const { absences } = await facultyRepository
+            .createQueryBuilder('f')
+            .leftJoinAndSelect('f.absences', 'absence')
+            .leftJoinAndSelect('absence.semester', 'semester')
+            .where({ id })
+            .andWhere(
+              'semester.academicYear = :acyr',
+              { acyr: testAcademicYear }
+            )
+            .getOne();
+
+          const newAbsencesNla = absences
+            .every(({ type }) => type === ABSENCE_TYPE.NO_LONGER_ACTIVE);
+          strictEqual(newAbsencesNla, true);
+        });
+      });
+      describe(`is anything other than ${ABSENCE_TYPE.NO_LONGER_ACTIVE}`, function () {
+        it(`defaults to ${ABSENCE_TYPE.PRESENT}`, async function () {
+          const presentFacultyMember = await facultyRepository
+            .createQueryBuilder('f')
+            .leftJoinAndSelect('f.absences', 'absence')
+            .where('absence.type = :type', { type: ABSENCE_TYPE.PARENTAL_LEAVE })
+            .getOne();
+          await semesterService.addAcademicYear(testAcademicYear);
+
+          const { absences } = await facultyRepository
+            .createQueryBuilder('f')
+            .leftJoinAndSelect('f.absences', 'absence')
+            .leftJoinAndSelect('absence.semester', 'semester')
+            .where({ id: presentFacultyMember.id })
+            .andWhere('semester.academicYear = :acyr', { acyr: testAcademicYear })
+            .getOne();
+          const allPresent = absences
+            .every(({ type }) => type === ABSENCE_TYPE.PRESENT);
+          strictEqual(allPresent, true);
+        });
       });
     });
   });

--- a/tests/integration/server/semester/semester.service.test.ts
+++ b/tests/integration/server/semester/semester.service.test.ts
@@ -432,7 +432,7 @@ describe('Semester Service', function () {
       });
       describe(`is anything other than ${ABSENCE_TYPE.NO_LONGER_ACTIVE}`, function () {
         it(`defaults to ${ABSENCE_TYPE.PRESENT}`, async function () {
-          const presentFacultyMember = await facultyRepository
+          const activeFacultyMember = await facultyRepository
             .createQueryBuilder('f')
             .leftJoinAndSelect('f.absences', 'absence')
             .where('absence.type = :type', { type: ABSENCE_TYPE.PARENTAL_LEAVE })
@@ -447,7 +447,7 @@ describe('Semester Service', function () {
           });
           const newFallAbsence = await absenceRepository.findOne({
             where: {
-              faculty: presentFacultyMember.id,
+              faculty: activeFacultyMember.id,
               semester: newFallSemester.id,
             },
           });
@@ -461,7 +461,7 @@ describe('Semester Service', function () {
           });
           const newSpringAbsence = await absenceRepository.findOne({
             where: {
-              faculty: presentFacultyMember.id,
+              faculty: activeFacultyMember.id,
               semester: newSpringSemester.id,
             },
           });


### PR DESCRIPTION
This PR builds on the work in #546 and cascades these changes into the new semester upon creation. This means that:

- A faculty member who is `ABSENCE_TYPE.NO_LONGER_ACTIVE` will cascade into the newly created semester as such
- A faculty member who is anything else will be set as `ABSENCE_TYPE.PRESENT` in the newly created semester.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #534

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
