### PR TITLE
Improve course instance offered tests

### DIFF
--- a/tests/integration/server/courseInstance/courseInstance.service.test.ts
+++ b/tests/integration/server/courseInstance/courseInstance.service.test.ts
@@ -20,7 +20,7 @@ import {
   MultiYearPlanInstanceFaculty,
   MultiYearPlanInstance,
 } from 'common/dto/multiYearPlan/MultiYearPlanResponseDTO';
-import { Repository } from 'typeorm';
+import { Not, Repository } from 'typeorm';
 import { testFourYearPlanAcademicYears } from 'testData';
 import CourseInstanceUpdateDTO from 'common/dto/courses/CourseInstanceUpdate.dto';
 import { stub } from 'sinon';

--- a/tests/integration/server/courseInstance/courseInstance.service.test.ts
+++ b/tests/integration/server/courseInstance/courseInstance.service.test.ts
@@ -458,12 +458,13 @@ describe('Course Instance Service', function () {
     beforeEach(function () {
       stub(configService, 'academicYear').get(() => currentAcademicYear);
     });
-    describe('editing an offered value to a non-retired value', function () {
+    describe('editing a non-retired offered value to a non-retired value', function () {
       context('when we are editing a past academic year instance', function () {
         beforeEach(async function () {
           newOfferedValue = OFFERED.N;
           instance = await instanceRepository.findOneOrFail({
             where: {
+              offered: Not(OFFERED.RETIRED),
               semester: {
                 academicYear: parseInt(currentAcademicYear, 10) - 2,
               },
@@ -487,6 +488,7 @@ describe('Course Instance Service', function () {
           newOfferedValue = OFFERED.Y;
           instance = await instanceRepository.findOneOrFail({
             where: {
+              offered: Not(OFFERED.RETIRED),
               semester: {
                 academicYear: currentAcademicYear,
               },
@@ -510,6 +512,7 @@ describe('Course Instance Service', function () {
           newOfferedValue = OFFERED.N;
           instance = await instanceRepository.findOneOrFail({
             where: {
+              offered: Not(OFFERED.RETIRED),
               semester: {
                 academicYear: parseInt(currentAcademicYear, 10) + 1,
               },
@@ -529,12 +532,13 @@ describe('Course Instance Service', function () {
         });
       });
     });
-    describe('editing an offered value to OFFERED.RETIRED', function () {
+    describe('editing a non-retired offered value to an OFFERED.RETIRED value', function () {
       context('when we are editing a past academic year instance', function () {
         beforeEach(async function () {
           newOfferedValue = OFFERED.RETIRED;
           instance = await instanceRepository.findOneOrFail({
             where: {
+              offered: Not(OFFERED.RETIRED),
               semester: {
                 academicYear: parseInt(currentAcademicYear, 10) - 2,
               },
@@ -563,6 +567,7 @@ describe('Course Instance Service', function () {
           newOfferedValue = OFFERED.RETIRED;
           instance = await instanceRepository.findOneOrFail({
             where: {
+              offered: Not(OFFERED.RETIRED),
               semester: {
                 academicYear: currentAcademicYear,
               },
@@ -586,6 +591,86 @@ describe('Course Instance Service', function () {
           newOfferedValue = OFFERED.RETIRED;
           instance = await instanceRepository.findOneOrFail({
             where: {
+              offered: Not(OFFERED.RETIRED),
+              semester: {
+                academicYear: parseInt(currentAcademicYear, 10) + 1,
+              },
+            },
+            relations: ['course', 'semester'],
+          });
+          updateInfo = {
+            preEnrollment: instance.preEnrollment,
+            studyCardEnrollment: instance.studyCardEnrollment,
+            actualEnrollment: instance.actualEnrollment,
+            offered: newOfferedValue,
+          };
+          result = await ciService.editCourseInstance(instance.id, updateInfo);
+        });
+        it('should return the updated instance', function () {
+          deepStrictEqual(result, updateInfo);
+        });
+      });
+    });
+    describe('editing an OFFERED.RETIRED value to a non-retired value', function () {
+      context('when we are editing a past academic year instance', function () {
+        beforeEach(async function () {
+          newOfferedValue = OFFERED.Y;
+          instance = await instanceRepository.findOneOrFail({
+            where: {
+              offered: OFFERED.RETIRED,
+              semester: {
+                academicYear: parseInt(currentAcademicYear, 10) - 2,
+              },
+            },
+            relations: ['course', 'semester'],
+          });
+          updateInfo = {
+            preEnrollment: instance.preEnrollment,
+            studyCardEnrollment: instance.studyCardEnrollment,
+            actualEnrollment: instance.actualEnrollment,
+            offered: newOfferedValue,
+          };
+          try {
+            result = await ciService
+              .editCourseInstance(instance.id, updateInfo);
+          } catch (error) {
+            response = error;
+          }
+        });
+        it('should throw a Bad Request Exception', function () {
+          strictEqual(response.status, 400);
+        });
+      });
+      context('when we are editing a current academic year instance', function () {
+        beforeEach(async function () {
+          newOfferedValue = OFFERED.Y;
+          instance = await instanceRepository.findOneOrFail({
+            where: {
+              offered: OFFERED.RETIRED,
+              semester: {
+                academicYear: currentAcademicYear,
+              },
+            },
+            relations: ['course', 'semester'],
+          });
+          updateInfo = {
+            preEnrollment: instance.preEnrollment,
+            studyCardEnrollment: instance.studyCardEnrollment,
+            actualEnrollment: instance.actualEnrollment,
+            offered: newOfferedValue,
+          };
+          result = await ciService.editCourseInstance(instance.id, updateInfo);
+        });
+        it('should return the updated instance', function () {
+          deepStrictEqual(result, updateInfo);
+        });
+      });
+      context('when we are editing a future academic year instance', function () {
+        beforeEach(async function () {
+          newOfferedValue = OFFERED.Y;
+          instance = await instanceRepository.findOneOrFail({
+            where: {
+              offered: OFFERED.RETIRED,
               semester: {
                 academicYear: parseInt(currentAcademicYear, 10) + 1,
               },


### PR DESCRIPTION
The original tests related to updating the `offered` field value were not explicitly defining the original offered value, potentially causing typeorm to find retired courses and trying to unretire them. This could be what is potentially causing the tests to fail in the build. These changes explicitly define the original and updated retired values so that the original course instance selected is not one that unexpectedly has a retired value for the offered field.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [ ] Normal <!-- New piece of functionality -->
- [x] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #628

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
