### PR TITLE
Format production logs in syslog format

### DIFF
--- a/src/server/log/__tests__/log.service.test.ts
+++ b/src/server/log/__tests__/log.service.test.ts
@@ -9,7 +9,7 @@ import winston, { Logger } from 'winston';
 import * as dummy from 'testData';
 import { LogService, LABEL } from '../log.service';
 
-describe('Log Service', function () {
+describe.only('Log Service', function () {
   let logService: LogService;
   let winstonStub: Record<string, SinonStub>;
   const testClass = 'testClass';
@@ -61,11 +61,6 @@ describe('Log Service', function () {
         new RegExp(LOG_LEVEL.INFO.toUpperCase()).test(formatted),
         true
       );
-    });
-    it('Should wrap the log level in [] and add spaces to pad out to 10 chars', function () {
-      // length of the timestamp plus a space
-      const timestampEnd = timestamp.length + 1;
-      strictEqual(formatted.substr(timestampEnd, 10), '[INFO]    ');
     });
   });
   describe('error', function () {

--- a/src/server/log/__tests__/log.service.test.ts
+++ b/src/server/log/__tests__/log.service.test.ts
@@ -9,7 +9,7 @@ import winston, { Logger } from 'winston';
 import * as dummy from 'testData';
 import { LogService, LABEL } from '../log.service';
 
-describe.only('Log Service', function () {
+describe('Log Service', function () {
   let logService: LogService;
   let winstonStub: Record<string, SinonStub>;
   const testClass = 'testClass';

--- a/src/server/log/log.service.ts
+++ b/src/server/log/log.service.ts
@@ -56,22 +56,10 @@ export enum LABEL {
 }
 
 /**
- * Computes the longest log level to use in padding out the log messages
- * Defined outside the service since this should not change at runtime
- *
- */
-const widestLog = Math.max(
-  ...Object.values(LOG_LEVEL).map(
-    (lvl: string): number => lvl.length
-  )
-);
-
-/**
  * An injectable service that instantiates a Winston logger, and overwrites the
  * existing Nest logging methods with Winston's methods.
  *
 */
-
 @Injectable()
 class LogService extends NestLogger implements TypeORMLogger {
   /**
@@ -96,7 +84,9 @@ class LogService extends NestLogger implements TypeORMLogger {
     this.logger = winston.createLogger({
       level: config.logLevel,
       format: winston.format.combine(
-        winston.format.timestamp(),
+        winston.format.timestamp({
+          format: 'MMM DD HH:mm:ss',
+        }),
         winston.format.printf(logFormat)
       ),
       transports: [
@@ -110,8 +100,8 @@ class LogService extends NestLogger implements TypeORMLogger {
      * TIMESTAMP [LEVEL]    (LABEL) MESSAGE
    */
   public logFormat(info: WinstonInfo): string {
-    const fmtLevel = `[${info.level.toUpperCase()}]`.padEnd(widestLog + 2);
-    return `${info.timestamp} ${fmtLevel} (${info.label}) ${info.message}`;
+    const fmtLevel = info.level.toUpperCase();
+    return `${info.timestamp} ${fmtLevel} ${info.label} ${info.message}`;
   }
 
   /**

--- a/src/server/log/log.service.ts
+++ b/src/server/log/log.service.ts
@@ -7,7 +7,7 @@ import { Logger as TypeORMLogger } from 'typeorm';
 import winston, { Logger as WinstonLogger } from 'winston';
 import { ConfigService } from 'server/config/config.service';
 import { StreamOptions } from 'morgan';
-import { TYPEORM_LOG_LEVEL, LOG_LEVEL } from 'common/constants';
+import { TYPEORM_LOG_LEVEL } from 'common/constants';
 import util from 'util';
 
 /**


### PR DESCRIPTION
This PR updates the log service date format to produce logs in the format expected by splunk(sylog format). 


This means, that instead of logs like this:

```
2023-03-15T20:59:41.518Z [INFO]    (NestJS#RoutesResolver) UserController {/api/api/users}:
2023-03-15T20:59:41.519Z [INFO]    (NestJS#RouterExplorer) Mapped {/api/api/users/current, GET} route
2023-03-15T20:59:41.519Z [INFO]    (NestJS#RoutesResolver) HealthCheckController {/api/health-check}:
2023-03-15T20:59:41.520Z [INFO]    (NestJS#RouterExplorer) Mapped {/api/health-check, GET} route
2023-03-15T20:59:41.520Z [INFO]    (NestJS#RoutesResolver) AuthController {/api}:
2023-03-15T20:59:41.520Z [INFO]    (NestJS#RouterExplorer) Mapped {/api/login, GET} route
2023-03-15T20:59:41.520Z [INFO]    (NestJS#RouterExplorer) Mapped {/api/validate, GET} route
2023-03-15T20:59:41.520Z [INFO]    (NestJS#RouterExplorer) Mapped {/api/logout, GET} route
2023-03-15T20:59:41.520Z [INFO]    (NestJS#RoutesResolver) CourseController {/api/api/courses}:
2023-03-15T20:59:41.520Z [INFO]    (NestJS#RouterExplorer) Mapped {/api/api/courses, GET} route
```

The app will _now_ generate logs like this:

```
Mar 15 21:00:18 INFO NestJS#RoutesResolver UserController {/api/api/users}:
Mar 15 21:00:18 INFO NestJS#RouterExplorer Mapped {/api/api/users/current, GET} route
Mar 15 21:00:18 INFO NestJS#RoutesResolver HealthCheckController {/api/health-check}:
Mar 15 21:00:18 INFO NestJS#RouterExplorer Mapped {/api/health-check, GET} route
Mar 15 21:00:18 INFO NestJS#RoutesResolver AuthController {/api}:
Mar 15 21:00:18 INFO NestJS#RouterExplorer Mapped {/api/login, GET} route
Mar 15 21:00:18 INFO NestJS#RouterExplorer Mapped {/api/validate, GET} route
Mar 15 21:00:18 INFO NestJS#RouterExplorer Mapped {/api/logout, GET} route
Mar 15 21:00:18 INFO NestJS#RoutesResolver CourseController {/api/api/courses}:
Mar 15 21:00:18 INFO NestJS#RouterExplorer Mapped {/api/api/courses, GET} route
```

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #384 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
