### PR TITLE
Show "Check Availability" for all non-seas rooms

### DIFF
--- a/src/client/components/pages/Courses/RoomSelectionTable.tsx
+++ b/src/client/components/pages/Courses/RoomSelectionTable.tsx
@@ -65,8 +65,8 @@ const displayAvailability = (
   if (meetingTitles.length > 0) {
     return `No (${meetingTitles.join(', ')})`;
   }
-  if (campus === 'FAS') {
-    return 'Check FAS Availability';
+  if (campus === 'Non-SEAS') {
+    return 'Check Availability';
   }
   return 'Yes';
 };

--- a/src/client/components/pages/Courses/__tests__/RoomSelectionTable.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/RoomSelectionTable.test.tsx
@@ -357,9 +357,9 @@ describe('Room Selection Table', function () {
             />
           );
         });
-        it('Should show check FAS availability', function () {
+        it('Should show "Check Availability"', function () {
           const { queryByText } = renderResult;
-          ok(queryByText('Check FAS Availability'));
+          ok(queryByText('Check Availability'));
         });
         it('Should not disable the add button', function () {
           const { getByRole } = renderResult;

--- a/src/common/__tests__/data/locations.ts
+++ b/src/common/__tests__/data/locations.ts
@@ -42,23 +42,23 @@ export const freeRoom: RoomMeetingResponse = {
 };
 
 /**
- * A room response for an FAS room with no meetings booked
+ * A room response for an Non-SEAS room with no meetings booked
  */
 export const freeFASRoom: RoomMeetingResponse = {
   id: '7a1918d1-173c-4628-baac-cd6cf10a9b95',
   name: 'Science Center Auditorium C',
-  campus: 'FAS',
+  campus: 'Non-SEAS',
   capacity: 240,
   meetingTitles: [],
 };
 
 /**
- * A room response for an FAS room with meetings booked
+ * A room response for an Non-SEAS room with meetings booked
  */
 export const bookedFASRoom: RoomMeetingResponse = {
   id: '6b923cb4-0215-4fa6-b7cf-db2b0b456b45',
   name: 'William James Hall B101',
-  campus: 'FAS',
+  campus: 'Non-SEAS',
   capacity: 140,
   meetingTitles: ['ABCD Meeting'],
 };


### PR DESCRIPTION
Any rooms not managed by SEAS were assumed to be FAS. However, given the possible usage of HBS, Longwood etc. rooms in the future....adding a special case for each campus would quickly become unmanagable. Add to that the fact that HBS is _technically_ in Allston.

Therefore, any non-seas rooms are now part of a ficticious "Non-SEAS" campus in the campus table rather than creating special cases for each Harvard school. This still allows the room to be booked, but under the proviso of "We don't have any availability for this room, so you should double check with room book"

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #596 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->