### PR TITLE
Fix bug to allow users to unpair sameAs value in Course Modal

### DIFF
--- a/src/server/course/__tests__/course.controller.test.ts
+++ b/src/server/course/__tests__/course.controller.test.ts
@@ -146,7 +146,7 @@ describe('Course controller', function () {
           mockCourseRepository.save.args[0][0],
           {
             ...cs50Course,
-            sameAs: undefined,
+            sameAs: null,
           }
         );
       });

--- a/src/server/course/__tests__/course.controller.test.ts
+++ b/src/server/course/__tests__/course.controller.test.ts
@@ -226,6 +226,29 @@ describe('Course controller', function () {
           BadRequestException
         );
       });
+      it('allows users to remove the sameAs value', async function () {
+        mockAreaRepository.findOne.resolves(cs50Course.area);
+        mockCourseRepository.findOneOrFail
+          .onFirstCall().resolves({
+            ...cs50Course,
+            sameAs: physicsCourse.id,
+          })
+          .onSecondCall().resolves(physicsCourse);
+        mockCourseRepository.save.resolves(cs50Course);
+
+        const course = await controller.update(
+          cs50Course.id,
+          updateCourseExample
+        );
+
+        deepStrictEqual(
+          course,
+          {
+            ...computerScienceCourseResponse,
+            sameAs: null,
+          }
+        );
+      });
     });
   });
 });

--- a/src/server/course/course.controller.ts
+++ b/src/server/course/course.controller.ts
@@ -156,6 +156,8 @@ export class CourseController {
       if (childCourses > 0) {
         throw new BadRequestException('Parent courses cannot be children');
       }
+    } else {
+      sameAsCourse = null;
     }
 
     const fullCourse = {

--- a/tests/integration/e2e/SchedulePage.test.tsx
+++ b/tests/integration/e2e/SchedulePage.test.tsx
@@ -193,7 +193,7 @@ describe('End-to-end Schedule Page tests', function () {
         const parentMeetingInfo = `${parentCourseDay}, ${parentStartTime} to ${parentEndTime} in ${parentLocation}`;
         const childCourseInfo = `${testChildCourse.prefix} ${testChildCourse.number} on ${parentMeetingInfo}`;
         await renderResult.findByText(childCourseInfo);
-      }).timeout(120000);
+      });
     });
   });
 });

--- a/tests/integration/e2e/SchedulePage.test.tsx
+++ b/tests/integration/e2e/SchedulePage.test.tsx
@@ -193,7 +193,7 @@ describe('End-to-end Schedule Page tests', function () {
         const parentMeetingInfo = `${parentCourseDay}, ${parentStartTime} to ${parentEndTime} in ${parentLocation}`;
         const childCourseInfo = `${testChildCourse.prefix} ${testChildCourse.number} on ${parentMeetingInfo}`;
         await renderResult.findByText(childCourseInfo);
-      });
+      }).timeout(120000);
     });
   });
 });


### PR DESCRIPTION
This fixes a bug in the Course modal that was preventing users from being able to save the `saveAs` value as `null` when the course previously had a non `null` value.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #650

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
