### PR TITLE
Remove retired courses and child courses from Course Admin Modal Same As dropdown

### DIFF
--- a/src/client/api/__tests__/courses.test.ts
+++ b/src/client/api/__tests__/courses.test.ts
@@ -14,6 +14,7 @@ import {
 import { TermKey } from 'common/constants/term';
 import { cs50CourseInstance } from 'testData';
 import CourseInstanceUpdateDTO from 'common/dto/courses/CourseInstanceUpdate.dto';
+import { ActiveParentCourses } from 'common/dto/courses/ActiveParentCourses.dto';
 import request, {
   AxiosResponse,
 } from '../request';
@@ -24,6 +25,7 @@ describe('Course Admin API', function () {
   let createCourseResult: ManageCourseResponseDTO;
   let editCourseResult: ManageCourseResponseDTO;
   let editCourseInstanceResult: CourseInstanceUpdateDTO;
+  let activeParentCoursesResult: ActiveParentCourses[];
   let getStub: SinonStub;
   let postStub: SinonStub;
   let putStub: SinonStub;
@@ -298,6 +300,38 @@ describe('Course Admin API', function () {
           ),
           dummy.error
         );
+      });
+    });
+  });
+  describe('getActiveParentCourses', function () {
+    beforeEach(function () {
+      getStub = stub(request, 'get');
+    });
+    context('when data fetch succeeds', function () {
+      beforeEach(async function () {
+        getStub.resolves({
+          data: dummy.activeParentCoursesExample,
+        } as AxiosResponse<ActiveParentCourses[]>);
+        activeParentCoursesResult = await CourseAPI.getActiveParentCourses();
+      });
+      it('should return the course information', function () {
+        deepStrictEqual(
+          activeParentCoursesResult,
+          dummy.activeParentCoursesExample
+        );
+      });
+    });
+    context('when data fetch fails', function () {
+      beforeEach(function () {
+        getStub.rejects(dummy.error);
+      });
+      it('should throw an error', async function () {
+        try {
+          await CourseAPI.getActiveParentCourses();
+          fail('Did not throw an error');
+        } catch (err) {
+          deepStrictEqual(err, dummy.error);
+        }
       });
     });
   });

--- a/src/client/api/courses.ts
+++ b/src/client/api/courses.ts
@@ -6,6 +6,7 @@ import { ScheduleViewResponseDTO } from 'common/dto/schedule/schedule.dto';
 import { TERM } from 'common/constants';
 import CourseInstanceUpdateDTO from 'common/dto/courses/CourseInstanceUpdate.dto';
 import { RoomScheduleResponseDTO } from 'common/dto/schedule/roomSchedule.dto';
+import { ActiveParentCourses } from 'common/dto/courses/ActiveParentCourses.dto';
 import request from './request';
 import { InstructorResponseDTO } from '../../common/dto/courses/InstructorResponse.dto';
 import { InstructorRequestDTO } from '../../common/dto/courses/InstructorRequest.dto';
@@ -103,6 +104,15 @@ export const updateCourseInstance = async (
   return response.data as CourseInstanceUpdateDTO;
 };
 
+/**
+ * Retrieves all non-retired, non-child courses
+ */
+export const getActiveParentCourses = async ()
+: Promise<ActiveParentCourses[]> => {
+  const response = await request.get('/api/courses/active-parents');
+  return response.data as ActiveParentCourses[];
+};
+
 export const CourseAPI = {
   getAllCourses,
   createCourse,
@@ -112,4 +122,5 @@ export const CourseAPI = {
   updateInstructorList,
   updateCourseInstance,
   getRoomScheduleForSemester,
+  getActiveParentCourses,
 };

--- a/src/client/components/pages/CourseAdmin.tsx
+++ b/src/client/components/pages/CourseAdmin.tsx
@@ -103,7 +103,7 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
   ] = useState(false);
 
   /**
-   * The currently selected faculty
+   * The currently selected course
    */
   const [
     currentCourse,
@@ -273,7 +273,8 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
               type: MESSAGE_ACTION.PUSH,
             });
           }}
-          courses={currentActiveParentCourses}
+          allCourses={currentCourses}
+          parentCourses={currentActiveParentCourses}
         />
       </div>
     </div>

--- a/src/client/components/pages/CourseAdmin.tsx
+++ b/src/client/components/pages/CourseAdmin.tsx
@@ -25,6 +25,7 @@ import { MessageContext, MetadataContext } from 'client/context';
 import { TableRowProps } from 'mark-one/lib/Tables/TableRow';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEdit } from '@fortawesome/free-solid-svg-icons';
+import { ActiveParentCourses } from 'common/dto/courses/ActiveParentCourses.dto';
 import { getAreaColor } from '../../../common/constants';
 import { CourseAPI } from '../../api/courses';
 import { VerticalSpace } from '../layout';
@@ -48,6 +49,14 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
    */
   const [currentCourses, setCourses] = useState(
     [] as ManageCourseResponseDTO[]
+  );
+
+  /**
+   * The current list of non-retired courses that are eligible to be parent
+   * courses
+   */
+  const [currentActiveParentCourses, setActiveParentCourses] = useState(
+    [] as ActiveParentCourses[]
   );
 
   /**
@@ -110,6 +119,8 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
     try {
       const loadedCourses = await CourseAPI.getAllCourses();
       setCourses(loadedCourses);
+      const parentCourses = await CourseAPI.getActiveParentCourses();
+      setActiveParentCourses(parentCourses);
     } catch (e) {
       dispatchMessage({
         message: new AppMessage(
@@ -262,7 +273,7 @@ const CourseAdmin: FunctionComponent = function (): ReactElement {
               type: MESSAGE_ACTION.PUSH,
             });
           }}
-          courses={currentCourses}
+          courses={currentActiveParentCourses}
         />
       </div>
     </div>

--- a/src/client/components/pages/Courses/CourseModal.tsx
+++ b/src/client/components/pages/Courses/CourseModal.tsx
@@ -37,6 +37,7 @@ import {
 import { CourseAPI } from 'client/api';
 import { AxiosError } from 'client/api/request';
 import { ErrorParser, ServerErrorInfo } from 'client/classes';
+import { ActiveParentCourses } from 'common/dto/courses/ActiveParentCourses.dto';
 
 interface CourseModalProps {
   /**
@@ -59,7 +60,7 @@ interface CourseModalProps {
   /**
    * Array of courses used to populate the sameAs selection dropdown
    */
-  courses: ManageCourseResponseDTO[];
+  courses: ActiveParentCourses[];
 }
 
 interface FormErrors {
@@ -299,7 +300,6 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
     () => [{ value: '', label: '' }]
       .concat(
         courses.filter(({ id }) => id !== currentCourse?.id)
-          .filter(({ sameAs }) => sameAs === null)
           .map(({ id, catalogNumber }): {
             value: string;
             label: string;

--- a/src/client/components/pages/Courses/CourseModal.tsx
+++ b/src/client/components/pages/Courses/CourseModal.tsx
@@ -58,9 +58,13 @@ interface CourseModalProps {
    */
   onSuccess: (course: ManageCourseResponseDTO) => Promise<void>;
   /**
+   * An array of all courses
+   */
+  allCourses: ManageCourseResponseDTO[];
+  /**
    * Array of courses used to populate the sameAs selection dropdown
    */
-  courses: ActiveParentCourses[];
+  parentCourses: ActiveParentCourses[];
 }
 
 interface FormErrors {
@@ -94,7 +98,8 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
   currentCourse,
   onSuccess,
   onClose,
-  courses,
+  allCourses,
+  parentCourses,
 }): ReactElement {
   /**
    * The current value for the metadata context
@@ -299,7 +304,7 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
   const courseOptions = useMemo(
     () => [{ value: '', label: '' }]
       .concat(
-        courses.filter(({ id }) => id !== currentCourse?.id)
+        parentCourses.filter(({ id }) => id !== currentCourse?.id)
           .map(({ id, catalogNumber }): {
             value: string;
             label: string;
@@ -308,16 +313,16 @@ const CourseModal: FunctionComponent<CourseModalProps> = function ({
             label: catalogNumber,
           }))
       ),
-    [courses, currentCourse]
+    [parentCourses, currentCourse]
   );
 
   /**
    * Array of catalog numbers that are child courses of the current course
    */
   const childCourses = useMemo(
-    () => courses.filter(({ sameAs }) => sameAs === currentCourse?.id)
+    () => allCourses.filter(({ sameAs }) => sameAs === currentCourse?.id)
       .map(({ catalogNumber }) => catalogNumber),
-    [courses, currentCourse]
+    [allCourses, currentCourse]
   );
 
   return (

--- a/src/client/components/pages/Courses/__tests__/CourseModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/CourseModal.test.tsx
@@ -69,7 +69,8 @@ describe('Course Modal', function () {
             isVisible
             onClose={() => {}}
             onSuccess={() => null}
-            courses={[]}
+            allCourses={[]}
+            parentCourses={[]}
           />
         ));
       });
@@ -143,7 +144,8 @@ describe('Course Modal', function () {
               currentCourse={physicsCourseResponse}
               onClose={() => {}}
               onSuccess={() => null}
-              courses={testData}
+              allCourses={testData}
+              parentCourses={[]}
             />
           );
         });
@@ -200,7 +202,8 @@ describe('Course Modal', function () {
               currentCourse={physicsCourseResponse}
               onClose={() => {}}
               onSuccess={() => null}
-              courses={activeParentCoursesExample}
+              allCourses={testData}
+              parentCourses={activeParentCoursesExample}
             />
           );
           const sameAsInput = modal.getByLabelText('Same As', { exact: false }) as HTMLSelectElement;
@@ -217,7 +220,8 @@ describe('Course Modal', function () {
               currentCourse={physicsCourseResponse}
               onClose={() => {}}
               onSuccess={() => null}
-              courses={testData}
+              allCourses={testData}
+              parentCourses={activeParentCoursesExample}
             />
           );
           const sameAsInput = modal
@@ -240,7 +244,8 @@ describe('Course Modal', function () {
               currentCourse={computerScienceCourseResponse}
               onClose={() => {}}
               onSuccess={() => null}
-              courses={testData}
+              allCourses={testData}
+              parentCourses={activeParentCoursesExample}
             />
           );
           const sameAsInput = modal
@@ -254,7 +259,7 @@ describe('Course Modal', function () {
               currentCourse={computerScienceCourseResponse}
               onClose={() => {}}
               onSuccess={() => null}
-              courses={[
+              allCourses={[
                 computerScienceCourseResponse,
                 childCourse,
                 {
@@ -262,6 +267,7 @@ describe('Course Modal', function () {
                   sameAs: computerScienceCourseResponse.id,
                 },
               ]}
+              parentCourses={[]}
             />
           );
           notDeepStrictEqual(
@@ -336,7 +342,8 @@ describe('Course Modal', function () {
           isVisible
           onClose={() => {}}
           onSuccess={() => null}
-          courses={[]}
+          allCourses={[]}
+          parentCourses={[]}
         />
       ));
     });
@@ -610,7 +617,8 @@ describe('Course Modal', function () {
               currentCourse={physicsCourseResponse}
               onSuccess={onSuccessStub}
               onClose={onCloseStub}
-              courses={[]}
+              allCourses={[]}
+              parentCourses={[]}
             />
           ));
         });
@@ -649,7 +657,8 @@ describe('Course Modal', function () {
               }}
               onSuccess={onSuccessStub}
               onClose={onCloseStub}
-              courses={[]}
+              allCourses={[]}
+              parentCourses={[]}
             />
           ));
         });
@@ -679,7 +688,8 @@ describe('Course Modal', function () {
               isVisible
               onSuccess={onSuccessStub}
               onClose={onCloseStub}
-              courses={[]}
+              allCourses={[]}
+              parentCourses={[]}
             />
           ));
           const existingAreaSelect = getByLabelText('Existing Area', { exact: true }) as HTMLSelectElement;
@@ -748,7 +758,8 @@ describe('Course Modal', function () {
               isVisible
               onSuccess={onSuccessStub}
               onClose={onCloseStub}
-              courses={[]}
+              allCourses={[]}
+              parentCourses={[]}
             />
           ));
         });

--- a/src/client/components/pages/Courses/__tests__/CourseModal.test.tsx
+++ b/src/client/components/pages/Courses/__tests__/CourseModal.test.tsx
@@ -26,6 +26,7 @@ import {
   physicsCourse,
   physicsCourseResponse,
   newAreaCourseResponse,
+  activeParentCoursesExample,
 } from 'testData';
 import { IS_SEAS } from 'common/constants';
 import request from 'client/api/request';
@@ -198,7 +199,7 @@ describe('Course Modal', function () {
               currentCourse={physicsCourseResponse}
               onClose={() => {}}
               onSuccess={() => null}
-              courses={testData}
+              courses={activeParentCoursesExample}
             />
           );
           const sameAsInput = modal.getByLabelText('Same As', { exact: false }) as HTMLSelectElement;
@@ -207,25 +208,6 @@ describe('Course Modal', function () {
           const courseIds = sameAsOptions.map((option) => option.value);
 
           strictEqual(courseIds.includes(physicsCourseResponse.id), false);
-        });
-        it('cannot contain a child course', function () {
-          const modal = render(
-            <CourseModal
-              isVisible
-              currentCourse={physicsCourseResponse}
-              onClose={() => {}}
-              onSuccess={() => null}
-              courses={testData}
-            />
-          );
-          const sameAsInput = modal
-            .getByLabelText('Same As') as HTMLSelectElement;
-          const sameAsOptions = within(sameAsInput)
-            .getAllByRole('option') as HTMLOptionElement[];
-
-          const courseIds = sameAsOptions.map((option) => option.value);
-
-          strictEqual(courseIds.includes(childCourse.id), false);
         });
       });
       describe('Error Message', function () {

--- a/src/common/__tests__/data/courses.ts
+++ b/src/common/__tests__/data/courses.ts
@@ -229,9 +229,5 @@ export const activeParentCoursesExample: ActiveParentCourses[] = [
   { id: '98a61a51-4280-4624-8bdc-c67a3b527c2d', catalogNumber: 'CS 288r' },
   { id: 'dad6a49e-02be-4d1a-8cb2-016cd902b585', catalogNumber: 'ES 212' },
   { id: 'b9a40bf7-56fa-4410-a377-5b0521910842', catalogNumber: 'GENED 1094' },
-  {
-    id: newAreaCourseResponse.id,
-    catalogNumber: newAreaCourseResponse.catalogNumber,
-  },
   { id: 'c5ceb64c-ddc2-49bf-9616-7a611d07ebf6', catalogNumber: 'SEMINAR AP Colloqium' },
 ];

--- a/src/common/__tests__/data/courses.ts
+++ b/src/common/__tests__/data/courses.ts
@@ -215,11 +215,23 @@ export const activeParentCoursesExample: ActiveParentCourses[] = [
   { id: '17c85af5-5b74-4202-8332-2604cd114b51', catalogNumber: 'AM 22b' },
   { id: '5fc4f4ba-e1ff-4b3b-8ae4-45edc7b2c578', catalogNumber: 'AM 108' },
   { id: '84ce8fa2-6184-472c-9f51-6f47bdb1a3bd', catalogNumber: 'AP 242' },
+  {
+    id: physicsCourseResponse.id,
+    catalogNumber: physicsCourseResponse.catalogNumber,
+  },
   { id: 'f4a148df-f36e-4bd5-8998-59207046e88a', catalogNumber: 'BE 153' },
   { id: '3f29ad8e-6163-45ae-bdce-9706e9fe30aa', catalogNumber: 'BE 191' },
+  {
+    id: computerScienceCourseResponse.id,
+    catalogNumber: computerScienceCourseResponse.catalogNumber,
+  },
   { id: '65bcdf61-de97-4758-ab16-8920d0b571dc', catalogNumber: 'CS 10' },
   { id: '98a61a51-4280-4624-8bdc-c67a3b527c2d', catalogNumber: 'CS 288r' },
   { id: 'dad6a49e-02be-4d1a-8cb2-016cd902b585', catalogNumber: 'ES 212' },
   { id: 'b9a40bf7-56fa-4410-a377-5b0521910842', catalogNumber: 'GENED 1094' },
+  {
+    id: newAreaCourseResponse.id,
+    catalogNumber: newAreaCourseResponse.catalogNumber,
+  },
   { id: 'c5ceb64c-ddc2-49bf-9616-7a611d07ebf6', catalogNumber: 'SEMINAR AP Colloqium' },
 ];

--- a/src/common/__tests__/data/courses.ts
+++ b/src/common/__tests__/data/courses.ts
@@ -4,6 +4,7 @@ import { CreateCourse } from 'common/dto/courses/CreateCourse.dto';
 import { ManageCourseResponseDTO } from 'common/dto/courses/ManageCourseResponse.dto';
 import { UpdateCourseDTO } from 'common/dto/courses/UpdateCourse.dto';
 import { FindCoursesQueryResult } from 'server/course/course.service';
+import { ActiveParentCourses } from 'common/dto/courses/ActiveParentCourses.dto';
 /**
  * Empty instance of a [[Course]] entity with no properties set. Useful for
  * testing that something of type `Course` was returned, or passed to a method
@@ -204,4 +205,21 @@ export const rawCatalogPrefixList = [
   { prefix: 'ESE' },
   { prefix: 'GENED' },
   { prefix: 'SEMINAR' },
+];
+
+/**
+ * An example [[ActiveParentCourses[]]] response
+ */
+export const activeParentCoursesExample: ActiveParentCourses[] = [
+  { id: 'd32921eb-acec-424d-8be3-60ed3a8e2996', catalogNumber: 'AC 209a' },
+  { id: '17c85af5-5b74-4202-8332-2604cd114b51', catalogNumber: 'AM 22b' },
+  { id: '5fc4f4ba-e1ff-4b3b-8ae4-45edc7b2c578', catalogNumber: 'AM 108' },
+  { id: '84ce8fa2-6184-472c-9f51-6f47bdb1a3bd', catalogNumber: 'AP 242' },
+  { id: 'f4a148df-f36e-4bd5-8998-59207046e88a', catalogNumber: 'BE 153' },
+  { id: '3f29ad8e-6163-45ae-bdce-9706e9fe30aa', catalogNumber: 'BE 191' },
+  { id: '65bcdf61-de97-4758-ab16-8920d0b571dc', catalogNumber: 'CS 10' },
+  { id: '98a61a51-4280-4624-8bdc-c67a3b527c2d', catalogNumber: 'CS 288r' },
+  { id: 'dad6a49e-02be-4d1a-8cb2-016cd902b585', catalogNumber: 'ES 212' },
+  { id: 'b9a40bf7-56fa-4410-a377-5b0521910842', catalogNumber: 'GENED 1094' },
+  { id: 'c5ceb64c-ddc2-49bf-9616-7a611d07ebf6', catalogNumber: 'SEMINAR AP Colloqium' },
 ];

--- a/src/common/dto/courses/ActiveParentCourses.dto.ts
+++ b/src/common/dto/courses/ActiveParentCourses.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export abstract class ActiveParentCourses {
+  @ApiProperty({
+    example: 'b8bc8456-51fd-48ef-b111-5a5990671cd1',
+  })
+  public id: string;
+
+  @ApiProperty({
+    example: 'AC 209a',
+  })
+  public catalogNumber: string;
+}

--- a/src/server/course/__tests__/course.service.test.ts
+++ b/src/server/course/__tests__/course.service.test.ts
@@ -20,9 +20,11 @@ import {
   computerScienceCourseResponse,
   physicsCourseResponse,
   rawCatalogPrefixList,
+  activeParentCoursesExample,
 } from 'testData';
 import { Area } from 'server/area/area.entity';
 import { SelectQueryBuilder } from 'typeorm';
+import { ConfigService } from 'server/config/config.service';
 import { CourseService } from '../course.service';
 import { Course } from '../course.entity';
 
@@ -71,6 +73,7 @@ describe('Course service', function () {
           provide: getRepositoryToken(Semester),
           useValue: mockSemesterRepository,
         },
+        ConfigService,
       ],
       controllers: [],
     }).compile();
@@ -147,6 +150,41 @@ describe('Course service', function () {
       });
       it('returns an empty array', async function () {
         const result = await courseService.getCatalogPrefixList();
+        strictEqual(result.length, 0);
+        deepStrictEqual(result, []);
+      });
+    });
+  });
+  describe('getAvailableParentCourses', function () {
+    context('when there are records in the database', function () {
+      beforeEach(function () {
+        mockCourseQueryBuilder.select.returnsThis();
+        mockCourseQueryBuilder.addSelect.returnsThis();
+        mockCourseQueryBuilder.innerJoin.returnsThis();
+        mockCourseQueryBuilder.where.returnsThis();
+        mockCourseQueryBuilder.andWhere.returnsThis();
+        mockCourseQueryBuilder.orderBy.returnsThis();
+        mockCourseQueryBuilder.addOrderBy.returnsThis();
+        mockCourseQueryBuilder.getRawMany.resolves(activeParentCoursesExample);
+      });
+      it('returns a list of course id numbers and their corresponding catalog numbers', async function () {
+        const result = await courseService.getAvailableParentCourses();
+        deepStrictEqual(result, activeParentCoursesExample);
+      });
+    });
+    context('when there are no records in the database', function () {
+      beforeEach(function () {
+        mockCourseQueryBuilder.select.returnsThis();
+        mockCourseQueryBuilder.addSelect.returnsThis();
+        mockCourseQueryBuilder.innerJoin.returnsThis();
+        mockCourseQueryBuilder.where.returnsThis();
+        mockCourseQueryBuilder.andWhere.returnsThis();
+        mockCourseQueryBuilder.orderBy.returnsThis();
+        mockCourseQueryBuilder.addOrderBy.returnsThis();
+        mockCourseQueryBuilder.getRawMany.resolves([]);
+      });
+      it('returns an empty array', async function () {
+        const result = await courseService.getAvailableParentCourses();
         strictEqual(result.length, 0);
         deepStrictEqual(result, []);
       });

--- a/src/server/course/course.controller.ts
+++ b/src/server/course/course.controller.ts
@@ -29,6 +29,7 @@ import { Authentication } from 'server/auth/authentication.guard';
 import { EntityNotFoundError } from 'typeorm/error/EntityNotFoundError';
 import { UpdateCourseDTO } from 'common/dto/courses/UpdateCourse.dto';
 import { Area } from 'server/area/area.entity';
+import { ActiveParentCourses } from 'common/dto/courses/ActiveParentCourses.dto';
 import { Course } from './course.entity';
 import { CourseService } from './course.service';
 
@@ -182,5 +183,16 @@ export class CourseController {
       catalogNumber: `${prefix} ${number}`,
       sameAs: updatedCourse.sameAs ? updatedCourse.sameAs.id : null,
     };
+  }
+
+  @Get('/active-parents')
+  @ApiOperation({ summary: 'Retrieve all non-retired, non-child courses from the database' })
+  @ApiOkResponse({
+    type: ActiveParentCourses,
+    description: 'An array of all the non-retired, non-child courses',
+    isArray: true,
+  })
+  public async getActiveParentCourses(): Promise<ActiveParentCourses[]> {
+    return this.courseService.getAvailableParentCourses();
   }
 }

--- a/src/server/course/course.service.ts
+++ b/src/server/course/course.service.ts
@@ -195,4 +195,5 @@ export class CourseService {
       id: result.id,
       catalogNumber: result.catalogNumber,
     }));
+  }
 }

--- a/src/server/course/course.service.ts
+++ b/src/server/course/course.service.ts
@@ -1,10 +1,17 @@
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DeepPartial } from 'typeorm';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Semester } from 'server/semester/semester.entity';
 import { Area } from 'server/area/area.entity';
+import {
+  IS_SEAS,
+  OFFERED,
+  TERM,
+  TERM_PATTERN,
+} from 'common/constants';
+import { ConfigService } from 'server/config/config.service';
 import { ManageCourseResponseDTO } from 'common/dto/courses/ManageCourseResponse.dto';
-import { IS_SEAS, TERM_PATTERN } from 'common/constants';
+import { ActiveParentCourses } from 'common/dto/courses/ActiveParentCourses.dto';
 import { Course } from './course.entity';
 import { CourseInstance } from '../courseInstance/courseinstance.entity';
 
@@ -42,6 +49,16 @@ export abstract class FindCoursesQueryResult {
   public private: boolean;
 }
 
+export abstract class ActiveParentCoursesResult {
+  public id: string;
+
+  public prefix: string;
+
+  public catalogNumber: string;
+
+  public sameAs: string;
+}
+
 @Injectable()
 export class CourseService {
   @InjectRepository(Area)
@@ -52,6 +69,9 @@ export class CourseService {
 
   @InjectRepository(Course)
   private courseRepository: Repository<Course>;
+
+  @Inject(ConfigService)
+  private readonly configService: ConfigService;
 
   /**
    * Retrieve all courses in the database and sort by:
@@ -135,4 +155,44 @@ export class CourseService {
         )
       );
   }
+
+  /**
+   * Retrieves all of the non-retired courses that are not a child of another
+   * course, since a child course cannot be a parent course.
+   */
+  public async getAvailableParentCourses(): Promise<ActiveParentCourses[]> {
+    const { academicYear } = this.configService;
+    let term: TERM;
+    // Determines the current term based off of the current month
+    const today = new Date();
+    if (today.getMonth() >= 6) {
+      term = TERM.FALL;
+    } else {
+      term = TERM.SPRING;
+    }
+
+    // Note that academicYear in the semester table is actually the calendar year
+    const semesterAcademicYear = term === TERM.FALL
+      ? academicYear + 1 : academicYear;
+
+    const results: ActiveParentCoursesResult[] = await this.courseRepository
+      .createQueryBuilder('c')
+      .select('c.id', 'id')
+      .addSelect('c.prefix', 'prefix')
+      .addSelect("CONCAT_WS(' ', c.prefix, c.number)", 'catalogNumber')
+      .addSelect('c."numberInteger"', 'numberInteger')
+      .addSelect('c."numberAlphabetical"', 'numberAlphabetical')
+      .addSelect('c."sameAsId"', 'sameAs')
+      .innerJoin(Semester, 's', 's."academicYear" = :academicYear AND s.term = :term', { academicYear: semesterAcademicYear, term })
+      .innerJoin(CourseInstance, 'ci', 'ci."courseId" = c.id AND ci."semesterId" = s.id')
+      .where('c."sameAsId" IS NULL')
+      .andWhere('ci.offered <> :offered', { offered: OFFERED.RETIRED })
+      .orderBy('prefix', 'ASC')
+      .addOrderBy('"numberInteger"', 'ASC')
+      .addOrderBy('"numberAlphabetical"', 'ASC')
+      .getRawMany();
+    return results.map((result) => ({
+      id: result.id,
+      catalogNumber: result.catalogNumber,
+    }));
 }

--- a/tests/integration/client/course/courseAdmin.test.tsx
+++ b/tests/integration/client/course/courseAdmin.test.tsx
@@ -33,6 +33,7 @@ import {
   adminUser,
   string,
   physicsCourse,
+  activeParentCoursesExample,
 } from 'testData';
 import { AUTH_MODE } from 'common/constants';
 import { render } from 'test-utils';
@@ -162,7 +163,7 @@ describe('Course Admin Modal Behavior', function () {
               isVisible
               onSuccess={onSuccessStub}
               onClose={onCloseStub}
-              courses={[physicsCourseResponse]}
+              courses={activeParentCoursesExample}
             />
           ));
         });
@@ -315,7 +316,7 @@ describe('Course Admin Modal Behavior', function () {
               currentCourse={physicsCourseResponse}
               onSuccess={onSuccessStub}
               onClose={onCloseStub}
-              courses={[physicsCourseResponse]}
+              courses={activeParentCoursesExample}
             />
           ));
         });
@@ -448,7 +449,7 @@ describe('Course Admin Modal Behavior', function () {
               isVisible
               onSuccess={onSuccessStub}
               onClose={onCloseStub}
-              courses={[physicsCourseResponse]}
+              courses={activeParentCoursesExample}
             />
           ));
         });
@@ -514,7 +515,7 @@ describe('Course Admin Modal Behavior', function () {
               currentCourse={physicsCourseResponse}
               onSuccess={onSuccessStub}
               onClose={onCloseStub}
-              courses={[physicsCourseResponse]}
+              courses={activeParentCoursesExample}
             />
           ));
         });

--- a/tests/integration/client/course/courseAdmin.test.tsx
+++ b/tests/integration/client/course/courseAdmin.test.tsx
@@ -34,6 +34,8 @@ import {
   string,
   physicsCourse,
   activeParentCoursesExample,
+  computerScienceCourseResponse,
+  newAreaCourseResponse,
 } from 'testData';
 import { AUTH_MODE } from 'common/constants';
 import { render } from 'test-utils';
@@ -41,6 +43,7 @@ import { SessionModule } from 'nestjs-session';
 import CourseModal from 'client/components/pages/Courses/CourseModal';
 import { Repository } from 'typeorm';
 import { Area } from 'server/area/area.entity';
+import { ManageCourseResponseDTO } from 'common/dto/courses/ManageCourseResponse.dto';
 import { TestingStrategy } from '../../../mocks/authentication/testing.strategy';
 import { CourseService } from '../../../../src/server/course/course.service';
 import { Course } from '../../../../src/server/course/course.entity';
@@ -73,6 +76,12 @@ describe('Course Admin Modal Behavior', function () {
   let authStub: SinonStub;
   let courseService: CourseService;
   let courseRepository: Repository<Course>;
+
+  const coursesTestData: ManageCourseResponseDTO[] = [
+    computerScienceCourseResponse,
+    physicsCourseResponse,
+    newAreaCourseResponse,
+  ];
 
   let testModule: TestingModule;
   let api: HttpServer;
@@ -163,7 +172,8 @@ describe('Course Admin Modal Behavior', function () {
               isVisible
               onSuccess={onSuccessStub}
               onClose={onCloseStub}
-              courses={activeParentCoursesExample}
+              allCourses={coursesTestData}
+              parentCourses={activeParentCoursesExample}
             />
           ));
         });
@@ -316,7 +326,8 @@ describe('Course Admin Modal Behavior', function () {
               currentCourse={physicsCourseResponse}
               onSuccess={onSuccessStub}
               onClose={onCloseStub}
-              courses={activeParentCoursesExample}
+              allCourses={coursesTestData}
+              parentCourses={activeParentCoursesExample}
             />
           ));
         });
@@ -449,7 +460,8 @@ describe('Course Admin Modal Behavior', function () {
               isVisible
               onSuccess={onSuccessStub}
               onClose={onCloseStub}
-              courses={activeParentCoursesExample}
+              allCourses={coursesTestData}
+              parentCourses={activeParentCoursesExample}
             />
           ));
         });
@@ -515,7 +527,8 @@ describe('Course Admin Modal Behavior', function () {
               currentCourse={physicsCourseResponse}
               onSuccess={onSuccessStub}
               onClose={onCloseStub}
-              courses={activeParentCoursesExample}
+              allCourses={coursesTestData}
+              parentCourses={activeParentCoursesExample}
             />
           ));
         });

--- a/tests/integration/e2e/SchedulePage.test.tsx
+++ b/tests/integration/e2e/SchedulePage.test.tsx
@@ -15,18 +15,24 @@ import { SessionModule } from 'nestjs-session';
 import { MemoryRouter } from 'react-router-dom';
 import App from 'client/components/App';
 import request from 'client/api/request';
-import { Repository, Not } from 'typeorm';
+import {
+  Repository,
+  Not,
+  IsNull,
+} from 'typeorm';
 import { SemesterModule } from 'server/semester/semester.module';
 import { Meeting } from 'server/meeting/meeting.entity';
 import { dayEnumToString } from 'common/constants/day';
 import { PGTime } from 'common/utils/PGTime';
+import { CourseInstance } from 'server/courseInstance/courseinstance.entity';
+import { Semester } from 'server/semester/semester.entity';
 import mockAdapter from '../../mocks/api/adapter';
 import { ConfigModule } from '../../../src/server/config/config.module';
 import { ConfigService } from '../../../src/server/config/config.service';
 import { AuthModule } from '../../../src/server/auth/auth.module';
 import { TestingStrategy } from '../../mocks/authentication/testing.strategy';
 import {
-  AUTH_MODE, TERM_PATTERN,
+  AUTH_MODE, IS_SEAS, OFFERED, TERM,
 } from '../../../src/common/constants';
 import { PopulationModule } from '../../mocks/database/population/population.module';
 import { CourseModule } from '../../../src/server/course/course.module';
@@ -41,6 +47,7 @@ describe('End-to-end Schedule Page tests', function () {
   let testModule: TestingModule;
   let authStub: SinonStub;
   let meetingRepository: Repository<Meeting>;
+  let ciRepository: Repository<CourseInstance>;
   const currentAcademicYear = 2019;
   let renderResult: RenderResult;
 
@@ -96,6 +103,9 @@ describe('End-to-end Schedule Page tests', function () {
     meetingRepository = testModule.get(
       getRepositoryToken(Meeting)
     );
+    ciRepository = testModule.get(
+      getRepositoryToken(CourseInstance)
+    );
     const nestApp = await testModule
       .createNestApplication()
       .useGlobalPipes(new BadRequestExceptionPipe())
@@ -108,91 +118,76 @@ describe('End-to-end Schedule Page tests', function () {
     return testModule.close();
   });
   describe('Rendering Schedule Information', function () {
-    let parentMeetings: Meeting[];
-    let childMeetings: Meeting[];
+    let testCi: CourseInstance;
+    let parentMeeting: Meeting;
+    let parentMeetingSemester: Semester;
+    let parentMeetingYear: string;
+    let parentMeetingTerm: TERM;
     beforeEach(async function () {
-      parentMeetings = await meetingRepository.find({
-        relations: ['courseInstance', 'courseInstance.course', 'courseInstance.course.area', 'room', 'room.building'],
+      // Find a course instance that has a same as value. The same as course
+      // will be used as the parent.
+      testCi = await ciRepository.findOneOrFail({
+        relations: ['course', 'course.sameAs', 'semester'],
         where: {
-          courseInstance: {
-            course: {
-              termPattern: TERM_PATTERN.BOTH,
-            },
+          offered: Not(OFFERED.RETIRED),
+          course: {
+            isSEAS: IS_SEAS.Y,
+            sameAs: Not(IsNull()),
           },
         },
       });
-      const parentMeetingCourse = parentMeetings[0].courseInstance.course;
-      childMeetings = await meetingRepository.find({
-        relations: ['courseInstance', 'courseInstance.course', 'courseInstance.course.area', 'room', 'room.building'],
+
+      parentMeeting = await meetingRepository.findOneOrFail({
+        relations: ['courseInstance', 'courseInstance.course', 'courseInstance.course.sameAs', 'courseInstance.semester', 'room', 'room.building'],
         where: {
-          day: Not(parentMeetings[0].day),
           courseInstance: {
-            course: {
-              id: Not(parentMeetingCourse.id),
-              area: {
-                name: Not(parentMeetingCourse.area.name),
-              },
-            },
+            offered: Not(OFFERED.RETIRED),
+            course: testCi.course.sameAs.id,
           },
         },
       });
+
+      parentMeetingSemester = parentMeeting.courseInstance.semester;
+      parentMeetingYear = parentMeetingSemester.academicYear;
+      parentMeetingTerm = parentMeetingSemester.term;
+
       renderResult = render(
-        <MemoryRouter initialEntries={['/course-admin']}>
+        <MemoryRouter initialEntries={['/schedule']}>
           <App />
         </MemoryRouter>
       );
     });
     context('when a course is a child of another', function () {
       it('should display the meeting information of the parent course', async function () {
-        const testMeeting = parentMeetings[0];
-        const testParentCourse = testMeeting.courseInstance.course;
-        const testChildCourse = childMeetings[0].courseInstance.course;
-        await renderResult.findAllByText(testChildCourse.title);
+        await waitForElementToBeRemoved(() => renderResult.getByText('Fetching User Data'));
+        await waitForElementToBeRemoved(() => renderResult.getByText('Fetching Course Schedule'));
+        const semesterDropdown = renderResult.getByLabelText(/semester/i) as HTMLSelectElement;
 
-        // Before setting the child course's "Same As" value to the parent,
-        // we are filtering the Course Admin table by area, because there are
-        // courses with the same title and differing catalog numbers. When
-        // selecting the edit button, we want to make sure we are selecting
-        // the intended one.
-        const areaLabelText = 'The table will be filtered as selected in this area dropdown filter';
-        const areaFilter = renderResult
-          .getByLabelText(areaLabelText) as HTMLSelectElement;
-        fireEvent.change(areaFilter,
-          { target: { value: testChildCourse.area.name } });
-        const catalogText = 'The table will be filtered as characters are typed in this course filter field';
-        const catalogFilter = renderResult
-          .getByLabelText(catalogText) as HTMLInputElement;
-        fireEvent.change(catalogFilter,
-          { target: { value: `${testChildCourse.prefix} ${testChildCourse.number}` } });
-        // Open the child course modal to edit the "Same As" value
-        const editButton = await renderResult
-          .findByLabelText(`Edit course information for ${testChildCourse.title}`,
-            { exact: false });
-        fireEvent.click(editButton);
-        await renderResult.findByRole('dialog');
-        const sameAsSelect = renderResult.getByLabelText('Same As', { exact: false }) as HTMLSelectElement;
-        fireEvent.change(
-          sameAsSelect,
-          { target: { value: testParentCourse.id } }
-        );
-        const submitButton = renderResult.getByText('Submit');
-        fireEvent.click(submitButton);
-        await waitForElementToBeRemoved(() => renderResult.getByRole('dialog'));
+        // Since the semester dropdown contains calendar years, the selection
+        // must be changed depending on the semester.
+        if (parentMeetingTerm === TERM.SPRING) {
+          fireEvent.change(semesterDropdown, { target: { value: `${parentMeetingTerm} ${parentMeetingYear}` } });
+        } else {
+          fireEvent.change(semesterDropdown, { target: { value: `${parentMeetingTerm} ${parseInt(parentMeetingYear, 10) - 1}` } });
+        }
 
-        // Navigate to the schedule page and wait for the table to render
-        const scheduleTab = await renderResult.findByText('Schedule');
-        fireEvent.click(scheduleTab);
+        await waitForElementToBeRemoved(() => renderResult.getByText(
+          'Fetching Course Schedule'
+        ));
+        await renderResult.findByText('7 PM');
+        const testParentCourse = parentMeeting.courseInstance.course;
+        const testChildCourse = testCi.course;
         const parentCatalogNumber = `${testParentCourse.prefix} ${testParentCourse.number}`;
         await renderResult.findAllByText(parentCatalogNumber, { exact: false });
 
         // Make sure the child course displays the parent course's meeting information
-        const parentCourseDay = dayEnumToString(testMeeting.day);
-        const parentStartTime = PGTime.toDisplay(testMeeting.startTime);
-        const parentEndTime = PGTime.toDisplay(testMeeting.endTime);
-        const parentLocation = `${testMeeting.room.building.name} ${testMeeting.room.name}`;
+        const parentCourseDay = dayEnumToString(parentMeeting.day);
+        const parentStartTime = PGTime.toDisplay(parentMeeting.startTime);
+        const parentEndTime = PGTime.toDisplay(parentMeeting.endTime);
+        const parentLocation = `${parentMeeting.room.building.name} ${parentMeeting.room.name}`;
         const parentMeetingInfo = `${parentCourseDay}, ${parentStartTime} to ${parentEndTime} in ${parentLocation}`;
         const childCourseInfo = `${testChildCourse.prefix} ${testChildCourse.number} on ${parentMeetingInfo}`;
-        await renderResult.findByText(childCourseInfo);
+        await renderResult.findByText(childCourseInfo, { exact: false });
       }).timeout(120000);
     });
   });


### PR DESCRIPTION
This PR removes the retired and child courses from the Course Admin Modal's Same As dropdown. A new API method, `getActiveParentCourses`, was added to get all of the non-retired, non-child courses, and these courses are directly passed into the Course Admin Modal via a prop called `parentCourses`.

This PR also fixes tests that broke as a result of merging new changes from `develop`.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #651

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
