### PR TITLE
Incorporate Same As Logic to Update Multi Year Plan and Schedule Table Displays

### DIFF
--- a/src/client/components/pages/Schedule/ScheduleView.tsx
+++ b/src/client/components/pages/Schedule/ScheduleView.tsx
@@ -82,6 +82,16 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
    * Track the prefix and catalog number of the course whose details should be shown.
    */
   const [currentPopover, setCurrentPopover] = useState('');
+
+  /**
+   * Keeps track of the course number that was clicked on so that we can use
+   * this value to control the popover visibility
+   */
+  const [clickedCourseInfo, setClickedCourseInfo] = useState({
+    prefix: '',
+    number: '',
+  });
+
   return (
     <WeekBlock
       firstHour={firstHour}
@@ -155,7 +165,9 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                           xOffset="0.5rem"
                           yOffset={`-${2 + listIndex}rem`}
                           title={`${coursePrefix} ${courseNumber}`}
-                          isVisible={currentPopover === instanceId}
+                          isVisible={(currentPopover === instanceId)
+                            && (clickedCourseInfo.number === courseNumber)
+                            && (clickedCourseInfo.prefix === coursePrefix)}
                         >
                           <p>{day}</p>
                           <p>{`${displayStartTime} - ${displayEndTime}`}</p>
@@ -190,7 +202,9 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                     return (
                       <CourseListing key={meetingId}>
                         <CourseListingButton
-                          isHighlighted={popoverInBlock && isSelected}
+                          isHighlighted={(popoverInBlock && isSelected)
+                            && (clickedCourseInfo.number === courseNumber)
+                            && (clickedCourseInfo.prefix === coursePrefix)}
                           disabled={
                             !isSelectedDegreeProgram
                             || (popoverInBlock && !isSelected)
@@ -206,6 +220,10 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                               setCurrentPopover((current) => (
                                 current === instanceId ? null : instanceId
                               ));
+                              setClickedCourseInfo({
+                                prefix: coursePrefix,
+                                number: event.currentTarget.innerText,
+                              });
                             }
                           }}
                         >

--- a/src/client/components/pages/Schedule/ScheduleView.tsx
+++ b/src/client/components/pages/Schedule/ScheduleView.tsx
@@ -83,15 +83,6 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
    */
   const [currentPopover, setCurrentPopover] = useState('');
 
-  /**
-   * Keeps track of the course number that was clicked on so that we can use
-   * this value to control the popover visibility
-   */
-  const [clickedCourseInfo, setClickedCourseInfo] = useState({
-    prefix: '',
-    number: '',
-  });
-
   return (
     <WeekBlock
       firstHour={firstHour}
@@ -165,9 +156,7 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                           xOffset="0.5rem"
                           yOffset={`-${2 + listIndex}rem`}
                           title={`${coursePrefix} ${courseNumber}`}
-                          isVisible={(currentPopover === instanceId)
-                            && (clickedCourseInfo.number === courseNumber)
-                            && (clickedCourseInfo.prefix === coursePrefix)}
+                          isVisible={(currentPopover === instanceId)}
                         >
                           <p>{day}</p>
                           <p>{`${displayStartTime} - ${displayEndTime}`}</p>
@@ -202,9 +191,7 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                     return (
                       <CourseListing key={meetingId}>
                         <CourseListingButton
-                          isHighlighted={(popoverInBlock && isSelected)
-                            && (clickedCourseInfo.number === courseNumber)
-                            && (clickedCourseInfo.prefix === coursePrefix)}
+                          isHighlighted={(popoverInBlock && isSelected)}
                           disabled={
                             !isSelectedDegreeProgram
                             || (popoverInBlock && !isSelected)
@@ -220,10 +207,6 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                               setCurrentPopover((current) => (
                                 current === instanceId ? null : instanceId
                               ));
-                              setClickedCourseInfo({
-                                prefix: coursePrefix,
-                                number: courseNumber,
-                              });
                             }
                           }}
                         >

--- a/src/client/components/pages/Schedule/ScheduleView.tsx
+++ b/src/client/components/pages/Schedule/ScheduleView.tsx
@@ -134,7 +134,8 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
               const resolvedDuration = Math.round(
                 duration / minuteResolution
               );
-              const popoverInBlock = courses.some(({
+              const popoverInBlock = (coursePrefix === clickedCourseInfo.prefix)
+              && courses.some(({
                 instanceId,
               }) => instanceId === currentPopover);
               return [...blocks, (
@@ -192,7 +193,8 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                       `${endHour}:${endMinute.toString().padStart(2, '0')}`
                     );
                     const isSelectedCoursePrefix = isPrefixActive(coursePrefix);
-                    const isSelected = currentPopover === instanceId;
+                    const isSelected = currentPopover === instanceId
+                    && courseNumber === clickedCourseInfo.number;
                     const isSelectedDegreeProgram = (
                       degreeProgram === DEGREE_PROGRAM.BOTH
                         || (isUndergraduate

--- a/src/client/components/pages/Schedule/ScheduleView.tsx
+++ b/src/client/components/pages/Schedule/ScheduleView.tsx
@@ -82,7 +82,6 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
    * Track the prefix and catalog number of the course whose details should be shown.
    */
   const [currentPopover, setCurrentPopover] = useState('');
-
   return (
     <WeekBlock
       firstHour={firstHour}
@@ -156,7 +155,7 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                           xOffset="0.5rem"
                           yOffset={`-${2 + listIndex}rem`}
                           title={`${coursePrefix} ${courseNumber}`}
-                          isVisible={(currentPopover === instanceId)}
+                          isVisible={currentPopover === instanceId}
                         >
                           <p>{day}</p>
                           <p>{`${displayStartTime} - ${displayEndTime}`}</p>
@@ -191,7 +190,7 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                     return (
                       <CourseListing key={meetingId}>
                         <CourseListingButton
-                          isHighlighted={(popoverInBlock && isSelected)}
+                          isHighlighted={popoverInBlock && isSelected}
                           disabled={
                             !isSelectedDegreeProgram
                             || (popoverInBlock && !isSelected)

--- a/src/client/components/pages/Schedule/ScheduleView.tsx
+++ b/src/client/components/pages/Schedule/ScheduleView.tsx
@@ -79,7 +79,7 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
       / minuteResolution;
 
   /**
-   * Track the prefix and catalog number of the course whose details should be shown.
+   * Track the course id of the course whose details should be shown.
    */
   const [currentPopover, setCurrentPopover] = useState('');
 

--- a/src/client/components/pages/Schedule/ScheduleView.tsx
+++ b/src/client/components/pages/Schedule/ScheduleView.tsx
@@ -82,6 +82,16 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
    * Track the prefix and catalog number of the course whose details should be shown.
    */
   const [currentPopover, setCurrentPopover] = useState('');
+
+  /**
+   * Keeps track of the course number that was clicked on so that we can use
+   * this value to control the popover visibility
+   */
+  const [clickedCourseInfo, setClickedCourseInfo] = useState({
+    prefix: '',
+    number: '',
+  });
+
   return (
     <WeekBlock
       firstHour={firstHour}
@@ -155,7 +165,9 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                           xOffset="0.5rem"
                           yOffset={`-${2 + listIndex}rem`}
                           title={`${coursePrefix} ${courseNumber}`}
-                          isVisible={currentPopover === instanceId}
+                          isVisible={(currentPopover === instanceId)
+                            && (clickedCourseInfo.number === courseNumber)
+                            && (clickedCourseInfo.prefix === coursePrefix)}
                         >
                           <p>{day}</p>
                           <p>{`${displayStartTime} - ${displayEndTime}`}</p>
@@ -190,7 +202,9 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                     return (
                       <CourseListing key={meetingId}>
                         <CourseListingButton
-                          isHighlighted={popoverInBlock && isSelected}
+                          isHighlighted={(popoverInBlock && isSelected)
+                            && (clickedCourseInfo.number === courseNumber)
+                            && (clickedCourseInfo.prefix === coursePrefix)}
                           disabled={
                             !isSelectedDegreeProgram
                             || (popoverInBlock && !isSelected)
@@ -206,6 +220,10 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                               setCurrentPopover((current) => (
                                 current === instanceId ? null : instanceId
                               ));
+                              setClickedCourseInfo({
+                                prefix: coursePrefix,
+                                number: courseNumber,
+                              });
                             }
                           }}
                         >

--- a/src/client/components/pages/Schedule/ScheduleView.tsx
+++ b/src/client/components/pages/Schedule/ScheduleView.tsx
@@ -222,7 +222,7 @@ const ScheduleView: FunctionComponent<ScheduleViewProps> = ({
                               ));
                               setClickedCourseInfo({
                                 prefix: coursePrefix,
-                                number: event.currentTarget.innerText,
+                                number: courseNumber,
                               });
                             }
                           }}

--- a/src/server/courseInstance/MultiYearPlanView.entity.ts
+++ b/src/server/courseInstance/MultiYearPlanView.entity.ts
@@ -18,6 +18,7 @@ import { IS_SEAS } from 'common/constants';
     .addSelect('c.prefix', 'catalogPrefix')
     .addSelect("CONCAT_WS(' ', c.prefix, c.number)", 'catalogNumber')
     .addSelect('c.title', 'title')
+    .addSelect('c."sameAsId"', 'sameAsId')
     .where(`c."isSEAS" <> '${IS_SEAS.N}'`)
     .from(Course, 'c'),
 })
@@ -50,6 +51,14 @@ export class MultiYearPlanView {
    */
   @ViewColumn()
   public title: string;
+
+  /**
+   * From [[Course]]
+   * A free text field for admin staff to record any other courses that this
+   * course is the same as
+   */
+  @ViewColumn()
+  public sameAsId: string;
 
   public semesters: SemesterView[];
 }

--- a/src/server/courseInstance/ScheduleBlockView.entity.ts
+++ b/src/server/courseInstance/ScheduleBlockView.entity.ts
@@ -32,7 +32,7 @@ import { ScheduleEntryView } from './ScheduleEntryView.entity';
     .addSelect('CONCAT(c.prefix, m.day, TO_CHAR(m."startTime"::TIME, \'HH24MI\'), TO_CHAR(m."endTime"::TIME, \'HH24MI\'), s.term, s."academicYear")', 'id')
     .distinct(true)
     .from(Course, 'c')
-    .leftJoin(CourseInstance, 'ci', 'ci."courseId" = c.id')
+    .leftJoin(CourseInstance, 'ci', 'ci."courseId" = COALESCE(c."sameAsId", c.id)')
     .innerJoin(Semester, 's', 's.id = ci."semesterId"')
     .innerJoin(Meeting, 'm', 'm."courseInstanceId" = ci.id')
     .groupBy('c.prefix')

--- a/src/server/courseInstance/ScheduleEntryView.entity.ts
+++ b/src/server/courseInstance/ScheduleEntryView.entity.ts
@@ -35,7 +35,7 @@ import { Campus } from '../location/campus.entity';
     .addSelect('campus.name', 'campus')
     .addSelect('CONCAT(c.prefix, m.day, TO_CHAR(m."startTime"::TIME, \'HH24MI\'), TO_CHAR(m."endTime"::TIME, \'HH24MI\'), s.term, s."academicYear")', 'blockId')
     .from(CourseInstance, 'ci')
-    .leftJoin(Course, 'c', 'c.id = COALESCE(c."sameAsId", ci."courseId")')
+    .leftJoin(Course, 'c', 'ci."courseId" = COALESCE(c."sameAsId", c.id)')
     .innerJoin(Semester, 's', 's.id = ci."semesterId"')
     .innerJoin(Meeting, 'm', 'm."courseInstanceId" = ci.id')
     .leftJoin(Room, 'r', 'r.id = m."roomId"')

--- a/src/server/courseInstance/ScheduleEntryView.entity.ts
+++ b/src/server/courseInstance/ScheduleEntryView.entity.ts
@@ -35,7 +35,7 @@ import { Campus } from '../location/campus.entity';
     .addSelect('campus.name', 'campus')
     .addSelect('CONCAT(c.prefix, m.day, TO_CHAR(m."startTime"::TIME, \'HH24MI\'), TO_CHAR(m."endTime"::TIME, \'HH24MI\'), s.term, s."academicYear")', 'blockId')
     .from(CourseInstance, 'ci')
-    .leftJoin(Course, 'c', 'ci."courseId" = c.id')
+    .leftJoin(Course, 'c', 'c.id = COALESCE(c."sameAsId", ci."courseId")')
     .innerJoin(Semester, 's', 's.id = ci."semesterId"')
     .innerJoin(Meeting, 'm', 'm."courseInstanceId" = ci.id')
     .leftJoin(Room, 'r', 'r.id = m."roomId"')

--- a/src/server/courseInstance/courseInstance.service.ts
+++ b/src/server/courseInstance/courseInstance.service.ts
@@ -164,7 +164,7 @@ export class CourseInstanceService {
         's.instance',
         MultiYearPlanInstanceView,
         'ci',
-        'c.id = ci."courseId" AND s.id = ci."semesterId"'
+        'ci."courseId" = COALESCE(c."sameAsId", c.id) AND s.id = ci."semesterId"'
       )
       .leftJoinAndMapMany(
         'ci.faculty',

--- a/src/server/migrations/1677723792323-AddSameAsId.ts
+++ b/src/server/migrations/1677723792323-AddSameAsId.ts
@@ -5,8 +5,6 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * use the field value to reference the parent, if it exists, of the course.
  */
 export class AddSameAsId1677723792323 implements MigrationInterface {
-  name = 'AddSameAsId1677723792323';
-
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'MultiYearPlanView']);
     await queryRunner.query('DROP VIEW "MultiYearPlanView"');

--- a/src/server/migrations/1677723792323-AddSameAsId.ts
+++ b/src/server/migrations/1677723792323-AddSameAsId.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * This will add the sameAsId field to the MultiYearPlanView so that we can
+ * use the field value to reference the parent, if it exists, of the course.
+ */
+export class AddSameAsId1677723792323 implements MigrationInterface {
+  name = 'AddSameAsId1677723792323';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'MultiYearPlanView']);
+    await queryRunner.query('DROP VIEW "MultiYearPlanView"');
+    await queryRunner.query('CREATE VIEW "MultiYearPlanView" AS SELECT "c"."id" AS "id", "c"."title" AS "title", "c"."prefix" AS "catalogPrefix", CONCAT_WS(\' \', "c"."prefix", "c"."number") AS "catalogNumber", c."sameAsId" AS "sameAsId" FROM "course" "c" WHERE c."isSEAS" <> \'N\'');
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'MultiYearPlanView', "SELECT \"c\".\"id\" AS \"id\", \"c\".\"title\" AS \"title\", \"c\".\"prefix\" AS \"catalogPrefix\", CONCAT_WS(' ', \"c\".\"prefix\", \"c\".\"number\") AS \"catalogNumber\", c.\"sameAsId\" AS \"sameAsId\" FROM \"course\" \"c\" WHERE c.\"isSEAS\" <> 'N'"]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'MultiYearPlanView']);
+    await queryRunner.query('DROP VIEW "MultiYearPlanView"');
+    await queryRunner.query('CREATE VIEW "MultiYearPlanView" AS SELECT "c"."id" AS "id", "c"."title" AS "title", "c"."prefix" AS "catalogPrefix", CONCAT_WS(\' \', "c"."prefix", "c"."number") AS "catalogNumber" FROM "course" "c" WHERE c."isSEAS" <> \'N\'');
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'MultiYearPlanView', "SELECT \"c\".\"id\" AS \"id\", \"c\".\"title\" AS \"title\", \"c\".\"prefix\" AS \"catalogPrefix\", CONCAT_WS(' ', \"c\".\"prefix\", \"c\".\"number\") AS \"catalogNumber\" FROM \"course\" \"c\" WHERE c.\"isSEAS\" <> 'N'"]);
+  }
+}

--- a/src/server/migrations/1678123233937-UpdateScheduleEntryView.ts
+++ b/src/server/migrations/1678123233937-UpdateScheduleEntryView.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * This update to the ScheduleEntryView will update the results such that if a
+ * course has a parent (this can be confirmed with the presence of a sameAs id),
+ * the instances of the parent will be displayed instead.
+ */
+export class UpdateScheduleEntryView1678123233937
+implements MigrationInterface {
+  name = 'UpdateScheduleEntryView1678123233937';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'ScheduleEntryView']);
+    await queryRunner.query('DROP VIEW "ScheduleEntryView"');
+    await queryRunner.query('CREATE VIEW "ScheduleEntryView" AS SELECT "ci"."id" AS "instanceId", "c"."number" AS "courseNumber", "c"."isUndergraduate" AS "isUndergraduate", "m"."id" AS "id", "campus"."name" AS "campus", CONCAT_WS(\' \', "b"."name", "r"."name") AS "room", CONCAT("c"."prefix", "m"."day", TO_CHAR(m."startTime"::TIME, \'HH24MI\'), TO_CHAR(m."endTime"::TIME, \'HH24MI\'), "s"."term", s."academicYear") AS "blockId" FROM "course_instance" "ci" LEFT JOIN "course" "c" ON "c"."id" = COALESCE(c."sameAsId", ci."courseId")  INNER JOIN "semester" "s" ON "s"."id" = ci."semesterId"  INNER JOIN "meeting" "m" ON m."courseInstanceId" = "ci"."id"  LEFT JOIN "room" "r" ON "r"."id" = m."roomId"  LEFT JOIN "building" "b" ON "b"."id" = r."buildingId"  LEFT JOIN "campus" "campus" ON "campus"."id" = b."campusId" WHERE c."isSEAS" <> \'N\'');
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'ScheduleEntryView', "SELECT \"ci\".\"id\" AS \"instanceId\", \"c\".\"number\" AS \"courseNumber\", \"c\".\"isUndergraduate\" AS \"isUndergraduate\", \"m\".\"id\" AS \"id\", \"campus\".\"name\" AS \"campus\", CONCAT_WS(' ', \"b\".\"name\", \"r\".\"name\") AS \"room\", CONCAT(\"c\".\"prefix\", \"m\".\"day\", TO_CHAR(m.\"startTime\"::TIME, 'HH24MI'), TO_CHAR(m.\"endTime\"::TIME, 'HH24MI'), \"s\".\"term\", s.\"academicYear\") AS \"blockId\" FROM \"course_instance\" \"ci\" LEFT JOIN \"course\" \"c\" ON \"c\".\"id\" = COALESCE(c.\"sameAsId\", ci.\"courseId\")  INNER JOIN \"semester\" \"s\" ON \"s\".\"id\" = ci.\"semesterId\"  INNER JOIN \"meeting\" \"m\" ON m.\"courseInstanceId\" = \"ci\".\"id\"  LEFT JOIN \"room\" \"r\" ON \"r\".\"id\" = m.\"roomId\"  LEFT JOIN \"building\" \"b\" ON \"b\".\"id\" = r.\"buildingId\"  LEFT JOIN \"campus\" \"campus\" ON \"campus\".\"id\" = b.\"campusId\" WHERE c.\"isSEAS\" <> 'N'"]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'ScheduleEntryView']);
+    await queryRunner.query('DROP VIEW "ScheduleEntryView"');
+    await queryRunner.query('CREATE VIEW "ScheduleEntryView" AS SELECT "ci"."id" AS "instanceId", "c"."number" AS "courseNumber", "c"."isUndergraduate" AS "isUndergraduate", "m"."id" AS "id", "campus"."name" AS "campus", CONCAT_WS(\' \', "b"."name", "r"."name") AS "room", CONCAT("c"."prefix", "m"."day", TO_CHAR(m."startTime"::TIME, \'HH24MI\'), TO_CHAR(m."endTime"::TIME, \'HH24MI\'), "s"."term", s."academicYear") AS "blockId" FROM "course_instance" "ci" LEFT JOIN "course" "c" ON ci."courseId" = "c"."id"  INNER JOIN "semester" "s" ON "s"."id" = ci."semesterId"  INNER JOIN "meeting" "m" ON m."courseInstanceId" = "ci"."id"  LEFT JOIN "room" "r" ON "r"."id" = m."roomId"  LEFT JOIN "building" "b" ON "b"."id" = r."buildingId"  LEFT JOIN "campus" "campus" ON "campus"."id" = b."campusId" WHERE c."isSEAS" <> \'N\'');
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'ScheduleEntryView', "SELECT \"ci\".\"id\" AS \"instanceId\", \"c\".\"number\" AS \"courseNumber\", \"c\".\"isUndergraduate\" AS \"isUndergraduate\", \"m\".\"id\" AS \"id\", \"campus\".\"name\" AS \"campus\", CONCAT_WS(' ', \"b\".\"name\", \"r\".\"name\") AS \"room\", CONCAT(\"c\".\"prefix\", \"m\".\"day\", TO_CHAR(m.\"startTime\"::TIME, 'HH24MI'), TO_CHAR(m.\"endTime\"::TIME, 'HH24MI'), \"s\".\"term\", s.\"academicYear\") AS \"blockId\" FROM \"course_instance\" \"ci\" LEFT JOIN \"course\" \"c\" ON ci.\"courseId\" = \"c\".\"id\"  INNER JOIN \"semester\" \"s\" ON \"s\".\"id\" = ci.\"semesterId\"  INNER JOIN \"meeting\" \"m\" ON m.\"courseInstanceId\" = \"ci\".\"id\"  LEFT JOIN \"room\" \"r\" ON \"r\".\"id\" = m.\"roomId\"  LEFT JOIN \"building\" \"b\" ON \"b\".\"id\" = r.\"buildingId\"  LEFT JOIN \"campus\" \"campus\" ON \"campus\".\"id\" = b.\"campusId\" WHERE c.\"isSEAS\" <> 'N'"]);
+  }
+}

--- a/src/server/migrations/1678202422266-UpdateScheduleEntryView.ts
+++ b/src/server/migrations/1678202422266-UpdateScheduleEntryView.ts
@@ -1,9 +1,12 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
+/**
+ * This migration updates the ScheduleEntryView such that if a course has a
+ * parent (which is indicated by the presence of a sameAsId value), we will
+ * get the schedule information of the course parent instead.
+ */
 export class UpdateScheduleEntryView1678202422266
 implements MigrationInterface {
-  name = 'UpdateScheduleEntryView1678202422266';
-
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'ScheduleEntryView']);
     await queryRunner.query('DROP VIEW "ScheduleEntryView"');

--- a/src/server/migrations/1678202422266-UpdateScheduleEntryView.ts
+++ b/src/server/migrations/1678202422266-UpdateScheduleEntryView.ts
@@ -1,19 +1,14 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-/**
- * This update to the ScheduleEntryView will update the results such that if a
- * course has a parent (this can be confirmed with the presence of a sameAs id),
- * the instances of the parent will be displayed instead.
- */
-export class UpdateScheduleEntryView1678123233937
+export class UpdateScheduleEntryView1678202422266
 implements MigrationInterface {
-  name = 'UpdateScheduleEntryView1678123233937';
+  name = 'UpdateScheduleEntryView1678202422266';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'ScheduleEntryView']);
     await queryRunner.query('DROP VIEW "ScheduleEntryView"');
-    await queryRunner.query('CREATE VIEW "ScheduleEntryView" AS SELECT "ci"."id" AS "instanceId", "c"."number" AS "courseNumber", "c"."isUndergraduate" AS "isUndergraduate", "m"."id" AS "id", "campus"."name" AS "campus", CONCAT_WS(\' \', "b"."name", "r"."name") AS "room", CONCAT("c"."prefix", "m"."day", TO_CHAR(m."startTime"::TIME, \'HH24MI\'), TO_CHAR(m."endTime"::TIME, \'HH24MI\'), "s"."term", s."academicYear") AS "blockId" FROM "course_instance" "ci" LEFT JOIN "course" "c" ON "c"."id" = COALESCE(c."sameAsId", ci."courseId")  INNER JOIN "semester" "s" ON "s"."id" = ci."semesterId"  INNER JOIN "meeting" "m" ON m."courseInstanceId" = "ci"."id"  LEFT JOIN "room" "r" ON "r"."id" = m."roomId"  LEFT JOIN "building" "b" ON "b"."id" = r."buildingId"  LEFT JOIN "campus" "campus" ON "campus"."id" = b."campusId" WHERE c."isSEAS" <> \'N\'');
-    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'ScheduleEntryView', "SELECT \"ci\".\"id\" AS \"instanceId\", \"c\".\"number\" AS \"courseNumber\", \"c\".\"isUndergraduate\" AS \"isUndergraduate\", \"m\".\"id\" AS \"id\", \"campus\".\"name\" AS \"campus\", CONCAT_WS(' ', \"b\".\"name\", \"r\".\"name\") AS \"room\", CONCAT(\"c\".\"prefix\", \"m\".\"day\", TO_CHAR(m.\"startTime\"::TIME, 'HH24MI'), TO_CHAR(m.\"endTime\"::TIME, 'HH24MI'), \"s\".\"term\", s.\"academicYear\") AS \"blockId\" FROM \"course_instance\" \"ci\" LEFT JOIN \"course\" \"c\" ON \"c\".\"id\" = COALESCE(c.\"sameAsId\", ci.\"courseId\")  INNER JOIN \"semester\" \"s\" ON \"s\".\"id\" = ci.\"semesterId\"  INNER JOIN \"meeting\" \"m\" ON m.\"courseInstanceId\" = \"ci\".\"id\"  LEFT JOIN \"room\" \"r\" ON \"r\".\"id\" = m.\"roomId\"  LEFT JOIN \"building\" \"b\" ON \"b\".\"id\" = r.\"buildingId\"  LEFT JOIN \"campus\" \"campus\" ON \"campus\".\"id\" = b.\"campusId\" WHERE c.\"isSEAS\" <> 'N'"]);
+    await queryRunner.query('CREATE VIEW "ScheduleEntryView" AS SELECT "ci"."id" AS "instanceId", "c"."number" AS "courseNumber", "c"."isUndergraduate" AS "isUndergraduate", "m"."id" AS "id", "campus"."name" AS "campus", CONCAT_WS(\' \', "b"."name", "r"."name") AS "room", CONCAT("c"."prefix", "m"."day", TO_CHAR(m."startTime"::TIME, \'HH24MI\'), TO_CHAR(m."endTime"::TIME, \'HH24MI\'), "s"."term", s."academicYear") AS "blockId" FROM "course_instance" "ci" LEFT JOIN "course" "c" ON ci."courseId" = COALESCE(c."sameAsId", "c"."id")  INNER JOIN "semester" "s" ON "s"."id" = ci."semesterId"  INNER JOIN "meeting" "m" ON m."courseInstanceId" = "ci"."id"  LEFT JOIN "room" "r" ON "r"."id" = m."roomId"  LEFT JOIN "building" "b" ON "b"."id" = r."buildingId"  LEFT JOIN "campus" "campus" ON "campus"."id" = b."campusId" WHERE c."isSEAS" <> \'N\'');
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'ScheduleEntryView', "SELECT \"ci\".\"id\" AS \"instanceId\", \"c\".\"number\" AS \"courseNumber\", \"c\".\"isUndergraduate\" AS \"isUndergraduate\", \"m\".\"id\" AS \"id\", \"campus\".\"name\" AS \"campus\", CONCAT_WS(' ', \"b\".\"name\", \"r\".\"name\") AS \"room\", CONCAT(\"c\".\"prefix\", \"m\".\"day\", TO_CHAR(m.\"startTime\"::TIME, 'HH24MI'), TO_CHAR(m.\"endTime\"::TIME, 'HH24MI'), \"s\".\"term\", s.\"academicYear\") AS \"blockId\" FROM \"course_instance\" \"ci\" LEFT JOIN \"course\" \"c\" ON ci.\"courseId\" = COALESCE(c.\"sameAsId\", \"c\".\"id\")  INNER JOIN \"semester\" \"s\" ON \"s\".\"id\" = ci.\"semesterId\"  INNER JOIN \"meeting\" \"m\" ON m.\"courseInstanceId\" = \"ci\".\"id\"  LEFT JOIN \"room\" \"r\" ON \"r\".\"id\" = m.\"roomId\"  LEFT JOIN \"building\" \"b\" ON \"b\".\"id\" = r.\"buildingId\"  LEFT JOIN \"campus\" \"campus\" ON \"campus\".\"id\" = b.\"campusId\" WHERE c.\"isSEAS\" <> 'N'"]);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/server/migrations/1678297871835-UpdateScheduleBlockView.ts
+++ b/src/server/migrations/1678297871835-UpdateScheduleBlockView.ts
@@ -9,8 +9,6 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  */
 export class UpdateScheduleBlockView1678297871835
 implements MigrationInterface {
-  name = 'UpdateScheduleBlockView1678297871835';
-
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'ScheduleBlockView']);
     await queryRunner.query('DROP VIEW "ScheduleBlockView"');

--- a/src/server/migrations/1678297871835-UpdateScheduleBlockView.ts
+++ b/src/server/migrations/1678297871835-UpdateScheduleBlockView.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * This migration updates the ScheduleBlockView to compare the instance's course
+ * ID with the sameAs value of the course if that exists. Since the
+ * related ScheduleEntryView has been updated to do this, this migration is
+ * fixing the mismatch between the ways the course instances were being joined
+ * to the courses.
+ */
+export class UpdateScheduleBlockView1678297871835
+implements MigrationInterface {
+  name = 'UpdateScheduleBlockView1678297871835';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'ScheduleBlockView']);
+    await queryRunner.query('DROP VIEW "ScheduleBlockView"');
+    await queryRunner.query('CREATE VIEW "ScheduleBlockView" AS SELECT DISTINCT "c"."prefix" AS "coursePrefix", "s"."term" AS "term", "m"."day" AS "weekday", s."academicYear" AS "calendarYear", EXTRACT(HOUR FROM m."startTime") AS "startHour", EXTRACT(MINUTE FROM m."startTime") AS "startMinute", EXTRACT(HOUR FROM m."endTime") AS "endHour", EXTRACT(MINUTE FROM m."endTime") AS "endMinute", EXTRACT(EPOCH FROM m."endTime"::TIME - m."startTime"::TIME) / 60 AS "duration", CONCAT("c"."prefix", "m"."day", TO_CHAR(m."startTime"::TIME, \'HH24MI\'), TO_CHAR(m."endTime"::TIME, \'HH24MI\'), "s"."term", s."academicYear") AS "id" FROM "course" "c" LEFT JOIN "course_instance" "ci" ON ci."courseId" = COALESCE(c."sameAsId", "c"."id")  INNER JOIN "semester" "s" ON "s"."id" = ci."semesterId"  INNER JOIN "meeting" "m" ON m."courseInstanceId" = "ci"."id" GROUP BY "c"."prefix", "m"."day", s."academicYear", "s"."term", m."startTime", m."endTime", c."isSEAS" HAVING c."isSEAS" <> \'N\'');
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'ScheduleBlockView', "SELECT DISTINCT \"c\".\"prefix\" AS \"coursePrefix\", \"s\".\"term\" AS \"term\", \"m\".\"day\" AS \"weekday\", s.\"academicYear\" AS \"calendarYear\", EXTRACT(HOUR FROM m.\"startTime\") AS \"startHour\", EXTRACT(MINUTE FROM m.\"startTime\") AS \"startMinute\", EXTRACT(HOUR FROM m.\"endTime\") AS \"endHour\", EXTRACT(MINUTE FROM m.\"endTime\") AS \"endMinute\", EXTRACT(EPOCH FROM m.\"endTime\"::TIME - m.\"startTime\"::TIME) / 60 AS \"duration\", CONCAT(\"c\".\"prefix\", \"m\".\"day\", TO_CHAR(m.\"startTime\"::TIME, 'HH24MI'), TO_CHAR(m.\"endTime\"::TIME, 'HH24MI'), \"s\".\"term\", s.\"academicYear\") AS \"id\" FROM \"course\" \"c\" LEFT JOIN \"course_instance\" \"ci\" ON ci.\"courseId\" = COALESCE(c.\"sameAsId\", \"c\".\"id\")  INNER JOIN \"semester\" \"s\" ON \"s\".\"id\" = ci.\"semesterId\"  INNER JOIN \"meeting\" \"m\" ON m.\"courseInstanceId\" = \"ci\".\"id\" GROUP BY \"c\".\"prefix\", \"m\".\"day\", s.\"academicYear\", \"s\".\"term\", m.\"startTime\", m.\"endTime\", c.\"isSEAS\" HAVING c.\"isSEAS\" <> 'N'"]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'ScheduleBlockView']);
+    await queryRunner.query('DROP VIEW "ScheduleBlockView"');
+    await queryRunner.query('CREATE VIEW "ScheduleBlockView" AS SELECT DISTINCT "c"."prefix" AS "coursePrefix", "s"."term" AS "term", "m"."day" AS "weekday", s."academicYear" AS "calendarYear", EXTRACT(HOUR FROM m."startTime") AS "startHour", EXTRACT(MINUTE FROM m."startTime") AS "startMinute", EXTRACT(HOUR FROM m."endTime") AS "endHour", EXTRACT(MINUTE FROM m."endTime") AS "endMinute", EXTRACT(EPOCH FROM m."endTime"::TIME - m."startTime"::TIME) / 60 AS "duration", CONCAT("c"."prefix", "m"."day", TO_CHAR(m."startTime"::TIME, \'HH24MI\'), TO_CHAR(m."endTime"::TIME, \'HH24MI\'), "s"."term", s."academicYear") AS "id" FROM "course" "c" LEFT JOIN "course_instance" "ci" ON ci."courseId" = "c"."id"  INNER JOIN "semester" "s" ON "s"."id" = ci."semesterId"  INNER JOIN "meeting" "m" ON m."courseInstanceId" = "ci"."id" GROUP BY "c"."prefix", "m"."day", s."academicYear", "s"."term", m."startTime", m."endTime", c."isSEAS" HAVING c."isSEAS" <> \'N\'');
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'ScheduleBlockView', "SELECT DISTINCT \"c\".\"prefix\" AS \"coursePrefix\", \"s\".\"term\" AS \"term\", \"m\".\"day\" AS \"weekday\", s.\"academicYear\" AS \"calendarYear\", EXTRACT(HOUR FROM m.\"startTime\") AS \"startHour\", EXTRACT(MINUTE FROM m.\"startTime\") AS \"startMinute\", EXTRACT(HOUR FROM m.\"endTime\") AS \"endHour\", EXTRACT(MINUTE FROM m.\"endTime\") AS \"endMinute\", EXTRACT(EPOCH FROM m.\"endTime\"::TIME - m.\"startTime\"::TIME) / 60 AS \"duration\", CONCAT(\"c\".\"prefix\", \"m\".\"day\", TO_CHAR(m.\"startTime\"::TIME, 'HH24MI'), TO_CHAR(m.\"endTime\"::TIME, 'HH24MI'), \"s\".\"term\", s.\"academicYear\") AS \"id\" FROM \"course\" \"c\" LEFT JOIN \"course_instance\" \"ci\" ON ci.\"courseId\" = \"c\".\"id\"  INNER JOIN \"semester\" \"s\" ON \"s\".\"id\" = ci.\"semesterId\"  INNER JOIN \"meeting\" \"m\" ON m.\"courseInstanceId\" = \"ci\".\"id\" GROUP BY \"c\".\"prefix\", \"m\".\"day\", s.\"academicYear\", \"s\".\"term\", m.\"startTime\", m.\"endTime\", c.\"isSEAS\" HAVING c.\"isSEAS\" <> 'N'"]);
+  }
+}

--- a/tests/integration/e2e/MultiYearPlan.test.tsx
+++ b/tests/integration/e2e/MultiYearPlan.test.tsx
@@ -1,0 +1,183 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import React from 'react';
+import {
+  stub, SinonStub,
+} from 'sinon';
+import {
+  render,
+  RenderResult,
+  fireEvent,
+  within,
+  wait,
+} from '@testing-library/react';
+import { TypeOrmModule, TypeOrmModuleOptions, getRepositoryToken } from '@nestjs/typeorm';
+import * as dummy from 'testData';
+import { SessionModule } from 'nestjs-session';
+import { MemoryRouter } from 'react-router-dom';
+import App from 'client/components/App';
+import request from 'client/api/request';
+import { Repository, Not } from 'typeorm';
+import {
+  strictEqual,
+} from 'assert';
+import { SemesterModule } from 'server/semester/semester.module';
+import mockAdapter from '../../mocks/api/adapter';
+import { ConfigModule } from '../../../src/server/config/config.module';
+import { ConfigService } from '../../../src/server/config/config.service';
+import { AuthModule } from '../../../src/server/auth/auth.module';
+import { TestingStrategy } from '../../mocks/authentication/testing.strategy';
+import {
+  AUTH_MODE,
+} from '../../../src/common/constants';
+import { PopulationModule } from '../../mocks/database/population/population.module';
+import { CourseModule } from '../../../src/server/course/course.module';
+import { BadRequestExceptionPipe } from '../../../src/server/utils/BadRequestExceptionPipe';
+import { MetadataModule } from '../../../src/server/metadata/metadata.module';
+import { FacultyModule } from '../../../src/server/faculty/faculty.module';
+import { CourseInstanceModule } from '../../../src/server/courseInstance/courseInstance.module';
+import { UserController } from '../../../src/server/user/user.controller';
+import { Course } from '../../../src/server/course/course.entity';
+import { LogModule } from '../../../src/server/log/log.module';
+
+describe('End-to-end Multi Year Plan tests', function () {
+  let testModule: TestingModule;
+  let authStub: SinonStub;
+  let courseRepository: Repository<Course>;
+  const currentAcademicYear = 2019;
+  let renderResult: RenderResult;
+
+  beforeEach(async function () {
+    authStub = stub(TestingStrategy.prototype, 'login');
+    const fakeConfig = new ConfigService(this.database.connectionEnv);
+    // Stub out the academicYear getter to lock us to a known year. Otherwise,
+    // tests might fail in the future if our test data don't include that year.
+    stub(fakeConfig, 'academicYear').get(() => currentAcademicYear);
+    stub(fakeConfig, 'logLevel').get(() => 'error');
+    testModule = await Test.createTestingModule({
+      imports: [
+        SessionModule.forRoot({
+          session: {
+            secret: dummy.safeString,
+            resave: true,
+            saveUninitialized: true,
+          },
+        }),
+        ConfigModule,
+        LogModule,
+        TypeOrmModule.forRootAsync({
+          imports: [ConfigModule],
+          useFactory: (
+            config: ConfigService
+          ): TypeOrmModuleOptions => ({
+            ...config.dbOptions,
+            synchronize: true,
+            autoLoadEntities: true,
+            retryAttempts: 10,
+            retryDelay: 10000,
+          }),
+          inject: [ConfigService],
+        }),
+        AuthModule.register({
+          strategies: [TestingStrategy],
+          defaultStrategy: AUTH_MODE.TEST,
+        }),
+        PopulationModule,
+        CourseModule,
+        FacultyModule,
+        CourseInstanceModule,
+        MetadataModule,
+        SemesterModule,
+      ],
+      controllers: [
+        UserController,
+      ],
+    })
+      .overrideProvider(ConfigService)
+      .useValue(fakeConfig)
+      .compile();
+    courseRepository = testModule.get(
+      getRepositoryToken(Course)
+    );
+    const nestApp = await testModule
+      .createNestApplication()
+      .useGlobalPipes(new BadRequestExceptionPipe())
+      .init();
+    const api = nestApp.getHttpServer();
+    request.defaults.adapter = mockAdapter(api);
+    authStub.resolves(dummy.adminUser);
+  });
+  afterEach(async function () {
+    return testModule.close();
+  });
+  describe('Rendering Instructor Information', function () {
+    let parentCourse: Course;
+    let childCourse: Course;
+    beforeEach(async function () {
+      parentCourse = await courseRepository.findOne();
+      childCourse = await courseRepository.findOne({
+        where: {
+          id: Not(parentCourse.id),
+        },
+      });
+      renderResult = render(
+        <MemoryRouter initialEntries={['/course-admin']}>
+          <App />
+        </MemoryRouter>
+      );
+    });
+    context('when a course is a child of another', function () {
+      it('should display the faculty of its parent course', async function () {
+        await renderResult.findByText(childCourse.title, { exact: false });
+        // Edit the child course to set its parent via the sameAs field
+        const editButton = await renderResult
+          .findByLabelText(`Edit course information for ${childCourse.title}`,
+            { exact: false });
+        fireEvent.click(editButton);
+        await renderResult.findByRole('dialog');
+        const sameAsSelect = renderResult.getByLabelText('Same As', { exact: false }) as HTMLSelectElement;
+        fireEvent.change(
+          sameAsSelect,
+          { target: { value: parentCourse.id } }
+        );
+        const submitButton = renderResult.getByText('Submit');
+        fireEvent.click(submitButton);
+        await wait(() => !renderResult.queryByText('required fields', { exact: false }));
+
+        // Navigate to multi year plan tab
+        const multiYearPlanTab = await renderResult.findByText('4 Year Plan', { exact: false });
+        fireEvent.click(multiYearPlanTab);
+        await renderResult.findByText(childCourse.title, { exact: false });
+
+        // Find the instructor information across the years for the parent course
+        const rows = renderResult.getAllByRole('row');
+        const utils = within(rows[1]);
+        const catalogNumberField = utils.queryByLabelText('The table will be filtered as characters are typed in this catalog number filter field');
+        fireEvent.change(catalogNumberField, { target: { value: `${parentCourse.prefix} ${parentCourse.number}` } });
+        const parentRow = Array.from(renderResult.getAllByRole('row'))[2] as HTMLTableRowElement;
+        let parentRowContent = (Array.from(parentRow.cells)
+          .map((cell) => cell.textContent));
+        // Remove the course top level information and
+        // take only the instructor information.
+        parentRowContent = parentRowContent.slice(3);
+
+        // Find the instructor information across the years for the child course
+        fireEvent.change(catalogNumberField, { target: { value: `${childCourse.prefix} ${childCourse.number}` } });
+        const childRow = Array.from(renderResult.getAllByRole('row'))[2] as HTMLTableRowElement;
+        let childRowContent = (Array.from(childRow.cells)
+          .map((cell) => cell.textContent));
+        // Remove the top level course information and
+        // take only the instructor information.
+        childRowContent = childRowContent.slice(3);
+
+        // Compare the faculty information and make sure they are equal
+        let areRowsEqual = true;
+        for (let i = 0; i < parentRowContent.length; i++) {
+          if (parentRowContent[i] !== childRowContent[i]) {
+            areRowsEqual = false;
+          }
+        }
+        strictEqual(areRowsEqual, true);
+      });
+    });
+  });
+});

--- a/tests/integration/e2e/MultiYearPlan.test.tsx
+++ b/tests/integration/e2e/MultiYearPlan.test.tsx
@@ -184,8 +184,8 @@ describe('End-to-end Multi Year Plan tests', function () {
         for (let i = 0; i < parentRowContent.length; i++) {
           if (parentRowContent[i] !== childRowContent[i]) {
             areRowsEqual = false;
-            numRowsCompared += 1;
           }
+          numRowsCompared += 1;
         }
         strictEqual(
           numRowsCompared > 0,

--- a/tests/integration/e2e/MultiYearPlan.test.tsx
+++ b/tests/integration/e2e/MultiYearPlan.test.tsx
@@ -178,16 +178,20 @@ describe('End-to-end Multi Year Plan tests', function () {
         // take only the instructor information.
         childRowContent = childRowContent.slice(3);
 
-        strictEqual(parentRowContent.length > 0, true, 'Parent course row is empty.');
-        strictEqual(childRowContent.length > 0, true, 'Child course row is empty.');
-
+        let numRowsCompared = 0;
         // Compare the faculty information and make sure they are equal
         let areRowsEqual = true;
         for (let i = 0; i < parentRowContent.length; i++) {
           if (parentRowContent[i] !== childRowContent[i]) {
             areRowsEqual = false;
+            numRowsCompared += 1;
           }
         }
+        strictEqual(
+          numRowsCompared > 0,
+          true,
+          'No rows were compared, possibly because the rows are empty.'
+        );
         strictEqual(areRowsEqual, true, 'Parent and child rows do not have the same content.');
       });
     });

--- a/tests/integration/e2e/MultiYearPlan.test.tsx
+++ b/tests/integration/e2e/MultiYearPlan.test.tsx
@@ -193,7 +193,7 @@ describe('End-to-end Multi Year Plan tests', function () {
           'No rows were compared, possibly because the rows are empty.'
         );
         strictEqual(areRowsEqual, true, 'Parent and child rows do not have the same content.');
-      });
+      }).timeout(120000);
     });
   });
 });

--- a/tests/integration/e2e/MultiYearPlan.test.tsx
+++ b/tests/integration/e2e/MultiYearPlan.test.tsx
@@ -8,7 +8,7 @@ import {
   RenderResult,
   fireEvent,
   within,
-  wait,
+  waitForElementToBeRemoved,
 } from '@testing-library/react';
 import { TypeOrmModule, TypeOrmModuleOptions, getRepositoryToken } from '@nestjs/typeorm';
 import * as dummy from 'testData';
@@ -141,7 +141,7 @@ describe('End-to-end Multi Year Plan tests', function () {
         );
         const submitButton = renderResult.getByText('Submit');
         fireEvent.click(submitButton);
-        await wait(() => !renderResult.queryByText('required fields', { exact: false }));
+        await waitForElementToBeRemoved(() => renderResult.getByRole('dialog'));
 
         // Navigate to multi year plan tab
         const multiYearPlanTab = await renderResult.findByText('4 Year Plan', { exact: false });

--- a/tests/integration/e2e/MultiYearPlan.test.tsx
+++ b/tests/integration/e2e/MultiYearPlan.test.tsx
@@ -169,6 +169,9 @@ describe('End-to-end Multi Year Plan tests', function () {
         // take only the instructor information.
         childRowContent = childRowContent.slice(3);
 
+        strictEqual(parentRowContent.length > 0, true, 'Parent course row is empty.');
+        strictEqual(childRowContent.length > 0, true, 'Child course row is empty.');
+
         // Compare the faculty information and make sure they are equal
         let areRowsEqual = true;
         for (let i = 0; i < parentRowContent.length; i++) {
@@ -176,7 +179,7 @@ describe('End-to-end Multi Year Plan tests', function () {
             areRowsEqual = false;
           }
         }
-        strictEqual(areRowsEqual, true);
+        strictEqual(areRowsEqual, true, 'Parent and child rows do not have the same content.');
       });
     });
   });

--- a/tests/integration/e2e/MultiYearPlan.test.tsx
+++ b/tests/integration/e2e/MultiYearPlan.test.tsx
@@ -21,6 +21,7 @@ import {
   strictEqual,
 } from 'assert';
 import { SemesterModule } from 'server/semester/semester.module';
+import { FacultyCourseInstance } from 'server/courseInstance/facultycourseinstance.entity';
 import mockAdapter from '../../mocks/api/adapter';
 import { ConfigModule } from '../../../src/server/config/config.module';
 import { ConfigService } from '../../../src/server/config/config.service';
@@ -43,6 +44,7 @@ describe('End-to-end Multi Year Plan tests', function () {
   let testModule: TestingModule;
   let authStub: SinonStub;
   let courseRepository: Repository<Course>;
+  let fciRepository: Repository<FacultyCourseInstance>;
   const currentAcademicYear = 2019;
   let renderResult: RenderResult;
 
@@ -98,6 +100,9 @@ describe('End-to-end Multi Year Plan tests', function () {
     courseRepository = testModule.get(
       getRepositoryToken(Course)
     );
+    fciRepository = testModule.get(
+      getRepositoryToken(FacultyCourseInstance)
+    );
     const nestApp = await testModule
       .createNestApplication()
       .useGlobalPipes(new BadRequestExceptionPipe())
@@ -112,9 +117,13 @@ describe('End-to-end Multi Year Plan tests', function () {
   describe('Rendering Instructor Information', function () {
     let parentCourse: Course;
     let childCourse: Course;
+    let instructor: FacultyCourseInstance;
     beforeEach(async function () {
-      parentCourse = await courseRepository.findOne();
-      childCourse = await courseRepository.findOne({
+      instructor = await fciRepository.findOneOrFail({
+        relations: ['courseInstance', 'courseInstance.course'],
+      });
+      parentCourse = instructor.courseInstance.course;
+      childCourse = await courseRepository.findOneOrFail({
         where: {
           id: Not(parentCourse.id),
         },

--- a/tests/integration/e2e/SchedulePage.test.tsx
+++ b/tests/integration/e2e/SchedulePage.test.tsx
@@ -1,0 +1,199 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import React from 'react';
+import {
+  stub, SinonStub,
+} from 'sinon';
+import {
+  render,
+  RenderResult,
+  fireEvent,
+  wait,
+} from '@testing-library/react';
+import { TypeOrmModule, TypeOrmModuleOptions, getRepositoryToken } from '@nestjs/typeorm';
+import * as dummy from 'testData';
+import { SessionModule } from 'nestjs-session';
+import { MemoryRouter } from 'react-router-dom';
+import App from 'client/components/App';
+import request from 'client/api/request';
+import { Repository, Not } from 'typeorm';
+import { SemesterModule } from 'server/semester/semester.module';
+import { Meeting } from 'server/meeting/meeting.entity';
+import { dayEnumToString } from 'common/constants/day';
+import { PGTime } from 'common/utils/PGTime';
+import mockAdapter from '../../mocks/api/adapter';
+import { ConfigModule } from '../../../src/server/config/config.module';
+import { ConfigService } from '../../../src/server/config/config.service';
+import { AuthModule } from '../../../src/server/auth/auth.module';
+import { TestingStrategy } from '../../mocks/authentication/testing.strategy';
+import {
+  AUTH_MODE, TERM_PATTERN,
+} from '../../../src/common/constants';
+import { PopulationModule } from '../../mocks/database/population/population.module';
+import { CourseModule } from '../../../src/server/course/course.module';
+import { BadRequestExceptionPipe } from '../../../src/server/utils/BadRequestExceptionPipe';
+import { MetadataModule } from '../../../src/server/metadata/metadata.module';
+import { FacultyModule } from '../../../src/server/faculty/faculty.module';
+import { CourseInstanceModule } from '../../../src/server/courseInstance/courseInstance.module';
+import { UserController } from '../../../src/server/user/user.controller';
+import { LogModule } from '../../../src/server/log/log.module';
+
+describe('End-to-end Schedule Page tests', function () {
+  let testModule: TestingModule;
+  let authStub: SinonStub;
+  let meetingRepository: Repository<Meeting>;
+  const currentAcademicYear = 2019;
+  let renderResult: RenderResult;
+
+  beforeEach(async function () {
+    authStub = stub(TestingStrategy.prototype, 'login');
+    const fakeConfig = new ConfigService(this.database.connectionEnv);
+    // Stub out the academicYear getter to lock us to a known year. Otherwise,
+    // tests might fail in the future if our test data don't include that year.
+    stub(fakeConfig, 'academicYear').get(() => currentAcademicYear);
+    stub(fakeConfig, 'logLevel').get(() => 'error');
+    testModule = await Test.createTestingModule({
+      imports: [
+        SessionModule.forRoot({
+          session: {
+            secret: dummy.safeString,
+            resave: true,
+            saveUninitialized: true,
+          },
+        }),
+        ConfigModule,
+        LogModule,
+        TypeOrmModule.forRootAsync({
+          imports: [ConfigModule],
+          useFactory: (
+            config: ConfigService
+          ): TypeOrmModuleOptions => ({
+            ...config.dbOptions,
+            synchronize: true,
+            autoLoadEntities: true,
+            retryAttempts: 10,
+            retryDelay: 10000,
+          }),
+          inject: [ConfigService],
+        }),
+        AuthModule.register({
+          strategies: [TestingStrategy],
+          defaultStrategy: AUTH_MODE.TEST,
+        }),
+        PopulationModule,
+        CourseModule,
+        FacultyModule,
+        CourseInstanceModule,
+        MetadataModule,
+        SemesterModule,
+      ],
+      controllers: [
+        UserController,
+      ],
+    })
+      .overrideProvider(ConfigService)
+      .useValue(fakeConfig)
+      .compile();
+    meetingRepository = testModule.get(
+      getRepositoryToken(Meeting)
+    );
+    const nestApp = await testModule
+      .createNestApplication()
+      .useGlobalPipes(new BadRequestExceptionPipe())
+      .init();
+    const api = nestApp.getHttpServer();
+    request.defaults.adapter = mockAdapter(api);
+    authStub.resolves(dummy.adminUser);
+  });
+  afterEach(async function () {
+    return testModule.close();
+  });
+  describe('Rendering Schedule Information', function () {
+    let parentMeetings: Meeting[];
+    let childMeetings: Meeting[];
+    beforeEach(async function () {
+      parentMeetings = await meetingRepository.find({
+        relations: ['courseInstance', 'courseInstance.course', 'courseInstance.course.area', 'room', 'room.building'],
+        where: {
+          courseInstance: {
+            course: {
+              termPattern: TERM_PATTERN.BOTH,
+            },
+          },
+        },
+      });
+      const parentMeetingCourse = parentMeetings[0].courseInstance.course;
+      childMeetings = await meetingRepository.find({
+        relations: ['courseInstance', 'courseInstance.course', 'courseInstance.course.area', 'room', 'room.building'],
+        where: {
+          day: Not(parentMeetings[0].day),
+          courseInstance: {
+            course: {
+              id: Not(parentMeetingCourse.id),
+              area: {
+                name: Not(parentMeetingCourse.area.name),
+              },
+            },
+          },
+        },
+      });
+      renderResult = render(
+        <MemoryRouter initialEntries={['/course-admin']}>
+          <App />
+        </MemoryRouter>
+      );
+    });
+    context('when a course is a child of another', function () {
+      it('should display the meeting information of the parent course', async function () {
+        const testMeeting = parentMeetings[0];
+        const testParentCourse = testMeeting.courseInstance.course;
+        const testChildCourse = childMeetings[0].courseInstance.course;
+        await renderResult.findAllByText(testChildCourse.title);
+
+        // Before setting the child course's "Same As" value to the parent,
+        // we are filtering the Course Admin table by area, because there are
+        // courses with the same title and differing catalog numbers. When
+        // selecting the edit button, we want to make sure we are selecting
+        // the intended one.
+        const areaLabelText = 'The table will be filtered as selected in this area dropdown filter';
+        const areaFilter = renderResult
+          .getByLabelText(areaLabelText) as HTMLSelectElement;
+        fireEvent.change(areaFilter,
+          { target: { value: testChildCourse.area.name } });
+        const catalogText = 'The table will be filtered as characters are typed in this course filter field';
+        const catalogFilter = renderResult
+          .getByLabelText(catalogText) as HTMLInputElement;
+        fireEvent.change(catalogFilter,
+          { target: { value: `${testChildCourse.prefix} ${testChildCourse.number}` } });
+        // Open the child course modal to edit the "Same As" value
+        const editButton = await renderResult
+          .findByLabelText(`Edit course information for ${testChildCourse.title}`,
+            { exact: false });
+        fireEvent.click(editButton);
+        await renderResult.findByRole('dialog');
+        const sameAsSelect = renderResult.getByLabelText('Same As', { exact: false }) as HTMLSelectElement;
+        fireEvent.change(
+          sameAsSelect,
+          { target: { value: testParentCourse.id } }
+        );
+        const submitButton = renderResult.getByText('Submit');
+        fireEvent.click(submitButton);
+        await wait(() => !renderResult.queryByText('required fields', { exact: false }));
+
+        // Navigate to the schedule page and wait for the table to render
+        const scheduleTab = await renderResult.findByText('Schedule');
+        fireEvent.click(scheduleTab);
+        const parentCatalogNumber = `${testParentCourse.prefix} ${testParentCourse.number}`;
+        await renderResult.findAllByText(parentCatalogNumber, { exact: false });
+
+        // Make sure the child course displays the parent course's meeting information
+        const parentCourseDay = dayEnumToString(testMeeting.day);
+        const parentStartTime = PGTime.toDisplay(testMeeting.startTime);
+        const parentEndTime = PGTime.toDisplay(testMeeting.endTime);
+        const parentLocation = `${testMeeting.room.building.name} ${testMeeting.room.name}`;
+        const parentMeetingInfo = `${parentCourseDay}, ${parentStartTime} to ${parentEndTime} in ${parentLocation}`;
+        const childCourseInfo = `${testChildCourse.prefix} ${testChildCourse.number} on ${parentMeetingInfo}`;
+        await renderResult.findByText(childCourseInfo);
+      });
+    });
+  });
+});

--- a/tests/integration/e2e/SchedulePage.test.tsx
+++ b/tests/integration/e2e/SchedulePage.test.tsx
@@ -7,7 +7,7 @@ import {
   render,
   RenderResult,
   fireEvent,
-  wait,
+  waitForElementToBeRemoved,
 } from '@testing-library/react';
 import { TypeOrmModule, TypeOrmModuleOptions, getRepositoryToken } from '@nestjs/typeorm';
 import * as dummy from 'testData';
@@ -177,7 +177,7 @@ describe('End-to-end Schedule Page tests', function () {
         );
         const submitButton = renderResult.getByText('Submit');
         fireEvent.click(submitButton);
-        await wait(() => !renderResult.queryByText('required fields', { exact: false }));
+        await waitForElementToBeRemoved(() => renderResult.getByRole('dialog'));
 
         // Navigate to the schedule page and wait for the table to render
         const scheduleTab = await renderResult.findByText('Schedule');


### PR DESCRIPTION
This PR contains 3 migrations. It updates the server logic such that the Multi Year Plan table will show the instructors of the course's parent if there is one. It also updates the Schedule such that the meeting information (day, time, and room information) of the parent, if there is one, is displayed.

A separate PR will be opened to update the display of the Faculty table to show the same as relationship. 

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #642

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
