### PR TITLE
Feature/345 implement table scrolling while table headers stick

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "lodash.merge": "^4.6.2",
         "lodash.set": "^4.3.2",
         "loglevel": "^1.6.8",
-        "mark-one": "^0.5.2",
+        "mark-one": "^0.5.4",
         "morgan": "^1.10.0",
         "nestjs-redis": "^1.3.3",
         "nestjs-session": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10398,9 +10398,9 @@
       }
     },
     "node_modules/mark-one": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.5.2.tgz",
-      "integrity": "sha512-e40DM8WBmHdR/6sm6rKjb4x9GX9SYamC36FglSpVncE9nuovxkgHS8mwN0oIv0ZsDpQq9En3t3TUpWXAutKrUw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.5.4.tgz",
+      "integrity": "sha512-xPIOsEYrZnQCR9V/STUsiYpMgW/W7hM0DY8lGBHWLNzm1L0endyGavWknrPkHyYS1BusOGRE0cN5KDBPYApkww==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",
         "@openfonts/open-sans_all": "^1.43.0",
@@ -27296,9 +27296,9 @@
       }
     },
     "mark-one": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.5.2.tgz",
-      "integrity": "sha512-e40DM8WBmHdR/6sm6rKjb4x9GX9SYamC36FglSpVncE9nuovxkgHS8mwN0oIv0ZsDpQq9En3t3TUpWXAutKrUw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mark-one/-/mark-one-0.5.4.tgz",
+      "integrity": "sha512-xPIOsEYrZnQCR9V/STUsiYpMgW/W7hM0DY8lGBHWLNzm1L0endyGavWknrPkHyYS1BusOGRE0cN5KDBPYApkww==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",
         "@openfonts/open-sans_all": "^1.43.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.set": "^4.3.2",
     "loglevel": "^1.6.8",
-    "mark-one": "^0.5.2",
+    "mark-one": "^0.5.4",
     "morgan": "^1.10.0",
     "nestjs-redis": "^1.3.3",
     "nestjs-session": "^1.0.0",

--- a/src/client/components/pages/CourseAdmin.tsx
+++ b/src/client/components/pages/CourseAdmin.tsx
@@ -148,7 +148,7 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
       </VerticalSpace>
       <div className="course-admin-table">
         <Table>
-          <TableHead>
+          <TableHead isSticky>
             <TableRow isStriped>
               <TableHeadingCell scope="col">Area</TableHeadingCell>
               <TableHeadingCell scope="col">Course</TableHeadingCell>

--- a/src/client/components/pages/Courses/CourseInstanceTable.tsx
+++ b/src/client/components/pages/Courses/CourseInstanceTable.tsx
@@ -137,7 +137,7 @@ const CourseInstanceTable: FunctionComponent<CourseInstanceTableProps> = ({
       {(fallColumns.length > 0 && <colgroup span={fallColumns.length} />)}
       {(springColumns.length > 0 && <colgroup span={springColumns.length} />)}
       <colgroup span={metaColumns.length} />
-      <TableHead>
+      <TableHead isSticky>
         {/*
           * Our top level of headers should only show the two semesters in the
           * current academic year, with all other headers blanked. If no

--- a/src/client/components/pages/Faculty/FacultyScheduleTable.tsx
+++ b/src/client/components/pages/Faculty/FacultyScheduleTable.tsx
@@ -135,7 +135,7 @@ const FacultyScheduleTable: FunctionComponent<FacultyScheduleTableProps> = ({
       <colgroup>
         <col />
       </colgroup>
-      <TableHead>
+      <TableHead isSticky>
         <TableRow noHighlight>
           <TableHeadingSpacer colSpan={5} />
           <TableHeadingCell

--- a/src/client/components/pages/FacultyAdmin.tsx
+++ b/src/client/components/pages/FacultyAdmin.tsx
@@ -173,7 +173,7 @@ const FacultyAdmin: FunctionComponent = (): ReactElement => {
       </VerticalSpace>
       <div className="faculty-admin-table">
         <Table>
-          <TableHead>
+          <TableHead isSticky>
             <TableRow isStriped>
               <TableHeadingCell scope="col">Area</TableHeadingCell>
               <TableHeadingCell scope="col">HUID</TableHeadingCell>

--- a/src/client/components/pages/MultiYearPlan.tsx
+++ b/src/client/components/pages/MultiYearPlan.tsx
@@ -260,7 +260,7 @@ const MultiYearPlan: FunctionComponent = (): ReactElement => {
                 </InstructionalTextBox>
               )}
             <Table>
-              <TableHead>
+              <TableHead isSticky>
                 <TableRow isStriped>
                   <TableHeadingCell scope="col">Catalog Prefix</TableHeadingCell>
                   <TableHeadingCell scope="col">Catalog Number</TableHeadingCell>

--- a/src/client/components/pages/RoomAdmin/RoomAdmin.tsx
+++ b/src/client/components/pages/RoomAdmin/RoomAdmin.tsx
@@ -248,7 +248,7 @@ const RoomAdmin: FunctionComponent = (): ReactElement => {
           : (
             <div className="room-admin-table">
               <Table>
-                <TableHead>
+                <TableHead isSticky>
                   <TableRow isStriped>
                     <TableHeadingCell scope="col">Campus</TableHeadingCell>
                     <TableHeadingCell scope="col">Building</TableHeadingCell>


### PR DESCRIPTION
## Describe your changes
  Mark-one prop called 'isSticky' added to TableHead to make the table head position sticky. To make the information still visible on the top of the table, tableHead defaults to isSticky' prop when the table is scrolled.


## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [X] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [X] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #345 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
