### PR TITLE
Update display of related courses in Faculty Schedule

### DIFF
--- a/src/client/components/pages/Faculty/FacultyScheduleTable.tsx
+++ b/src/client/components/pages/Faculty/FacultyScheduleTable.tsx
@@ -29,7 +29,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import {
   FacultyAbsence,
-  FacultyCourse,
   FacultyResponseDTO,
 } from 'common/dto/faculty/FacultyResponse.dto';
 import {
@@ -45,6 +44,7 @@ import {
 import { CellLayout } from 'client/components/general';
 import { MetadataContext } from 'client/context/MetadataContext';
 import { absenceToVariant } from '../utils/absenceToVariant';
+import { deduplicateCourses } from '../utils/deduplicateCourses';
 
 /**
  * Describes the semester specific filter(s)
@@ -100,28 +100,6 @@ interface FacultyScheduleTableProps {
  */
 const computeEditAbsenceButtonId = (faculty: FacultyResponseDTO, term: TERM):
 string => `editAbsence${faculty.id}${term}`;
-
-/**
- * Computes a list of unique courses to prevent duplicate courses from showing
- */
-const deduplicateCourses = (courses: FacultyCourse[]): string[] => {
-  const uniqueCourses: string[] = [];
-  courses.forEach((course) => {
-    if (uniqueCourses.indexOf(course.catalogNumber) === -1) {
-      uniqueCourses.push(course.catalogNumber);
-      // Only parse the sameAs value if there is one
-      if (course.sameAs !== '') {
-        const sameAsCourses = course.sameAs.split(', ');
-        sameAsCourses.forEach((sameAsCourse) => {
-          if (uniqueCourses.indexOf(sameAsCourse) === -1) {
-            uniqueCourses.push(sameAsCourse);
-          }
-        });
-      }
-    }
-  });
-  return uniqueCourses;
-};
 
 /**
  * Component representing the Faculty Schedules for a given academic year

--- a/src/client/components/pages/Faculty/FacultyScheduleTable.tsx
+++ b/src/client/components/pages/Faculty/FacultyScheduleTable.tsx
@@ -29,6 +29,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import {
   FacultyAbsence,
+  FacultyCourse,
   FacultyResponseDTO,
 } from 'common/dto/faculty/FacultyResponse.dto';
 import {
@@ -99,6 +100,28 @@ interface FacultyScheduleTableProps {
  */
 const computeEditAbsenceButtonId = (faculty: FacultyResponseDTO, term: TERM):
 string => `editAbsence${faculty.id}${term}`;
+
+/**
+ * Computes a list of unique courses to prevent duplicate courses from showing
+ */
+const deduplicateCourses = (courses: FacultyCourse[]): string[] => {
+  const uniqueCourses: string[] = [];
+  courses.forEach((course) => {
+    if (uniqueCourses.indexOf(course.catalogNumber) === -1) {
+      uniqueCourses.push(course.catalogNumber);
+      // Only parse the sameAs value if there is one
+      if (course.sameAs !== '') {
+        const sameAsCourses = course.sameAs.split(', ');
+        sameAsCourses.forEach((sameAsCourse) => {
+          if (uniqueCourses.indexOf(sameAsCourse) === -1) {
+            uniqueCourses.push(sameAsCourse);
+          }
+        });
+      }
+    }
+  });
+  return uniqueCourses;
+};
 
 /**
  * Component representing the Faculty Schedules for a given academic year
@@ -340,11 +363,12 @@ const FacultyScheduleTable: FunctionComponent<FacultyScheduleTableProps> = ({
               </CellLayout>
             </TableCell>
             <TableCell variant={absenceToVariant(faculty.fall.absence)}>
-              {faculty.fall.courses.map((course): ReactElement => (
-                <div key={course.id}>
-                  {course.catalogNumber}
-                </div>
-              ))}
+              {deduplicateCourses(faculty.fall.courses)
+                .map((course): ReactElement => (
+                  <div key={course}>
+                    {course}
+                  </div>
+                ))}
             </TableCell>
             <TableCell
               variant={absenceToVariant(faculty.spring.absence)}
@@ -385,11 +409,12 @@ const FacultyScheduleTable: FunctionComponent<FacultyScheduleTableProps> = ({
               </CellLayout>
             </TableCell>
             <TableCell variant={absenceToVariant(faculty.spring.absence)}>
-              {faculty.spring.courses.map((course): ReactElement => (
-                <div key={course.id}>
-                  {course.catalogNumber}
-                </div>
-              ))}
+              {deduplicateCourses(faculty.spring.courses)
+                .map((course): ReactElement => (
+                  <div key={course}>
+                    {course}
+                  </div>
+                ))}
             </TableCell>
           </TableRow>
         ))}

--- a/src/client/components/pages/Faculty/__tests__/FacultyTable.test.tsx
+++ b/src/client/components/pages/Faculty/__tests__/FacultyTable.test.tsx
@@ -34,6 +34,12 @@ import FacultySchedule from '../FacultyPage';
 import FacultyScheduleTable, { FacultyFilterState } from '../FacultyScheduleTable';
 
 /**
+ * Helper function to convert sameAs string to the expected format in the
+ * table cell.
+ */
+const formatSameAs = (sameAs: string): string => sameAs.replace(', ', '');
+
+/**
  * Helper function used to compare table row contents with faculty schedule data
  */
 const assertRowMatchesResponse = function (
@@ -60,13 +66,13 @@ const assertRowMatchesResponse = function (
     response.fall.absence.type
   ));
   strictEqual(fallCourses, response.fall.courses
-    .map((course) => course.catalogNumber)
+    .map((course) => course.catalogNumber.concat(formatSameAs(course.sameAs)))
     .join(''));
   strictEqual(springAbsence, absenceEnumToTitleCase(
     response.spring.absence.type
   ));
   strictEqual(springCourses, response.spring.courses
-    .map((course) => course.catalogNumber)
+    .map((course) => course.catalogNumber.concat(formatSameAs(course.sameAs)))
     .join(''));
 };
 

--- a/src/client/components/pages/utils/__tests__/deduplicateCourses.test.tsx
+++ b/src/client/components/pages/utils/__tests__/deduplicateCourses.test.tsx
@@ -1,0 +1,22 @@
+import { strictEqual } from 'assert';
+import { FacultyCourse } from 'common/dto/faculty/FacultyResponse.dto';
+import { appliedMathFacultyScheduleResponse, computerScienceFacultyScheduleResponse } from 'common/__tests__/data/faculty';
+import { deduplicateCourses } from '../deduplicateCourses';
+
+describe('deduplicateCourses helper function', function () {
+  const updatedCSResponse = computerScienceFacultyScheduleResponse;
+  // Edit one test faculty course array such that the sameAs is the value of
+  // another test faculty course.
+  updatedCSResponse.fall.courses[0].sameAs = appliedMathFacultyScheduleResponse
+    .fall.courses[0].catalogNumber;
+  // Merge the two arrays into one array of faculty courses
+  const testCourses: FacultyCourse[] = appliedMathFacultyScheduleResponse
+    .fall.courses.concat(
+      updatedCSResponse.fall.courses
+    );
+  it('returns an array of unique courses', function () {
+    const result = deduplicateCourses(testCourses);
+    const resultSet = [...new Set(result)];
+    strictEqual(result.length, resultSet.length);
+  });
+});

--- a/src/client/components/pages/utils/deduplicateCourses.ts
+++ b/src/client/components/pages/utils/deduplicateCourses.ts
@@ -1,0 +1,23 @@
+import { FacultyCourse } from 'common/dto/faculty/FacultyResponse.dto';
+
+/**
+ * Computes a list of unique courses to prevent duplicate courses from showing
+ */
+export const deduplicateCourses = (courses: FacultyCourse[]): string[] => {
+  const uniqueCourses: string[] = [];
+  courses.forEach((course) => {
+    if (uniqueCourses.indexOf(course.catalogNumber) === -1) {
+      uniqueCourses.push(course.catalogNumber);
+      // Only parse the sameAs value if there is one
+      if (course.sameAs !== '') {
+        const sameAsCourses = course.sameAs.split(', ');
+        sameAsCourses.forEach((sameAsCourse) => {
+          if (uniqueCourses.indexOf(sameAsCourse) === -1) {
+            uniqueCourses.push(sameAsCourse);
+          }
+        });
+      }
+    }
+  });
+  return uniqueCourses;
+};

--- a/src/common/__tests__/data/faculty.ts
+++ b/src/common/__tests__/data/faculty.ts
@@ -168,10 +168,12 @@ export const appliedMathFacultyScheduleResponse: FacultyResponseDTO = {
       {
         id: '37b66373-5000-43f2-9c14-8c2426273785',
         catalogNumber: 'AM 10',
+        sameAs: 'BE 100',
       },
       {
         id: '6cfaf5af-d2bc-4959-81cc-9f87bf38f9d3',
         catalogNumber: 'AM 20',
+        sameAs: '',
       },
     ],
     absence: {
@@ -186,6 +188,7 @@ export const appliedMathFacultyScheduleResponse: FacultyResponseDTO = {
       {
         id: '37b66373-5000-43f2-9c14-8c2426273785',
         catalogNumber: 'AM 10',
+        sameAs: 'BE 100',
       },
     ],
     absence: {
@@ -215,14 +218,17 @@ FacultyResponseDTO = {
       {
         id: '22225da5-5213-4787-b819-955f554eca4e',
         catalogNumber: 'EE 100',
+        sameAs: '',
       },
       {
         id: '05d04a88-8db2-46fe-8b87-aa70244ad655',
         catalogNumber: 'EE 20',
+        sameAs: '',
       },
       {
         id: 'bbc7492a-71b2-489b-a9ec-a0a052c4f5c8',
         catalogNumber: 'EE 210',
+        sameAs: '',
       },
     ],
     absence: {
@@ -237,18 +243,22 @@ FacultyResponseDTO = {
       {
         id: '441c517f-bc48-46e3-86c2-4949d1908c5d',
         catalogNumber: 'EE 204',
+        sameAs: '',
       },
       {
         id: '73d1ee13-8b05-46d9-86fc-9e86442f94bd',
         catalogNumber: 'EE 130',
+        sameAs: '',
       },
       {
         id: 'bbc7492a-71b2-489b-a9ec-a0a052c4f5c8',
         catalogNumber: 'EE 210',
+        sameAs: '',
       },
       {
         id: 'c6d3e613-fc0e-4ad4-91d3-7396dbb364f8',
         catalogNumber: 'EE 300',
+        sameAs: '',
       },
     ],
     absence: {
@@ -278,6 +288,7 @@ FacultyResponseDTO = {
       {
         id: '92abefb7-d0b3-4ec0-b4a4-9050867aa927',
         catalogNumber: 'CS 50',
+        sameAs: '',
       },
     ],
     absence: {
@@ -292,6 +303,7 @@ FacultyResponseDTO = {
       {
         id: 'bbb0d395-3176-4752-b08d-1af1e20d1c21',
         catalogNumber: 'CS 226',
+        sameAs: '',
       },
     ],
     absence: {
@@ -320,6 +332,7 @@ export const notActiveACSFacultyScheduleResponse: FacultyResponseDTO = {
       {
         id: 'bbc7492a-5fc2-40b3-9c8d-a0a052c4f5c8',
         catalogNumber: 'ACS 21',
+        sameAs: '',
       },
     ],
     absence: {
@@ -334,6 +347,7 @@ export const notActiveACSFacultyScheduleResponse: FacultyResponseDTO = {
       {
         id: 'caa6382b-54c5-484f-bf6c-a0a052c4f5c8',
         catalogNumber: 'ACS 33',
+        sameAs: '',
       },
     ],
     absence: {
@@ -362,6 +376,7 @@ export const partiallyActiveAMFacultyScheduleResponse: FacultyResponseDTO = {
       {
         id: 'bbc7492a-5fc2-40b3-9c8d-a0a052c4f5c8',
         catalogNumber: 'AM 45',
+        sameAs: 'CS 107, BE 102',
       },
     ],
     absence: {
@@ -376,6 +391,7 @@ export const partiallyActiveAMFacultyScheduleResponse: FacultyResponseDTO = {
       {
         id: 'caa6382b-54c5-484f-bf6c-a0a052c4f5c8',
         catalogNumber: 'AM 23',
+        sameAs: '',
       },
     ],
     absence: {
@@ -404,10 +420,12 @@ export const newAreaFacultyScheduleResponse: FacultyResponseDTO = {
       {
         id: '37b66373-5000-43f2-9c14-8c2426273785',
         catalogNumber: 'NA 100',
+        sameAs: '',
       },
       {
         id: '6cfaf5af-d2bc-4959-81cc-9f87bf38f9d3',
         catalogNumber: 'NA 210',
+        sameAs: '',
       },
     ],
     absence: {
@@ -422,6 +440,7 @@ export const newAreaFacultyScheduleResponse: FacultyResponseDTO = {
       {
         id: '37b66373-5000-43f2-9c14-8c2426273785',
         catalogNumber: 'NA 310',
+        sameAs: '',
       },
     ],
     absence: {

--- a/src/common/dto/faculty/FacultyResponse.dto.ts
+++ b/src/common/dto/faculty/FacultyResponse.dto.ts
@@ -13,6 +13,12 @@ export abstract class FacultyCourse {
     example: 'CS 50',
   })
   public catalogNumber: string;
+
+  @ApiProperty({
+    type: 'string',
+    example: 'AC 209A, CS 109A',
+  })
+  public sameAs: string;
 }
 
 export abstract class FacultyAbsence {

--- a/src/server/faculty/FacultyScheduleCourseView.entity.ts
+++ b/src/server/faculty/FacultyScheduleCourseView.entity.ts
@@ -16,9 +16,39 @@ import { Course } from 'server/course/course.entity';
     .addSelect('ci."semesterId"', 'semesterId')
     .addSelect('ci."courseId"', 'id')
     .addSelect("CONCAT_WS(' ', c.prefix, c.number)", 'catalogNumber')
+    .addSelect(`
+      CASE
+        -- 1. A course with children won't have a parent or siblings
+        WHEN count("childCourses".id) > 0
+          THEN STRING_AGG(CONCAT_WS(' ', "childCourses".prefix, "childCourses".number), ', ')
+        -- 2. A course with siblings must have a parent AND cannot have children
+        WHEN count("siblingCourses".id) > 0
+          THEN CONCAT_WS(
+            ', ',
+            CONCAT_WS(' ', "parentCourse".prefix, "parentCourse".number),
+            STRING_AGG(CONCAT_WS(' ', "siblingCourses".prefix, "siblingCourses".number), ', ')
+          )
+        -- 3. A course with a parent but no siblings cannot have children
+        WHEN c."sameAsId" IS NOT NULL
+          THEN CONCAT_WS(' ', "parentCourse".prefix, "parentCourse".number)
+        -- 4. Default to empty string
+        ELSE ''
+      END`, 'sameAs')
     .from(FacultyCourseInstance, 'fci')
     .leftJoin(CourseInstance, 'ci', 'ci.id = fci."courseInstanceId"')
-    .leftJoin(Course, 'c', 'ci."courseId" = c.id'),
+    .leftJoin(Course, 'c', 'ci."courseId" = c.id')
+    .leftJoin(Course, 'parentCourse', '"parentCourse"."id" = c."sameAsId"')
+    .leftJoin(Course, 'childCourses', '"childCourses"."sameAsId" = c.id')
+    .leftJoin(Course, 'siblingCourses', '"siblingCourses"."sameAsId" = c."sameAsId" AND "siblingCourses".id <> c.id')
+    .groupBy('fci."courseInstanceId"')
+    .addGroupBy('fci."facultyId"')
+    .addGroupBy('ci."semesterId"')
+    .addGroupBy('ci."courseId"')
+    .addGroupBy('c.prefix')
+    .addGroupBy('c.number')
+    .addGroupBy('c."sameAsId"')
+    .addGroupBy('"parentCourse".prefix')
+    .addGroupBy('"parentCourse".number'),
 })
 /**
  * Represents a course within [[FacultyScheduleSemesterView]]
@@ -51,4 +81,12 @@ export class FacultyScheduleCourseView {
    */
   @ViewColumn()
   public catalogNumber: string;
+
+  /**
+   * From [[Course]]
+   * A free text field for admin staff to record any other courses that this
+   * course is the same as
+   */
+  @ViewColumn()
+  public sameAs: string;
 }

--- a/src/server/migrations/1679024560355-AddSameAsToFacultyScheduleCourseView.ts
+++ b/src/server/migrations/1679024560355-AddSameAsToFacultyScheduleCourseView.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * This migration updates the FacultyScheduleCourseView to add a sameAs column.
+ * The value, if it exists, would show the course's children if the course is a
+ * parent, or it would show the course's parent and siblings, if any.
+ */
+export class AddSameAsToFacultyScheduleCourseView1679024560355
+implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'FacultyScheduleCourseView']);
+    await queryRunner.query('DROP VIEW "FacultyScheduleCourseView"');
+    await queryRunner.query(`CREATE VIEW "FacultyScheduleCourseView" AS SELECT fci."courseInstanceId" AS "courseInstanceId", fci."facultyId" AS "facultyId", ci."semesterId" AS "semesterId", ci."courseId" AS "id", CONCAT_WS(' ', "c"."prefix", "c"."number") AS "catalogNumber", 
+      CASE
+        -- 1. A course with children won't have a parent or siblings
+        WHEN count("childCourses".id) > 0
+          THEN STRING_AGG(CONCAT_WS(' ', "childCourses".prefix, "childCourses".number), ', ')
+        -- 2. A course with siblings must have a parent AND cannot have children
+        WHEN count("siblingCourses".id) > 0
+          THEN CONCAT_WS(
+            ', ',
+            CONCAT_WS(' ', "parentCourse".prefix, "parentCourse".number),
+            STRING_AGG(CONCAT_WS(' ', "siblingCourses".prefix, "siblingCourses".number), ', ')
+          )
+        -- 3. A course with a parent but no siblings cannot have children
+        WHEN c."sameAsId" IS NOT NULL
+          THEN CONCAT_WS(' ', "parentCourse".prefix, "parentCourse".number)
+        -- 4. Default to empty string
+        ELSE ''
+      END AS "sameAs" FROM "faculty_course_instances_course_instance" "fci" LEFT JOIN "course_instance" "ci" ON "ci"."id" = fci."courseInstanceId"  LEFT JOIN "course" "c" ON ci."courseId" = "c"."id"  LEFT JOIN "course" "parentCourse" ON "parentCourse"."id" = c."sameAsId"  LEFT JOIN "course" "childCourses" ON "childCourses"."sameAsId" = "c"."id"  LEFT JOIN "course" "siblingCourses" ON "siblingCourses"."sameAsId" = c."sameAsId" AND "siblingCourses".id <> "c"."id" GROUP BY fci."courseInstanceId", fci."facultyId", ci."semesterId", ci."courseId", "c"."prefix", "c"."number", c."sameAsId", "parentCourse".prefix, "parentCourse".number`);
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'FacultyScheduleCourseView', "SELECT fci.\"courseInstanceId\" AS \"courseInstanceId\", fci.\"facultyId\" AS \"facultyId\", ci.\"semesterId\" AS \"semesterId\", ci.\"courseId\" AS \"id\", CONCAT_WS(' ', \"c\".\"prefix\", \"c\".\"number\") AS \"catalogNumber\", \n      CASE\n        -- 1. A course with children won't have a parent or siblings\n        WHEN count(\"childCourses\".id) > 0\n          THEN STRING_AGG(CONCAT_WS(' ', \"childCourses\".prefix, \"childCourses\".number), ', ')\n        -- 2. A course with siblings must have a parent AND cannot have children\n        WHEN count(\"siblingCourses\".id) > 0\n          THEN CONCAT_WS(\n            ', ',\n            CONCAT_WS(' ', \"parentCourse\".prefix, \"parentCourse\".number),\n            STRING_AGG(CONCAT_WS(' ', \"siblingCourses\".prefix, \"siblingCourses\".number), ', ')\n          )\n        -- 3. A course with a parent but no siblings cannot have children\n        WHEN c.\"sameAsId\" IS NOT NULL\n          THEN CONCAT_WS(' ', \"parentCourse\".prefix, \"parentCourse\".number)\n        -- 4. Default to empty string\n        ELSE ''\n      END AS \"sameAs\" FROM \"faculty_course_instances_course_instance\" \"fci\" LEFT JOIN \"course_instance\" \"ci\" ON \"ci\".\"id\" = fci.\"courseInstanceId\"  LEFT JOIN \"course\" \"c\" ON ci.\"courseId\" = \"c\".\"id\"  LEFT JOIN \"course\" \"parentCourse\" ON \"parentCourse\".\"id\" = c.\"sameAsId\"  LEFT JOIN \"course\" \"childCourses\" ON \"childCourses\".\"sameAsId\" = \"c\".\"id\"  LEFT JOIN \"course\" \"siblingCourses\" ON \"siblingCourses\".\"sameAsId\" = c.\"sameAsId\" AND \"siblingCourses\".id <> \"c\".\"id\" GROUP BY fci.\"courseInstanceId\", fci.\"facultyId\", ci.\"semesterId\", ci.\"courseId\", \"c\".\"prefix\", \"c\".\"number\", c.\"sameAsId\", \"parentCourse\".prefix, \"parentCourse\".number"]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "schema" = $2 AND "name" = $3', ['VIEW', 'public', 'FacultyScheduleCourseView']);
+    await queryRunner.query('DROP VIEW "FacultyScheduleCourseView"');
+    await queryRunner.query('CREATE VIEW "FacultyScheduleCourseView" AS SELECT fci."courseInstanceId" AS "courseInstanceId", fci."facultyId" AS "facultyId", ci."semesterId" AS "semesterId", ci."courseId" AS "id", CONCAT_WS(\' \', "c"."prefix", "c"."number") AS "catalogNumber" FROM "faculty_course_instances_course_instance" "fci" LEFT JOIN "course_instance" "ci" ON "ci"."id" = fci."courseInstanceId"  LEFT JOIN "course" "c" ON ci."courseId" = "c"."id"');
+    await queryRunner.query('INSERT INTO "typeorm_metadata"("type", "schema", "name", "value") VALUES ($1, $2, $3, $4)', ['VIEW', 'public', 'FacultyScheduleCourseView', "SELECT fci.\"courseInstanceId\" AS \"courseInstanceId\", fci.\"facultyId\" AS \"facultyId\", ci.\"semesterId\" AS \"semesterId\", ci.\"courseId\" AS \"id\", CONCAT_WS(' ', \"c\".\"prefix\", \"c\".\"number\") AS \"catalogNumber\" FROM \"faculty_course_instances_course_instance\" \"fci\" LEFT JOIN \"course_instance\" \"ci\" ON \"ci\".\"id\" = fci.\"courseInstanceId\"  LEFT JOIN \"course\" \"c\" ON ci.\"courseId\" = \"c\".\"id\""]);
+  }
+}

--- a/tests/integration/e2e/FacultySchedule.test.tsx
+++ b/tests/integration/e2e/FacultySchedule.test.tsx
@@ -1,0 +1,214 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import React from 'react';
+import {
+  stub, SinonStub,
+} from 'sinon';
+import {
+  render,
+  RenderResult,
+  fireEvent,
+  within,
+} from '@testing-library/react';
+import { TypeOrmModule, TypeOrmModuleOptions, getRepositoryToken } from '@nestjs/typeorm';
+import * as dummy from 'testData';
+import { SessionModule } from 'nestjs-session';
+import { MemoryRouter } from 'react-router-dom';
+import App from 'client/components/App';
+import request from 'client/api/request';
+import { Repository, Not, IsNull } from 'typeorm';
+import { SemesterModule } from 'server/semester/semester.module';
+import { Course } from 'server/course/course.entity';
+import { FacultyCourseInstance } from 'server/courseInstance/facultycourseinstance.entity';
+import { Faculty } from 'server/faculty/faculty.entity';
+import { strictEqual } from 'assert';
+import mockAdapter from '../../mocks/api/adapter';
+import { ConfigModule } from '../../../src/server/config/config.module';
+import { ConfigService } from '../../../src/server/config/config.service';
+import { AuthModule } from '../../../src/server/auth/auth.module';
+import { TestingStrategy } from '../../mocks/authentication/testing.strategy';
+import {
+  AUTH_MODE, TERM_PATTERN,
+} from '../../../src/common/constants';
+import { PopulationModule } from '../../mocks/database/population/population.module';
+import { CourseModule } from '../../../src/server/course/course.module';
+import { BadRequestExceptionPipe } from '../../../src/server/utils/BadRequestExceptionPipe';
+import { MetadataModule } from '../../../src/server/metadata/metadata.module';
+import { FacultyModule } from '../../../src/server/faculty/faculty.module';
+import { CourseInstanceModule } from '../../../src/server/courseInstance/courseInstance.module';
+import { UserController } from '../../../src/server/user/user.controller';
+import { LogModule } from '../../../src/server/log/log.module';
+
+describe('End-to-end Faculty Schedule Page', function () {
+  let testModule: TestingModule;
+  let authStub: SinonStub;
+  let courseRepository: Repository<Course>;
+  let fciRepository: Repository<FacultyCourseInstance>;
+  const currentAcademicYear = 2019;
+  let renderResult: RenderResult;
+
+  beforeEach(async function () {
+    authStub = stub(TestingStrategy.prototype, 'login');
+    const fakeConfig = new ConfigService(this.database.connectionEnv);
+    // Stub out the academicYear getter to lock us to a known year. Otherwise,
+    // tests might fail in the future if our test data don't include that year.
+    stub(fakeConfig, 'academicYear').get(() => currentAcademicYear);
+    stub(fakeConfig, 'logLevel').get(() => 'error');
+    testModule = await Test.createTestingModule({
+      imports: [
+        SessionModule.forRoot({
+          session: {
+            secret: dummy.safeString,
+            resave: true,
+            saveUninitialized: true,
+          },
+        }),
+        ConfigModule,
+        LogModule,
+        TypeOrmModule.forRootAsync({
+          imports: [ConfigModule],
+          useFactory: (
+            config: ConfigService
+          ): TypeOrmModuleOptions => ({
+            ...config.dbOptions,
+            synchronize: true,
+            autoLoadEntities: true,
+            retryAttempts: 10,
+            retryDelay: 10000,
+          }),
+          inject: [ConfigService],
+        }),
+        AuthModule.register({
+          strategies: [TestingStrategy],
+          defaultStrategy: AUTH_MODE.TEST,
+        }),
+        PopulationModule,
+        CourseModule,
+        FacultyModule,
+        CourseInstanceModule,
+        MetadataModule,
+        SemesterModule,
+      ],
+      controllers: [
+        UserController,
+      ],
+    })
+      .overrideProvider(ConfigService)
+      .useValue(fakeConfig)
+      .compile();
+    courseRepository = testModule.get(
+      getRepositoryToken(Course)
+    );
+    fciRepository = testModule.get(
+      getRepositoryToken(FacultyCourseInstance)
+    );
+    const nestApp = await testModule
+      .createNestApplication()
+      .useGlobalPipes(new BadRequestExceptionPipe())
+      .init();
+    const api = nestApp.getHttpServer();
+    request.defaults.adapter = mockAdapter(api);
+    authStub.resolves(dummy.adminUser);
+  });
+  afterEach(async function () {
+    return testModule.close();
+  });
+  describe('Rendering Schedule Information', function () {
+    let testFacultyCourseInstances: FacultyCourseInstance[];
+    let courseWithSameAs: Course;
+    let associatedCourses: string[];
+    let associatedFaculty: Faculty[];
+    beforeEach(async function () {
+      courseWithSameAs = await courseRepository.findOneOrFail({
+        relations: ['sameAs'],
+        where: {
+          sameAs: Not(IsNull()),
+        },
+      });
+      const parentCourse = courseWithSameAs.sameAs;
+      const coursesWithCommonSameAs = await courseRepository.find({
+        relations: ['sameAs'],
+        where: {
+          sameAs: {
+            title: parentCourse.title,
+            prefix: parentCourse.prefix,
+            number: parentCourse.number,
+          },
+        },
+      });
+      const childCourses = coursesWithCommonSameAs.map((course) => `${course.prefix} ${course.number}`);
+
+      // Create a list of all of the associated courses
+      associatedCourses = childCourses.concat(`${parentCourse.prefix} ${parentCourse.number}`);
+
+      testFacultyCourseInstances = await fciRepository.find({
+        relations: ['courseInstance', 'courseInstance.course', 'courseInstance.course.area', 'courseInstance.semester', 'faculty'],
+        where: {
+          courseInstance: {
+            course: {
+              prefix: parentCourse.prefix,
+              number: parentCourse.number,
+            },
+            semester: {
+              academicYear: currentAcademicYear,
+            },
+          },
+        },
+      });
+
+      // Get all of the faculty related to the associated courses
+      associatedFaculty = testFacultyCourseInstances
+        .map((instance) => instance.faculty);
+
+      renderResult = render(
+        <MemoryRouter initialEntries={['/faculty']}>
+          <App />
+        </MemoryRouter>
+      );
+    });
+    context('when a course has a sameAs relationship with another', function () {
+      it('should display the related courses for that faculty entry', async function () {
+        await renderResult.findAllByText(associatedCourses[0]);
+
+        // Filter the rows by the associated faculty
+        const rows = renderResult.getAllByRole('row');
+        const utils = within(rows[2]);
+        const lastNameField = utils.queryByLabelText('Change to filter the faculty list by last name');
+        const firstNameField = utils.queryByLabelText('Change to filter the faculty list by first name');
+
+        // Check that for each of the faculty rows that the appropriate course
+        // information is displayed.
+        associatedFaculty.forEach((faculty) => {
+          fireEvent.change(lastNameField,
+            { target: { value: faculty.lastName } });
+          fireEvent.change(firstNameField,
+            { target: { value: faculty.firstName } });
+
+          // Check the content of the faculty row
+          const parentRow = Array.from(renderResult.getAllByRole('row'))[3] as HTMLTableRowElement;
+          const parentRowContent = (Array.from(parentRow.cells)
+            .map((cell) => cell.textContent));
+
+          // Make sure for that the term that the tested course occurs in that
+          // the associated "same as" courses are displayed.
+          const courseTerm = courseWithSameAs.termPattern;
+          if (courseTerm === TERM_PATTERN.FALL) {
+            associatedCourses.forEach((course) => {
+              // An index of 6 corresponds to the fall courses column
+              strictEqual(parentRowContent[6].includes(course), true, `${course} was expected in the cell but was not found`);
+            });
+          } else if (courseTerm === TERM_PATTERN.SPRING) {
+            associatedCourses.forEach((course) => {
+              // An index of 8 corresponds to the spring courses column
+              strictEqual(parentRowContent[8].includes(course), true, `${course} was expected in the cell but was not found`);
+            });
+          } else { // When the term pattern is TERM_PATTERN.BOTH
+            associatedCourses.forEach((course) => {
+              strictEqual(parentRowContent[6].includes(course), true, `${course} was expected in the cell but was not found`);
+              strictEqual(parentRowContent[8].includes(course), true, `${course} was expected in the cell but was not found`);
+            });
+          }
+        });
+      });
+    });
+  });
+});

--- a/tests/integration/e2e/SchedulePage.test.tsx
+++ b/tests/integration/e2e/SchedulePage.test.tsx
@@ -193,7 +193,7 @@ describe('End-to-end Schedule Page tests', function () {
         const parentMeetingInfo = `${parentCourseDay}, ${parentStartTime} to ${parentEndTime} in ${parentLocation}`;
         const childCourseInfo = `${testChildCourse.prefix} ${testChildCourse.number} on ${parentMeetingInfo}`;
         await renderResult.findByText(childCourseInfo);
-      });
+      }).timeout(120000);
     });
   });
 });


### PR DESCRIPTION
This PR updates the display of the Faculty Schedule to include the courses that are related via the "same as" relationship set in the `Course` entity. This is considered a breaking change, because it includes a migration to add the `sameAs` column to the `ScheduleBlockView` so that we can get access to this relationship.  

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #642

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
