### PR TITLE
Feature/656 course report add same as field to spreadsheet

### DIFF
--- a/src/client/api/reports.ts
+++ b/src/client/api/reports.ts
@@ -71,6 +71,7 @@ export const getReport = async (
     reportURL,
     { credentials: 'include' }
   );
+  console.log(response)
   return downloadAttachment(response);
 };
 

--- a/src/client/api/reports.ts
+++ b/src/client/api/reports.ts
@@ -71,7 +71,6 @@ export const getReport = async (
     reportURL,
     { credentials: 'include' }
   );
-  console.log(response)
   return downloadAttachment(response);
 };
 

--- a/src/server/courseInstance/courseInstance.service.ts
+++ b/src/server/courseInstance/courseInstance.service.ts
@@ -142,8 +142,6 @@ export class CourseInstanceService {
       .addOrderBy('spring_meetings.day', 'ASC')
       .addOrderBy('spring_meetings.startTime', 'ASC')
       .addOrderBy('spring_meetings.endTime', 'ASC');
-
-      console.log("coursequery",courseQuery.printSql())
     return courseQuery.getMany() as Promise<CourseInstanceResponseDTO[]>;
   }
 

--- a/src/server/courseInstance/courseInstance.service.ts
+++ b/src/server/courseInstance/courseInstance.service.ts
@@ -143,6 +143,7 @@ export class CourseInstanceService {
       .addOrderBy('spring_meetings.startTime', 'ASC')
       .addOrderBy('spring_meetings.endTime', 'ASC');
 
+      console.log("coursequery",courseQuery.printSql())
     return courseQuery.getMany() as Promise<CourseInstanceResponseDTO[]>;
   }
 

--- a/src/server/report/report.service.ts
+++ b/src/server/report/report.service.ts
@@ -51,6 +51,7 @@ export class ReportService {
       { header: 'Is Seas?', key: 'isSEAS' },
       { header: 'Is Undergrad?', key: 'isUndergrad' },
       { header: 'Notes', key: 'notes' },
+      { header: 'SameAs', key: 'sameAs' },
     ];
     yearRange.forEach((year) => {
       const springYear = year.toString().substr(2);
@@ -82,6 +83,7 @@ export class ReportService {
         isSEAS: isSEASEnumToString(course.isSEAS),
         isUndergrad: course.isUndergraduate ? 'Undergraduate' : 'Graduate',
         notes: course.notes,
+        sameAs: course.sameAs,
       };
       yearRange.forEach((year, yearIndex) => {
         const courseInYear = allCourseData[yearIndex][courseIndex];
@@ -128,7 +130,6 @@ export class ReportService {
     (_, index) => startYear + index);
     // Create an object with year keys pointing to lists of faculty info
     const yearToFaculty = await this.facultyService.getAllByYear(yearList);
-
     const facultyToInfoMap: { [id: string]: {
       [year: string]: FacultyResponseDTO } } = {};
 

--- a/src/server/report/report.service.ts
+++ b/src/server/report/report.service.ts
@@ -51,7 +51,7 @@ export class ReportService {
       { header: 'Is Seas?', key: 'isSEAS' },
       { header: 'Is Undergrad?', key: 'isUndergrad' },
       { header: 'Notes', key: 'notes' },
-      { header: 'SameAs', key: 'sameAs' },
+      { header: 'Same As', key: 'sameAs' },
     ];
     yearRange.forEach((year) => {
       const springYear = year.toString().substr(2);

--- a/src/server/report/report.service.ts
+++ b/src/server/report/report.service.ts
@@ -37,14 +37,6 @@ export class ReportService {
       yearRange.map((year) => this.ciService.getAllByYear(year))
     );
 
-    // Move sameAs information from notes field to sameAs field
-    allCourseData[0].forEach((course) => {
-      if (course.notes && course.notes.toLowerCase().startsWith('same')) {
-        course.sameAs = course.notes;
-        course.notes = '';
-      }
-    });
-
     // Create our workbook and sheet
     const coursesReport = new Excel.stream.xlsx.WorkbookWriter({
       stream: xlsxStream,

--- a/src/server/report/report.service.ts
+++ b/src/server/report/report.service.ts
@@ -36,7 +36,11 @@ export class ReportService {
     const allCourseData: CourseInstanceResponseDTO[][] = await Promise.all(
       yearRange.map((year) => this.ciService.getAllByYear(year))
     );
-
+    allCourseData[0].forEach((course) => {
+      if (course.notes && course.notes.toLowerCase().startsWith('same')) {
+        course.sameAs = course.notes;
+      }
+    });
     // Create our workbook and sheet
     const coursesReport = new Excel.stream.xlsx.WorkbookWriter({
       stream: xlsxStream,

--- a/src/server/report/report.service.ts
+++ b/src/server/report/report.service.ts
@@ -36,11 +36,15 @@ export class ReportService {
     const allCourseData: CourseInstanceResponseDTO[][] = await Promise.all(
       yearRange.map((year) => this.ciService.getAllByYear(year))
     );
+
+    // Move sameAs information from notes field to sameAs field
     allCourseData[0].forEach((course) => {
       if (course.notes && course.notes.toLowerCase().startsWith('same')) {
         course.sameAs = course.notes;
+        course.notes = '';
       }
     });
+
     // Create our workbook and sheet
     const coursesReport = new Excel.stream.xlsx.WorkbookWriter({
       stream: xlsxStream,


### PR DESCRIPTION
## Describe your changes
 This PR adds a field to the course report download spread sheet. When a user clicks on `Download Course Report` button, whether the sameAs selected in the `customized view` menu or not, sameAs field appears next to notes column with sameAs information.  

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [X] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [X] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #656 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
