### PR TITLE
Feature/640 add policy links to footer

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -23,11 +23,13 @@ import {
   PageBody,
   LoadSpinner,
   Footer,
+  ExternalLink,
 } from 'mark-one';
 import { getCurrentUser } from 'client/api';
 import { getMetadata } from 'client/api/metadata';
 import { User } from 'common/classes';
 import { MetadataResponse } from 'common/dto/metadata/MetadataResponse.dto';
+import styled from 'styled-components';
 import {
   Message,
   AppRouter,
@@ -76,6 +78,18 @@ const App: FunctionComponent = (): ReactElement => {
    * Tracks whether we're still fetching the user and metadata
    */
   const [isDataFetching, setDataFetching] = useState(true);
+
+  /**
+   * Policy links and items that will be rendered on the page footer
+   */
+  const FooterListItem = styled.div`
+  border-right: 1px solid black;
+  padding: 0 0.5rem;
+  font-size: 0.9em;
+  font-weight: 400;
+  display: 'flex';
+  listStyle: 'none';
+`;
 
   /**
    * Get the currently authenticated user from the server on launch.
@@ -139,6 +153,13 @@ const App: FunctionComponent = (): ReactElement => {
                         justify="center"
                       >
                         {appVersion}
+                        <FooterListItem>
+                          © 2023 President and Fellows of Harvard College
+                        </FooterListItem>
+                        <FooterListItem><ExternalLink href="https://seas.harvard.edu/office-diversity-inclusion-and-belonging/about-us" rel="nofollow">Diversity Mission</ExternalLink></FooterListItem>
+                        <FooterListItem><ExternalLink href="https://trademark.harvard.edu/pages/trademark-notice" rel="nofollow">Trademark Notice</ExternalLink></FooterListItem>
+                        <FooterListItem><ExternalLink href="https://accessibility.huit.harvard.edu/digital-accessibility-policy" rel="nofollow">Accessibility Policy</ExternalLink></FooterListItem>
+                        <FooterListItem><ExternalLink href="https://seas.harvard.edu/privacy-policy" rel="nofollow">Privacy Policy</ExternalLink></FooterListItem>
                       </Footer>
                     </>
                   )}

--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -80,15 +80,20 @@ const App: FunctionComponent = (): ReactElement => {
   const [isDataFetching, setDataFetching] = useState(true);
 
   /**
-   * Policy links and items that will be rendered on the page footer
+   * A custom footer component to render Policy links and items
    */
-  const FooterListItem = styled.div`
-  border-right: 1px solid black;
-  padding: 0 0.5rem;
-  font-size: 0.9em;
-  font-weight: 400;
-  display: 'flex';
-  listStyle: 'none';
+  const CustomFooter = styled(Footer)`
+  ul {
+    list-style: none;
+    display: flex;
+    li {
+      padding: 0 0.5rem;
+      border-right: 1px solid black;
+      &:last-of-type {
+        border: 0px;
+      }
+  }
+}
 `;
 
   /**
@@ -149,18 +154,20 @@ const App: FunctionComponent = (): ReactElement => {
                     <>
                       <AppHeader />
                       <AppRouter />
-                      <Footer
+                      <CustomFooter
                         justify="center"
                       >
                         {appVersion}
-                        <FooterListItem>
-                          © 2023 President and Fellows of Harvard College
-                        </FooterListItem>
-                        <FooterListItem><ExternalLink href="https://seas.harvard.edu/office-diversity-inclusion-and-belonging/about-us" rel="nofollow">Diversity Mission</ExternalLink></FooterListItem>
-                        <FooterListItem><ExternalLink href="https://trademark.harvard.edu/pages/trademark-notice" rel="nofollow">Trademark Notice</ExternalLink></FooterListItem>
-                        <FooterListItem><ExternalLink href="https://accessibility.huit.harvard.edu/digital-accessibility-policy" rel="nofollow">Accessibility Policy</ExternalLink></FooterListItem>
-                        <FooterListItem><ExternalLink href="https://seas.harvard.edu/privacy-policy" rel="nofollow">Privacy Policy</ExternalLink></FooterListItem>
-                      </Footer>
+                        <ul>
+                          <li>
+                            © 2023 President and Fellows of Harvard College
+                          </li>
+                          <li><ExternalLink href="https://seas.harvard.edu/office-diversity-inclusion-and-belonging/about-us" rel="nofollow">Diversity Mission</ExternalLink></li>
+                          <li><ExternalLink href="https://trademark.harvard.edu/pages/trademark-notice" rel="nofollow">Trademark Notice</ExternalLink></li>
+                          <li><ExternalLink href="https://accessibility.huit.harvard.edu/digital-accessibility-policy" rel="nofollow">Accessibility Policy</ExternalLink></li>
+                          <li><ExternalLink href="https://seas.harvard.edu/privacy-policy" rel="nofollow">Privacy Policy</ExternalLink></li>
+                        </ul>
+                      </CustomFooter>
                     </>
                   )}
                 <Message

--- a/src/client/components/pages/Courses/CoursesPage.tsx
+++ b/src/client/components/pages/Courses/CoursesPage.tsx
@@ -16,7 +16,6 @@ import {
   POSITION,
   VARIANT,
   Dropdown,
-  Footer,
 } from 'mark-one';
 import { MessageContext, MetadataContext } from 'client/context';
 import CourseInstanceResponseDTO from 'common/dto/courses/CourseInstanceResponse';
@@ -830,18 +829,6 @@ const CoursesPage: FunctionComponent = (): ReactElement => {
         }}
         onClose={closeEnrollmentModal}
       />
-      <tfoot style={{ insetBlockEnd: 0 }}>
-        <ul style={{
-          display: 'flex', listStyle: 'none', justifyContent: 'center', padding: '1em',
-        }}
-        >
-          <li>© 2023 President and Fellows of Harvard College</li>
-          <li style={{ color: 'black' }}><a href="https://seas.harvard.edu/office-diversity-inclusion-and-belonging/about-us" rel="nofollow">Diversity Mission</a></li>
-          <li><a href="https://trademark.harvard.edu/pages/trademark-notice" rel="nofollow">Trademark Notice</a></li>
-          <li><a href="https://accessibility.huit.harvard.edu/digital-accessibility-policy" rel="nofollow">Accessibility Policy</a></li>
-          <li><a href="https://seas.harvard.edu/privacy-policy" rel="nofollow">Privacy Policy</a></li>
-        </ul>
-      </tfoot>
     </div>
   );
 };

--- a/src/client/components/pages/Courses/CoursesPage.tsx
+++ b/src/client/components/pages/Courses/CoursesPage.tsx
@@ -16,6 +16,7 @@ import {
   POSITION,
   VARIANT,
   Dropdown,
+  Footer,
 } from 'mark-one';
 import { MessageContext, MetadataContext } from 'client/context';
 import CourseInstanceResponseDTO from 'common/dto/courses/CourseInstanceResponse';
@@ -829,6 +830,18 @@ const CoursesPage: FunctionComponent = (): ReactElement => {
         }}
         onClose={closeEnrollmentModal}
       />
+      <tfoot style={{ insetBlockEnd: 0 }}>
+        <ul style={{
+          display: 'flex', listStyle: 'none', justifyContent: 'center', padding: '1em',
+        }}
+        >
+          <li>© 2023 President and Fellows of Harvard College</li>
+          <li style={{ color: 'black' }}><a href="https://seas.harvard.edu/office-diversity-inclusion-and-belonging/about-us" rel="nofollow">Diversity Mission</a></li>
+          <li><a href="https://trademark.harvard.edu/pages/trademark-notice" rel="nofollow">Trademark Notice</a></li>
+          <li><a href="https://accessibility.huit.harvard.edu/digital-accessibility-policy" rel="nofollow">Accessibility Policy</a></li>
+          <li><a href="https://seas.harvard.edu/privacy-policy" rel="nofollow">Privacy Policy</a></li>
+        </ul>
+      </tfoot>
     </div>
   );
 };


### PR DESCRIPTION
## Describe your changes
 This PR adds items including policy links the footer on all course planner pages. A new styled component `FooterListItem` was created to adjust the style and render lists of policy links horizontally with in the `Footer` component.

referenced: [Vittorio's note](https://github.com/seas-computing/course-planner_ux/commit/7e30e0506067b645b668fa72c82a372f2e6d8ebb?diff=split)

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [X] I have run `eslint` on the code
- [X] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [X] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #640 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
